### PR TITLE
feat: improve no-citation rate with few-shot examples and evidence header

### DIFF
--- a/baseline_reporag/generation/evidence_pack.py
+++ b/baseline_reporag/generation/evidence_pack.py
@@ -5,6 +5,13 @@ from dataclasses import dataclass
 from ..ingestion.store import ChunkStore, Chunk
 from ..memory.session import SessionState
 
+# Citation instruction header — keep in sync with _SYSTEM (prompt.py) and
+# _FORMAT_HINT (prompt.py).  See also: design-policy §5-2 DR1-001.
+_EVIDENCE_HEADER = (
+    "IMPORTANT: You MUST cite every factual claim"
+    " using [C:N] notation from the chunks below."
+)
+
 
 @dataclass
 class EvidencePack:
@@ -12,6 +19,8 @@ class EvidencePack:
     chunk_indices: dict[str, int]  # chunk_id -> 1-based citation index
 
     def format_for_prompt(self) -> str:
+        if not self.chunks:
+            return ""
         parts: list[str] = []
         for chunk in self.chunks:
             idx = self.chunk_indices[chunk.chunk_id]
@@ -22,7 +31,8 @@ class EvidencePack:
             if chunk.section_header:
                 header += f"  [{chunk.section_header}]"
             parts.append(f"{header}\n{chunk.content.strip()}")
-        return "\n\n---\n\n".join(parts)
+        body = "\n\n---\n\n".join(parts)
+        return f"{_EVIDENCE_HEADER}\n\n{body}"
 
 
 def build_evidence_pack(

--- a/baseline_reporag/generation/generator.py
+++ b/baseline_reporag/generation/generator.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Callable
 
 try:
-    import mlx.core as mx
+    import mlx.core as mx  # noqa: F401 – imported for side-effect / availability check
     import mlx_lm
     from mlx_lm.sample_utils import make_sampler
     _HAS_MLX = True

--- a/baseline_reporag/generation/prompt.py
+++ b/baseline_reporag/generation/prompt.py
@@ -12,12 +12,22 @@ Rules:
 6. Respond in the same language as the question.\
 """
 
+# Citation rules — keep in sync with _EVIDENCE_HEADER (evidence_pack.py) and
+# _SYSTEM Rules 2, 5 above.  See also: design-policy §5-2 DR1-001.
 _FORMAT_HINT = """\
 Answer format:
 - Start with a direct answer.
 - Cite every factual claim: [C:N].
 - Use code blocks for code snippets.
-- End with a one-sentence summary if the answer is long.\
+- End with a one-sentence summary if the answer is long.
+
+Examples of well-cited answers (cite ONLY from the current chunks):
+
+Q: Where is the main entry point?
+A: The main entry point is the `main()` function defined in [C:1]. It initialises the application config and starts the server.
+
+Q: How is the module structured?
+A: The module has three layers: the HTTP handler in [C:1] dispatches requests to the service class in [C:3], which queries the database via the repository in [C:5].\
 """
 
 

--- a/baseline_reporag/ingestion/chunker.py
+++ b/baseline_reporag/ingestion/chunker.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import ast
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 
 @dataclass
@@ -96,7 +96,7 @@ def _chunk_python(
         cur_syms = []
 
     for s, e, name in boundaries:
-        node_body = "".join(lines[s - 1: e])
+        "".join(lines[s - 1: e])
         if cur_start is None:
             cur_start, cur_end, cur_syms = s, e, [name]
         else:

--- a/baseline_reporag/pipeline.py
+++ b/baseline_reporag/pipeline.py
@@ -9,9 +9,9 @@ from __future__ import annotations
 import uuid
 from dataclasses import dataclass
 
-from .citation import CitationResult, resolve_citations
+from .citation import resolve_citations
 from .config import Config
-from .generation.evidence_pack import EvidencePack, build_evidence_pack
+from .generation.evidence_pack import build_evidence_pack
 from .generation.generator import Generator
 from .generation.prompt import build_messages
 from .indexing.embedding import EmbeddingIndex
@@ -19,10 +19,10 @@ from .indexing.lexical import LexicalIndex
 from .indexing.symbol_graph import SymbolGraph
 from .ingestion.store import ChunkStore
 from .logger import RunLogger
-from .memory.session import SessionManager, SessionState, Turn
+from .memory.session import SessionManager
 from .profiler import LatencyBreakdown, MemorySnapshot, TurnProfiler
 from .retrieval.graph_expansion import expand_with_graph
-from .retrieval.hybrid import RetrievalResult, hybrid_search
+from .retrieval.hybrid import hybrid_search
 
 
 @dataclass

--- a/baseline_reporag/profiler.py
+++ b/baseline_reporag/profiler.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import time
 import tracemalloc
 from contextlib import contextmanager
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Iterator
 
 

--- a/baseline_reporag/tests/test_citation.py
+++ b/baseline_reporag/tests/test_citation.py
@@ -1,0 +1,74 @@
+"""Tests for baseline_reporag.citation — resolve_citations."""
+
+from __future__ import annotations
+
+from baseline_reporag.citation import resolve_citations
+from baseline_reporag.generation.evidence_pack import EvidencePack
+from baseline_reporag.ingestion.store import Chunk
+
+
+def _make_chunk(chunk_id: str, content: str = "x = 1") -> Chunk:
+    return Chunk(
+        chunk_id=chunk_id,
+        repo_id="repo",
+        repo_commit="abc",
+        rel_path="src/main.py",
+        language="python",
+        start_line=1,
+        end_line=5,
+        content=content,
+        symbols=[],
+        section_header="",
+        file_header="",
+    )
+
+
+def _make_pack(n: int = 2) -> EvidencePack:
+    chunks = [_make_chunk(f"c{i}") for i in range(1, n + 1)]
+    indices = {c.chunk_id: i + 1 for i, c in enumerate(chunks)}
+    return EvidencePack(chunks=chunks, chunk_indices=indices)
+
+
+# ------------------------------------------------------------------
+
+
+def test_resolve_single_citation() -> None:
+    pack = _make_pack(2)
+    result = resolve_citations("See [C:1] for details.", pack)
+    assert result.cited_chunk_ids == ["c1"]
+    assert result.no_citation is False
+
+
+def test_resolve_multiple_citations() -> None:
+    pack = _make_pack(3)
+    result = resolve_citations("Found in [C:1] and [C:2].", pack)
+    assert set(result.cited_chunk_ids) == {"c1", "c2"}
+    assert result.no_citation is False
+
+
+def test_no_citation_detected() -> None:
+    pack = _make_pack(2)
+    result = resolve_citations("No evidence here.", pack)
+    assert result.no_citation is True
+    assert result.cited_chunk_ids == []
+
+
+def test_wrong_citation_detected() -> None:
+    pack = _make_pack(2)
+    result = resolve_citations("See [C:99] for info.", pack)
+    assert result.wrong_citation_indices == [99]
+    assert result.cited_chunk_ids == []
+
+
+def test_duplicate_citations_deduplicated() -> None:
+    pack = _make_pack(2)
+    result = resolve_citations("[C:1] and again [C:1].", pack)
+    assert result.cited_chunk_ids == ["c1"]
+    assert len(result.cited_chunk_ids) == 1
+
+
+def test_header_echoback_not_detected() -> None:
+    """Literal '[C:N]' (letter N, not a digit) must not be detected."""
+    pack = _make_pack(2)
+    result = resolve_citations("Use [C:N] notation to cite.", pack)
+    assert result.no_citation is True

--- a/baseline_reporag/tests/test_evidence_pack.py
+++ b/baseline_reporag/tests/test_evidence_pack.py
@@ -1,0 +1,74 @@
+"""Tests for baseline_reporag.generation.evidence_pack — EvidencePack.format_for_prompt."""
+
+from __future__ import annotations
+
+import re
+
+from baseline_reporag.generation.evidence_pack import EvidencePack, _EVIDENCE_HEADER
+from baseline_reporag.ingestion.store import Chunk
+
+
+def _make_chunk(
+    chunk_id: str,
+    content: str = "x = 1",
+    section_header: str = "",
+) -> Chunk:
+    return Chunk(
+        chunk_id=chunk_id,
+        repo_id="repo",
+        repo_commit="abc",
+        rel_path="src/main.py",
+        language="python",
+        start_line=1,
+        end_line=5,
+        content=content,
+        symbols=[],
+        section_header=section_header,
+        file_header="",
+    )
+
+
+def _make_pack(chunks: list[Chunk]) -> EvidencePack:
+    indices = {c.chunk_id: i + 1 for i, c in enumerate(chunks)}
+    return EvidencePack(chunks=chunks, chunk_indices=indices)
+
+
+# ------------------------------------------------------------------
+
+
+def test_format_for_prompt_contains_header() -> None:
+    """Output must start with _EVIDENCE_HEADER."""
+    pack = _make_pack([_make_chunk("c1")])
+    text = pack.format_for_prompt()
+    assert text.startswith(_EVIDENCE_HEADER)
+
+
+def test_format_for_prompt_header_no_digit_citation() -> None:
+    """The header itself must not contain [C:<digit>] patterns."""
+    assert not re.search(r"\[C:\d+\]", _EVIDENCE_HEADER)
+
+
+def test_format_for_prompt_chunk_indices() -> None:
+    pack = _make_pack([_make_chunk("c1"), _make_chunk("c2")])
+    text = pack.format_for_prompt()
+    assert "[C:1]" in text
+    assert "[C:2]" in text
+
+
+def test_format_for_prompt_separator() -> None:
+    pack = _make_pack([_make_chunk("c1"), _make_chunk("c2")])
+    text = pack.format_for_prompt()
+    assert "---" in text
+
+
+def test_format_for_prompt_empty_chunks() -> None:
+    pack = _make_pack([])
+    text = pack.format_for_prompt()
+    assert text == ""
+
+
+def test_format_for_prompt_section_header() -> None:
+    chunk = _make_chunk("c1", section_header="MyClass.method")
+    pack = _make_pack([chunk])
+    text = pack.format_for_prompt()
+    assert "MyClass.method" in text

--- a/baseline_reporag/tests/test_prompt.py
+++ b/baseline_reporag/tests/test_prompt.py
@@ -1,0 +1,78 @@
+"""Tests for baseline_reporag.generation.prompt — _SYSTEM, _FORMAT_HINT, build_messages."""
+
+from __future__ import annotations
+
+import re
+
+from baseline_reporag.generation.prompt import _SYSTEM, _FORMAT_HINT, build_messages
+from baseline_reporag.generation.evidence_pack import _EVIDENCE_HEADER
+
+
+# ------------------------------------------------------------------
+# _SYSTEM / _FORMAT_HINT constants
+# ------------------------------------------------------------------
+
+
+def test_system_message_contains_citation_rules() -> None:
+    assert "[C:N]" in _SYSTEM
+    assert "Cite" in _SYSTEM or "cite" in _SYSTEM.lower()
+
+
+def test_format_hint_contains_few_shot_examples() -> None:
+    """_FORMAT_HINT must contain at least one Q:/A: example block."""
+    assert "Q:" in _FORMAT_HINT
+    assert "A:" in _FORMAT_HINT
+
+
+def test_format_hint_examples_use_concrete_indices() -> None:
+    """Few-shot examples must use concrete [C:<digit>] citations."""
+    concrete = re.findall(r"\[C:\d+\]", _FORMAT_HINT)
+    assert len(concrete) >= 2, f"Expected >=2 concrete citations, got {concrete}"
+
+
+def test_citation_notation_consistency() -> None:
+    """_EVIDENCE_HEADER, _SYSTEM, _FORMAT_HINT all mention [C:N]."""
+    for source_name, source in [
+        ("_EVIDENCE_HEADER", _EVIDENCE_HEADER),
+        ("_SYSTEM", _SYSTEM),
+        ("_FORMAT_HINT", _FORMAT_HINT),
+    ]:
+        assert "[C:N]" in source or re.search(r"\[C:\d+\]", source), (
+            f"{source_name} missing citation notation"
+        )
+
+
+# ------------------------------------------------------------------
+# build_messages
+# ------------------------------------------------------------------
+
+
+def test_build_messages_structure() -> None:
+    msgs = build_messages("What?", "evidence")
+    assert len(msgs) == 2
+    assert msgs[0]["role"] == "system"
+    assert msgs[1]["role"] == "user"
+
+
+def test_build_messages_includes_evidence() -> None:
+    msgs = build_messages("What?", "evidence text here")
+    user_content = msgs[1]["content"]
+    assert "evidence text here" in user_content
+
+
+def test_build_messages_includes_format_hint() -> None:
+    msgs = build_messages("What?", "ev")
+    user_content = msgs[1]["content"]
+    assert "Answer format" in user_content
+
+
+def test_build_messages_with_history() -> None:
+    msgs = build_messages("What?", "ev", history_text="prev turn")
+    user_content = msgs[1]["content"]
+    assert "prev turn" in user_content
+
+
+def test_build_messages_without_history() -> None:
+    msgs = build_messages("What?", "ev")
+    user_content = msgs[1]["content"]
+    assert "Conversation History" not in user_content

--- a/baseline_reporag/tests/test_prompt_evidence_integration.py
+++ b/baseline_reporag/tests/test_prompt_evidence_integration.py
@@ -1,0 +1,55 @@
+"""Integration tests: prompt + evidence_pack interplay."""
+
+from __future__ import annotations
+
+from baseline_reporag.generation.evidence_pack import EvidencePack, _EVIDENCE_HEADER
+from baseline_reporag.generation.prompt import build_messages
+from baseline_reporag.ingestion.store import Chunk
+
+
+def _make_chunk(chunk_id: str, content: str = "x = 1") -> Chunk:
+    return Chunk(
+        chunk_id=chunk_id,
+        repo_id="repo",
+        repo_commit="abc",
+        rel_path="src/main.py",
+        language="python",
+        start_line=1,
+        end_line=5,
+        content=content,
+        symbols=[],
+        section_header="",
+        file_header="",
+    )
+
+
+def _make_pack(n: int = 2) -> EvidencePack:
+    chunks = [_make_chunk(f"c{i}") for i in range(1, n + 1)]
+    indices = {c.chunk_id: i + 1 for i, c in enumerate(chunks)}
+    return EvidencePack(chunks=chunks, chunk_indices=indices)
+
+
+# ------------------------------------------------------------------
+
+
+def test_build_messages_preserves_headered_evidence_text() -> None:
+    """Evidence text with header must pass through to the user message."""
+    pack = _make_pack(2)
+    evidence_text = pack.format_for_prompt()
+    msgs = build_messages("What?", evidence_text)
+    user_content = msgs[1]["content"]
+    assert _EVIDENCE_HEADER in user_content
+    assert "[C:1]" in user_content
+    assert "[C:2]" in user_content
+
+
+def test_placeholder_echoback_and_valid_citation_can_coexist() -> None:
+    """An LLM answer echoing the instruction '[C:N]' alongside a real
+    citation [C:1] must still credit the real citation."""
+    from baseline_reporag.citation import resolve_citations
+
+    pack = _make_pack(2)
+    answer = "As per [C:N] notation, see [C:1] for the entry point."
+    result = resolve_citations(answer, pack)
+    assert result.cited_chunk_ids == ["c1"]
+    assert result.no_citation is False

--- a/evals/grader_template.py
+++ b/evals/grader_template.py
@@ -107,7 +107,7 @@ def grade_one(
     Call the judge model and return parsed scores.
     Replace the NotImplementedError with your LLM client call.
     """
-    messages = build_grader_messages(
+    build_grader_messages(
         question, reference_answer, grading_notes, answer, cited_chunk_ids
     )
     # TODO: call LLM judge here

--- a/photon_mlx/blocks.py
+++ b/photon_mlx/blocks.py
@@ -1,7 +1,6 @@
 """LLaMA-style transformer blocks in MLX (shared by encoder and decoder)."""
 from __future__ import annotations
 
-import math
 
 import mlx.core as mx
 import mlx.nn as nn

--- a/photon_mlx/data.py
+++ b/photon_mlx/data.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import json
 import random
 from pathlib import Path
-from typing import Iterator
 
 import mlx.core as mx
 

--- a/photon_mlx/inference.py
+++ b/photon_mlx/inference.py
@@ -10,10 +10,8 @@ Wraps the PhotonModel for multi-turn session usage:
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
 import mlx.core as mx
-import mlx.nn as nn
 
 from .model import PhotonModel
 from .session import DriftMetrics, HierarchicalState, PhotonSessionState

--- a/photon_mlx/model.py
+++ b/photon_mlx/model.py
@@ -14,7 +14,6 @@ Architecture (2-level, chunk_sizes=[4,4]):
 """
 from __future__ import annotations
 
-import math
 from typing import Any
 
 import mlx.core as mx
@@ -164,7 +163,7 @@ class PhotonModel(nn.Module):
 
         prefix = converter(h_above)                    # (B, N_low, P, D)
         enc_chunked = enc_out.reshape(B, N_high, C, D) # (B, N_high, C, D)
-        prefix_chunked = prefix.reshape(B, N_high, C, P, D)
+        prefix.reshape(B, N_high, C, P, D)
 
         # Per-chunk: [P prefix vecs, 1 encoder vec] = P+1 positions
         # But actually each super-chunk has C encoder positions.

--- a/photon_mlx/tests/test_optimize.py
+++ b/photon_mlx/tests/test_optimize.py
@@ -5,7 +5,6 @@ import sys
 from pathlib import Path
 
 import mlx.core as mx
-import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 

--- a/photon_mlx/tests/test_safe_recgen.py
+++ b/photon_mlx/tests/test_safe_recgen.py
@@ -1,7 +1,6 @@
 """Tests for Safe RecGen controller."""
 from __future__ import annotations
 
-import pytest
 
 from photon_mlx.safe_recgen import (
     FallbackReason,

--- a/photon_mlx/tests/test_session.py
+++ b/photon_mlx/tests/test_session.py
@@ -18,7 +18,6 @@ from torch_ref.config import (
 from photon_mlx.model import PhotonModel
 from photon_mlx.inference import PhotonInference
 from photon_mlx.session import (
-    DriftMetrics,
     HierarchicalState,
     PhotonSessionState,
     cosine_distance,

--- a/photon_mlx/tests/test_training.py
+++ b/photon_mlx/tests/test_training.py
@@ -1,15 +1,12 @@
 """Training pipeline tests for PHOTON."""
 from __future__ import annotations
 
-import json
 import sys
-import tempfile
 from pathlib import Path
 
 import mlx.core as mx
 import mlx.nn as nn
 import mlx.optimizers
-import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 

--- a/photon_mlx/trainer.py
+++ b/photon_mlx/trainer.py
@@ -99,7 +99,6 @@ def train(
     resume_from: str | Path | None = None,
 ) -> TrainState:
     """Full training loop."""
-    t_cfg = cfg.model
     h_cfg = cfg.hierarchy
 
     # Build model

--- a/scripts/generate_eval_sets.py
+++ b/scripts/generate_eval_sets.py
@@ -18,8 +18,6 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from baseline_reporag.config import load_config
-from baseline_reporag.ingestion.store import ChunkStore
 
 # ================================================================
 # Static eval templates (30 per category)
@@ -283,13 +281,13 @@ def generate_stress_turns(topic: str, n: int = 10) -> list[str]:
         f"{topic}の概要を教えてください。",
         f"{topic}の主要ファイルはどこですか？",
         f"{topic}のエントリポイントを教えてください。",
-        f"そのコードを見せてください。",
-        f"依存関係を教えてください。",
-        f"変更した場合の影響範囲は？",
-        f"テストはどこにありますか？",
-        f"改善案を提案してください。",
-        f"最もリスクが高い変更は何ですか？",
-        f"まとめてください。",
+        "そのコードを見せてください。",
+        "依存関係を教えてください。",
+        "変更した場合の影響範囲は？",
+        "テストはどこにありますか？",
+        "改善案を提案してください。",
+        "最もリスクが高い変更は何ですか？",
+        "まとめてください。",
     ]
     return base_questions[:n]
 

--- a/scripts/train_photon_quick.py
+++ b/scripts/train_photon_quick.py
@@ -6,7 +6,6 @@ Usage:
 """
 from __future__ import annotations
 
-import json
 import sys
 import time
 from pathlib import Path

--- a/torch_ref/model.py
+++ b/torch_ref/model.py
@@ -6,8 +6,6 @@ mask patterns, and forward pass.
 """
 from __future__ import annotations
 
-import math
-from dataclasses import dataclass
 
 import torch
 import torch.nn as nn


### PR DESCRIPTION
## Summary
- Add few-shot citation examples to `_FORMAT_HINT` in `prompt.py` showing well-cited answers with `[C:N]` notation
- Insert `_EVIDENCE_HEADER` ("IMPORTANT: You MUST cite...") at the top of the evidence pack in `evidence_pack.py`
- Add empty evidence pack guard in `format_for_prompt()`
- Apply ruff auto-fixes across codebase (unused imports/variables)
- Add 23 new tests for prompt, citation, evidence_pack, and prompt-evidence integration

## Context
Issue #7 の retrieval 修正で no-citation rate を 35% → 25% に改善したが、残りの 25% は generation 側（`[C:N]` フォーマット遵守不足）が原因。本 PR では prompt 強化と evidence pack header 挿入で citation 遵守率を向上させる。

## Test plan
- [x] 新規テスト 23件 PASSED
- [x] 全108テスト PASSED (`python -m pytest baseline_reporag/tests/ torch_ref/tests/ photon_mlx/tests/ -v`)
- [x] ruff check: All checks passed
- [x] ruff format: No diff

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)