### PR TITLE
feat: first-turn-only evidence header and few-shot citation examples

### DIFF
--- a/baseline_reporag/generation/prompt.py
+++ b/baseline_reporag/generation/prompt.py
@@ -12,12 +12,31 @@ Rules:
 6. Respond in the same language as the question.\
 """
 
-_FORMAT_HINT = """\
+_FEW_SHOT_EXAMPLES = """\
+Example:
+Q: Where is the main router defined?
+A: The main application router is defined in `app/main.py` [C:1], \
+where it uses `APIRouter` to register all endpoints [C:2].
+
+Q: How is authentication implemented across the codebase?
+A: Authentication is handled by a middleware in `auth/middleware.py` [C:1] \
+that validates JWT tokens [C:3]. The token generation logic is in \
+`auth/tokens.py` [C:2], using the `python-jose` library for signing.\
+"""
+
+_EVIDENCE_HEADER = (
+    "IMPORTANT: You MUST cite every factual claim"
+    " using [C:N] notation from the chunks below."
+)
+
+_FORMAT_HINT = f"""\
 Answer format:
 - Start with a direct answer.
 - Cite every factual claim: [C:N].
 - Use code blocks for code snippets.
-- End with a one-sentence summary if the answer is long.\
+- End with a one-sentence summary if the answer is long.
+
+{_FEW_SHOT_EXAMPLES}\
 """
 
 

--- a/baseline_reporag/pipeline.py
+++ b/baseline_reporag/pipeline.py
@@ -4,6 +4,7 @@ Core query pipeline shared by server.py and cli.py.
 Wires together retrieval → graph expansion → evidence pack →
 generation → citation with profiling and logging.
 """
+
 from __future__ import annotations
 
 import uuid
@@ -13,7 +14,7 @@ from .citation import resolve_citations
 from .config import Config
 from .generation.evidence_pack import build_evidence_pack
 from .generation.generator import Generator
-from .generation.prompt import build_messages
+from .generation.prompt import _EVIDENCE_HEADER, build_messages
 from .indexing.embedding import EmbeddingIndex
 from .indexing.lexical import LexicalIndex
 from .indexing.symbol_graph import SymbolGraph
@@ -73,7 +74,9 @@ class RepoRAGPipeline:
         session_id = session_id or str(uuid.uuid4())
         repo_id = repo_id or cfg.repo.repo_id
         session = self.sessions.get_or_create(
-            session_id, repo_id, cfg.repo.repo_commit,
+            session_id,
+            repo_id,
+            cfg.repo.repo_commit,
         )
 
         # --- Retrieval ---
@@ -115,9 +118,15 @@ class RepoRAGPipeline:
 
         # --- Generation ---
         with prof.phase("generation"):
+            evidence_text = pack.format_for_prompt()
+            # INVARIANT: session.add_turn() is called AFTER this point (line ~132),
+            # so len(session.turns) == 0 correctly identifies the first turn.
+            is_first_turn = len(session.turns) == 0
+            if is_first_turn:
+                evidence_text = f"{_EVIDENCE_HEADER}\n\n{evidence_text}"
             messages = build_messages(
                 question=question,
-                evidence_text=pack.format_for_prompt(),
+                evidence_text=evidence_text,
                 history_text=session.history_text(max_turns=4),
             )
             answer = self.generator.generate(messages)
@@ -133,24 +142,26 @@ class RepoRAGPipeline:
         self.sessions.save(session)
 
         # --- Log ---
-        self.logger.log_turn({
-            "session_id": session_id,
-            "turn_id": turn.turn_id,
-            "repo_id": repo_id,
-            "repo_commit": cfg.repo.repo_commit,
-            "model_id": cfg.model.model_id,
-            "question": question,
-            "answer": answer,
-            "retrieval_chunk_ids": [r.chunk_id for r in raw],
-            "evidence_pack_ids": [c.chunk_id for c in pack.chunks],
-            "cited_chunk_ids": citation.cited_chunk_ids,
-            "wrong_citation_indices": citation.wrong_citation_indices,
-            "no_citation": citation.no_citation,
-            "latency": latency.as_dict(),
-            "memory": memory.as_dict(),
-            "fallback_flag": False,
-            "fallback_reason": None,
-        })
+        self.logger.log_turn(
+            {
+                "session_id": session_id,
+                "turn_id": turn.turn_id,
+                "repo_id": repo_id,
+                "repo_commit": cfg.repo.repo_commit,
+                "model_id": cfg.model.model_id,
+                "question": question,
+                "answer": answer,
+                "retrieval_chunk_ids": [r.chunk_id for r in raw],
+                "evidence_pack_ids": [c.chunk_id for c in pack.chunks],
+                "cited_chunk_ids": citation.cited_chunk_ids,
+                "wrong_citation_indices": citation.wrong_citation_indices,
+                "no_citation": citation.no_citation,
+                "latency": latency.as_dict(),
+                "memory": memory.as_dict(),
+                "fallback_flag": False,
+                "fallback_reason": None,
+            }
+        )
 
         return QueryResult(
             answer=answer,

--- a/baseline_reporag/tests/test_citation.py
+++ b/baseline_reporag/tests/test_citation.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from baseline_reporag.citation import resolve_citations
+from baseline_reporag.generation.evidence_pack import EvidencePack
+from baseline_reporag.ingestion.chunker import Chunk
+
+
+def _make_chunk(chunk_id: str, rel_path: str = "test.py") -> Chunk:
+    """テスト用の最小限の Chunk を作成する。"""
+    return Chunk(
+        chunk_id=chunk_id,
+        repo_id="test_repo",
+        repo_commit="abc123",
+        rel_path=rel_path,
+        language="python",
+        start_line=1,
+        end_line=10,
+        content="def hello(): pass",
+        symbols=["hello"],
+        section_header="",
+        file_header="# test.py",
+    )
+
+
+def _make_pack(n: int = 3) -> EvidencePack:
+    """n 個のチャンクを持つ EvidencePack を作成する。"""
+    chunks = [_make_chunk(f"chunk_{i}") for i in range(n)]
+    chunk_indices = {c.chunk_id: i + 1 for i, c in enumerate(chunks)}
+    return EvidencePack(chunks=chunks, chunk_indices=chunk_indices)
+
+
+class TestResolveCitations:
+    """resolve_citations() の基本動作を検証する。"""
+
+    def test_resolve_citations_with_valid_citations(self) -> None:
+        """正常な [C:N] が検出されること。"""
+        pack = _make_pack(3)
+        answer = "The function is in [C:1] and used by [C:3]."
+        result = resolve_citations(answer, pack)
+        assert set(result.cited_chunk_ids) == {"chunk_0", "chunk_2"}
+        assert result.no_citation is False
+        assert result.wrong_citation_indices == []
+
+    def test_resolve_citations_no_citation(self) -> None:
+        """citation なしの回答で no_citation=True。"""
+        pack = _make_pack(3)
+        answer = "The function exists in the codebase."
+        result = resolve_citations(answer, pack)
+        assert result.cited_chunk_ids == []
+        assert result.no_citation is True
+
+    def test_resolve_citations_wrong_citation(self) -> None:
+        """evidence pack に存在しないインデックスが wrong_citation_indices に入ること。"""
+        pack = _make_pack(2)  # indices 1, 2 only
+        answer = "See [C:1] and [C:5]."
+        result = resolve_citations(answer, pack)
+        assert "chunk_0" in result.cited_chunk_ids  # [C:1] is valid
+        assert 5 in result.wrong_citation_indices  # [C:5] is invalid
+        assert result.no_citation is False
+
+
+class TestEchoBackResistance:
+    """_EVIDENCE_HEADER の echo-back 耐性を検証する。"""
+
+    def test_echoback_cn_not_matched(self) -> None:
+        """[C:N]（文字 N）が citation として検出されないこと。"""
+        pack = _make_pack(3)
+        answer = "You MUST cite using [C:N] notation. The router is in [C:1]."
+        result = resolve_citations(answer, pack)
+        assert result.cited_chunk_ids == ["chunk_0"]  # [C:1] のみ
+        assert result.no_citation is False
+
+    def test_echoback_header_only(self) -> None:
+        """ヘッダーの echo-back のみで実 citation がない場合 no_citation=True。"""
+        pack = _make_pack(3)
+        answer = "IMPORTANT: You MUST cite every factual claim using [C:N] notation."
+        result = resolve_citations(answer, pack)
+        assert result.no_citation is True
+
+    def test_echoback_mixed(self) -> None:
+        """[C:N] + 実 citation [C:1] 混在時に [C:1] のみ検出。"""
+        pack = _make_pack(3)
+        answer = "Use [C:N] notation. The implementation is in [C:1] and [C:2]."
+        result = resolve_citations(answer, pack)
+        assert set(result.cited_chunk_ids) == {"chunk_0", "chunk_1"}
+        assert result.no_citation is False

--- a/baseline_reporag/tests/test_evidence_pack.py
+++ b/baseline_reporag/tests/test_evidence_pack.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from baseline_reporag.generation.evidence_pack import EvidencePack
+from baseline_reporag.ingestion.chunker import Chunk
+
+
+def _make_chunk(
+    chunk_id: str,
+    rel_path: str = "app/main.py",
+    content: str = "def hello(): pass",
+    start_line: int = 1,
+    end_line: int = 10,
+    section_header: str = "",
+) -> Chunk:
+    """テスト用の Chunk を作成する。"""
+    return Chunk(
+        chunk_id=chunk_id,
+        repo_id="test_repo",
+        repo_commit="abc123",
+        rel_path=rel_path,
+        language="python",
+        start_line=start_line,
+        end_line=end_line,
+        content=content,
+        symbols=["hello"],
+        section_header=section_header,
+        file_header="# app/main.py",
+    )
+
+
+class TestFormatForPrompt:
+    """EvidencePack.format_for_prompt() のフォーマット検証。"""
+
+    def test_format_for_prompt_basic(self) -> None:
+        """チャンクが正しくフォーマットされること。"""
+        chunk = _make_chunk("c1", content="def main(): pass")
+        pack = EvidencePack(chunks=[chunk], chunk_indices={"c1": 1})
+        result = pack.format_for_prompt()
+        assert "[C:1]" in result
+        assert "app/main.py" in result
+        assert "def main(): pass" in result
+
+    def test_format_for_prompt_indices(self) -> None:
+        """インデックスが 1-based で正確であること。"""
+        chunks = [
+            _make_chunk("c1", content="first"),
+            _make_chunk("c2", content="second"),
+            _make_chunk("c3", content="third"),
+        ]
+        indices = {"c1": 1, "c2": 2, "c3": 3}
+        pack = EvidencePack(chunks=chunks, chunk_indices=indices)
+        result = pack.format_for_prompt()
+        assert "[C:1]" in result
+        assert "[C:2]" in result
+        assert "[C:3]" in result
+        # Verify order: C:1 appears before C:2 before C:3
+        assert result.index("[C:1]") < result.index("[C:2]")
+        assert result.index("[C:2]") < result.index("[C:3]")
+
+    def test_format_for_prompt_with_section_header(self) -> None:
+        """section_header 付きチャンクが正しくフォーマットされること。"""
+        chunk = _make_chunk(
+            "c1",
+            content="class MyRouter: pass",
+            section_header="MyRouter",
+        )
+        pack = EvidencePack(chunks=[chunk], chunk_indices={"c1": 1})
+        result = pack.format_for_prompt()
+        assert "[MyRouter]" in result
+
+    def test_format_for_prompt_empty_chunks(self) -> None:
+        """空チャンクリストでエラーにならないこと。"""
+        pack = EvidencePack(chunks=[], chunk_indices={})
+        result = pack.format_for_prompt()
+        assert result == ""

--- a/baseline_reporag/tests/test_pipeline_integration.py
+++ b/baseline_reporag/tests/test_pipeline_integration.py
@@ -1,0 +1,205 @@
+"""Pipeline integration tests for evidence header and few-shot injection.
+
+Mock strategy (from design policy Section 7):
+- Generator: MagicMock, capture .generate() call args
+- ChunkStore: MagicMock with get_many() returning test chunks
+- LexicalIndex / EmbeddingIndex / SymbolGraph: MagicMock
+- RunLogger: MagicMock
+- SessionManager: real instance (in-memory)
+- hybrid_search / expand_with_graph: patched to return test chunk IDs
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+# Guard: pipeline.py → generator.py triggers MLX import at collection time.
+# Provide stub modules so tests are collected even without MLX installed.
+# Only inject stubs when MLX is genuinely absent (not already loaded).
+if importlib.util.find_spec("mlx") is None:
+    for _mod in ("mlx", "mlx.core", "mlx_lm", "mlx_lm.sample_utils"):
+        if _mod not in sys.modules:
+            _stub = ModuleType(_mod)
+            _stub.make_sampler = lambda **kw: None  # type: ignore[attr-defined]
+            sys.modules[_mod] = _stub
+
+from baseline_reporag.config import Config  # noqa: E402
+from baseline_reporag.ingestion.chunker import Chunk  # noqa: E402
+from baseline_reporag.memory.session import SessionManager  # noqa: E402
+from baseline_reporag.pipeline import RepoRAGPipeline  # noqa: E402
+
+
+def _make_test_chunks() -> list[Chunk]:
+    """テスト用の固定チャンクを作成する。"""
+    return [
+        Chunk(
+            chunk_id="chunk_0",
+            repo_id="test_repo",
+            repo_commit="abc123",
+            rel_path="app/main.py",
+            language="python",
+            start_line=1,
+            end_line=10,
+            content="def main():\n    app = FastAPI()\n    return app",
+            symbols=["main"],
+            section_header="main",
+            file_header="# app/main.py",
+        ),
+        Chunk(
+            chunk_id="chunk_1",
+            repo_id="test_repo",
+            repo_commit="abc123",
+            rel_path="app/router.py",
+            language="python",
+            start_line=1,
+            end_line=15,
+            content="router = APIRouter()\n@router.get('/')\ndef index(): pass",
+            symbols=["index"],
+            section_header="index",
+            file_header="# app/router.py",
+        ),
+    ]
+
+
+def _build_test_pipeline(
+    generator: MagicMock | None = None,
+) -> RepoRAGPipeline:
+    """テスト用の RepoRAGPipeline を構築する。"""
+    cfg_data = {
+        "repo": {
+            "repo_id": "test_repo",
+            "repo_commit": "abc123",
+        },
+        "retrieval": {
+            "lexical_top_k": 10,
+            "embedding_top_k": 10,
+            "fused_top_k": 8,
+            "weights": {"lexical": 0.5, "embedding": 0.5},
+            "graph_expansion": {"max_hops": 1, "max_nodes": 16},
+            "neighborhood_expansion": {"before": 1, "after": 1},
+        },
+        "evidence_pack": {
+            "max_chunks": 16,
+            "max_tokens": 16000,
+        },
+        "model": {
+            "model_id": "test-model",
+        },
+    }
+    config = Config(cfg_data)
+
+    mock_store = MagicMock()
+    mock_store.get_many.return_value = _make_test_chunks()
+
+    mock_gen = generator or MagicMock()
+    if generator is None:
+        mock_gen.generate.return_value = "Answer with [C:1]."
+
+    sessions = SessionManager()  # real in-memory instance
+
+    return RepoRAGPipeline(
+        config=config,
+        store=mock_store,
+        lexical=MagicMock(),
+        embedding=MagicMock(),
+        graph=MagicMock(),
+        sessions=sessions,
+        generator=mock_gen,
+        logger=MagicMock(),
+    )
+
+
+# Mock return values for hybrid_search and expand_with_graph
+_MOCK_CHUNK_IDS = ["chunk_0", "chunk_1"]
+
+
+def _mock_hybrid_search(**kwargs):  # noqa: ANN003
+    """hybrid_search のモック: RetrievalResult のリストを返す。"""
+    from baseline_reporag.retrieval.hybrid import RetrievalResult
+
+    return [
+        RetrievalResult(chunk_id=cid, score=1.0, lexical_score=0.5, embedding_score=0.5)
+        for cid in _MOCK_CHUNK_IDS
+    ]
+
+
+def _mock_expand_with_graph(**kwargs):  # noqa: ANN003
+    """expand_with_graph のモック: chunk ID リストを返す。"""
+    return _MOCK_CHUNK_IDS
+
+
+@patch(
+    "baseline_reporag.pipeline.expand_with_graph",
+    side_effect=_mock_expand_with_graph,
+)
+@patch(
+    "baseline_reporag.pipeline.hybrid_search",
+    side_effect=_mock_hybrid_search,
+)
+class TestPipelineEvidenceHeader:
+    """pipeline.py の evidence header 挿入ロジックを検証する。"""
+
+    def test_first_turn_includes_evidence_header(
+        self,
+        mock_search: MagicMock,
+        mock_expand: MagicMock,
+    ) -> None:
+        """First turn の evidence_text に _EVIDENCE_HEADER が含まれること。"""
+        mock_gen = MagicMock()
+        mock_gen.generate.return_value = "Answer with [C:1]."
+        pipeline = _build_test_pipeline(generator=mock_gen)
+        pipeline.query("test question", session_id="s1")
+        messages = mock_gen.generate.call_args[0][0]
+        user_content = messages[1]["content"]
+        assert "IMPORTANT: You MUST cite" in user_content
+
+    def test_second_turn_excludes_evidence_header(
+        self,
+        mock_search: MagicMock,
+        mock_expand: MagicMock,
+    ) -> None:
+        """2nd turn の evidence_text に _EVIDENCE_HEADER が含まれないこと。"""
+        mock_gen = MagicMock()
+        mock_gen.generate.return_value = "Answer with [C:1]."
+        pipeline = _build_test_pipeline(generator=mock_gen)
+        pipeline.query("first question", session_id="s1")
+        pipeline.query("second question", session_id="s1")
+        # 2nd call args
+        messages = mock_gen.generate.call_args[0][0]
+        user_content = messages[1]["content"]
+        assert "IMPORTANT: You MUST cite" not in user_content
+
+    def test_first_turn_includes_few_shot(
+        self,
+        mock_search: MagicMock,
+        mock_expand: MagicMock,
+    ) -> None:
+        """First turn で few-shot example が含まれること。"""
+        mock_gen = MagicMock()
+        mock_gen.generate.return_value = "Answer with [C:1]."
+        pipeline = _build_test_pipeline(generator=mock_gen)
+        pipeline.query("test question", session_id="s1")
+        messages = mock_gen.generate.call_args[0][0]
+        user_content = messages[1]["content"]
+        assert "Example:" in user_content
+        assert "Q: Where is the main router defined?" in user_content
+
+    def test_follow_up_turn_includes_few_shot(
+        self,
+        mock_search: MagicMock,
+        mock_expand: MagicMock,
+    ) -> None:
+        """Follow-up でも few-shot は含まれること（_FORMAT_HINT は全ターン）。"""
+        mock_gen = MagicMock()
+        mock_gen.generate.return_value = "Answer with [C:1]."
+        pipeline = _build_test_pipeline(generator=mock_gen)
+        pipeline.query("first question", session_id="s1")
+        pipeline.query("second question", session_id="s1")
+        # 2nd call args
+        messages = mock_gen.generate.call_args[0][0]
+        user_content = messages[1]["content"]
+        assert "Example:" in user_content
+        assert "Q: Where is the main router defined?" in user_content

--- a/baseline_reporag/tests/test_prompt.py
+++ b/baseline_reporag/tests/test_prompt.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import re
+
+from baseline_reporag.generation.prompt import (
+    _FORMAT_HINT,
+    build_messages,
+)
+
+
+class TestBuildMessages:
+    """build_messages() の出力構造を検証する。"""
+
+    def test_build_messages_returns_system_and_user(self) -> None:
+        """build_messages() が system + user の 2 メッセージを返すこと。"""
+        msgs = build_messages(
+            question="What is the main router?",
+            evidence_text="[C:1] app/main.py\ndef main(): pass",
+        )
+        assert len(msgs) == 2
+        assert msgs[0]["role"] == "system"
+        assert msgs[1]["role"] == "user"
+
+    def test_build_messages_includes_format_hint(self) -> None:
+        """user message に _FORMAT_HINT が含まれること。"""
+        msgs = build_messages(
+            question="Where is auth?",
+            evidence_text="[C:1] auth/main.py\nclass Auth: pass",
+        )
+        user_content = msgs[1]["content"]
+        assert _FORMAT_HINT in user_content
+
+    def test_build_messages_with_history(self) -> None:
+        """history_text が含まれる場合の出力構造確認。"""
+        history = "Q1: What is X?\nA1: X is Y."
+        msgs = build_messages(
+            question="Follow up",
+            evidence_text="[C:1] foo.py\npass",
+            history_text=history,
+        )
+        user_content = msgs[1]["content"]
+        assert "Conversation History" in user_content
+        assert history in user_content
+
+
+class TestFormatHintFewShot:
+    """_FORMAT_HINT 内の few-shot example を検証する。"""
+
+    def test_format_hint_contains_few_shot_examples(self) -> None:
+        """_FORMAT_HINT に _FEW_SHOT_EXAMPLES が含まれること。"""
+        from baseline_reporag.generation.prompt import _FEW_SHOT_EXAMPLES
+
+        assert _FEW_SHOT_EXAMPLES in _FORMAT_HINT
+
+    def test_few_shot_examples_contain_citation_pattern(self) -> None:
+        """_FEW_SHOT_EXAMPLES 内に [C:\\d+] パターンが含まれること。"""
+        from baseline_reporag.generation.prompt import _FEW_SHOT_EXAMPLES
+
+        assert re.search(r"\[C:\d+\]", _FEW_SHOT_EXAMPLES)
+
+    def test_few_shot_examples_count(self) -> None:
+        """example 数が 2 であること（"Q:" で始まる行が 2 つ）。"""
+        from baseline_reporag.generation.prompt import _FEW_SHOT_EXAMPLES
+
+        q_count = len(re.findall(r"^Q:", _FEW_SHOT_EXAMPLES, re.MULTILINE))
+        assert q_count == 2
+
+    def test_format_hint_token_budget(self) -> None:
+        """_FORMAT_HINT が 500 トークン（約 2000 文字）以内であること。"""
+        assert len(_FORMAT_HINT) <= 2000


### PR DESCRIPTION
## Summary
- Add few-shot citation examples to `_FORMAT_HINT` in `prompt.py`
- Insert `_EVIDENCE_HEADER` only on **first turn** via `pipeline.py` (`is_first_turn = len(session.turns) == 0`)
- Add 21 new tests (prompt, citation, evidence_pack, pipeline integration)

## Key design change from PR #12 (reverted)
- `evidence_pack.py` is **NOT modified** — PR #12's regression was caused by inserting the header every turn via `format_for_prompt()`
- Header injection is now controlled at the **pipeline layer**, gated by turn count
- This preserves the first-turn citation improvement (43%→27%) while avoiding multi-turn degradation (35%→57%)

## Files changed
- `baseline_reporag/generation/prompt.py` — few-shot examples + `_EVIDENCE_HEADER` constant
- `baseline_reporag/pipeline.py` — first-turn-only header injection
- 4 new test files in `baseline_reporag/tests/`

## Test plan
- [x] 106 tests PASSED
- [x] ruff check: All checks passed
- [x] ruff format: No diff
- [ ] **Post-merge**: static 20q + multi-turn eval to verify no regression

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)