### PR TITLE
feat(retrieval): add file-type boost to promote .py chunks (#24)

### DIFF
--- a/baseline_reporag/pipeline.py
+++ b/baseline_reporag/pipeline.py
@@ -24,7 +24,7 @@ from .logger import RunLogger
 from .memory.session import SessionManager
 from .profiler import LatencyBreakdown, MemorySnapshot, TurnProfiler
 from .retrieval.graph_expansion import expand_with_graph
-from .retrieval.hybrid import hybrid_search
+from .retrieval.hybrid import apply_file_type_boost, hybrid_search
 from .retrieval.query_expansion import expand_query
 from .retrieval.reranker import CrossEncoderReranker
 
@@ -164,6 +164,11 @@ class RepoRAGPipeline:
                     top_k=cfg.retrieval.rerank_top_k,
                     rerank_query=expansion_terms,  # English terms for cross-encoder
                 )
+
+        # --- File-type boost (post-reranking) ---
+        file_type_boost = cfg.retrieval.get("file_type_boost", 0.0)
+        if file_type_boost:
+            raw = apply_file_type_boost(raw, boost=file_type_boost)
 
         # --- Graph expansion ---
         with prof.phase("graph_expansion"):

--- a/baseline_reporag/retrieval/hybrid.py
+++ b/baseline_reporag/retrieval/hybrid.py
@@ -98,3 +98,50 @@ def hybrid_search(
 
     results = sorted(merged.values(), key=lambda r: r.score, reverse=True)
     return results[:fused_top_k]
+
+
+def _extract_extension(chunk_id: str) -> str:
+    """Extract file extension from a chunk_id of the form ``repo::path::span``.
+
+    >>> _extract_extension("repo::src/app.py::0-120")
+    '.py'
+    >>> _extract_extension("repo::README.md::0-50")
+    '.md'
+    >>> _extract_extension("repo::Makefile::0-10")
+    ''
+    """
+    parts = chunk_id.split("::")
+    if len(parts) >= 2:
+        path = parts[1]
+        dot = path.rfind(".")
+        if dot != -1:
+            return path[dot:]
+    return ""
+
+
+def apply_file_type_boost(
+    results: list[RetrievalResult],
+    boost: float = 0.0,
+) -> list[RetrievalResult]:
+    """Add a score bonus to ``.py`` chunks and re-sort.
+
+    Designed to run **after** cross-encoder reranking (which overwrites
+    the hybrid score) so that implementation files rank higher than
+    docs/config files.  When *boost* is ``0.0`` the list is returned
+    unchanged (no copy, no re-sort) to preserve backward-compatibility.
+    """
+    if boost == 0.0:
+        return results
+    boosted = []
+    for r in results:
+        ext = _extract_extension(r.chunk_id)
+        new_score = r.score + boost if ext == ".py" else r.score
+        boosted.append(
+            RetrievalResult(
+                chunk_id=r.chunk_id,
+                score=new_score,
+                lexical_score=r.lexical_score,
+                embedding_score=r.embedding_score,
+            )
+        )
+    return sorted(boosted, key=lambda x: x.score, reverse=True)

--- a/baseline_reporag/tests/test_hybrid.py
+++ b/baseline_reporag/tests/test_hybrid.py
@@ -1,0 +1,119 @@
+"""Tests for hybrid retrieval helpers: _extract_extension and apply_file_type_boost."""
+
+from __future__ import annotations
+
+import pytest
+
+from baseline_reporag.retrieval.hybrid import (
+    RetrievalResult,
+    _extract_extension,
+    apply_file_type_boost,
+)
+
+
+# ---------------------------------------------------------------------------
+# _extract_extension
+# ---------------------------------------------------------------------------
+
+
+class TestExtractExtension:
+    def test_python_file(self) -> None:
+        assert _extract_extension("repo::src/app.py::0-120") == ".py"
+
+    def test_markdown_file(self) -> None:
+        assert _extract_extension("repo::docs/README.md::0-50") == ".md"
+
+    def test_yaml_file(self) -> None:
+        assert _extract_extension("repo::configs/base.yaml::0-30") == ".yaml"
+
+    def test_nested_path(self) -> None:
+        assert _extract_extension("repo::a/b/c/d.ts::10-20") == ".ts"
+
+    def test_no_extension(self) -> None:
+        assert _extract_extension("repo::Makefile::0-10") == ""
+
+    def test_dotfile(self) -> None:
+        # e.g. .gitignore -> ".gitignore"
+        assert _extract_extension("repo::.gitignore::0-5") == ".gitignore"
+
+    def test_missing_parts(self) -> None:
+        assert _extract_extension("single_part") == ""
+
+    def test_empty_string(self) -> None:
+        assert _extract_extension("") == ""
+
+    def test_two_parts_no_span(self) -> None:
+        assert _extract_extension("repo::main.go") == ".go"
+
+
+# ---------------------------------------------------------------------------
+# apply_file_type_boost
+# ---------------------------------------------------------------------------
+
+
+def _make_result(chunk_id: str, score: float) -> RetrievalResult:
+    return RetrievalResult(
+        chunk_id=chunk_id,
+        score=score,
+        lexical_score=0.0,
+        embedding_score=0.0,
+    )
+
+
+class TestApplyFileTypeBoost:
+    def test_zero_boost_returns_same_list(self) -> None:
+        results = [
+            _make_result("r::a.md::0-10", 1.0),
+            _make_result("r::b.py::0-10", 0.5),
+        ]
+        out = apply_file_type_boost(results, boost=0.0)
+        assert out is results  # identity — no copy
+
+    def test_boost_lifts_py_above_md(self) -> None:
+        results = [
+            _make_result("r::docs/guide.md::0-10", 0.80),
+            _make_result("r::src/main.py::0-10", 0.70),
+        ]
+        out = apply_file_type_boost(results, boost=0.15)
+        # .py score becomes 0.85, .md stays 0.80 -> .py should be first
+        assert out[0].chunk_id == "r::src/main.py::0-10"
+        assert out[0].score == pytest.approx(0.85)
+        assert out[1].chunk_id == "r::docs/guide.md::0-10"
+        assert out[1].score == pytest.approx(0.80)
+
+    def test_non_py_files_unchanged(self) -> None:
+        results = [
+            _make_result("r::a.yaml::0-10", 0.9),
+            _make_result("r::b.md::0-10", 0.8),
+        ]
+        out = apply_file_type_boost(results, boost=0.15)
+        assert out[0].score == pytest.approx(0.9)
+        assert out[1].score == pytest.approx(0.8)
+
+    def test_preserves_original_fields(self) -> None:
+        r = RetrievalResult(
+            chunk_id="r::x.py::0-5",
+            score=1.0,
+            lexical_score=0.6,
+            embedding_score=0.4,
+        )
+        out = apply_file_type_boost([r], boost=0.1)
+        assert out[0].lexical_score == pytest.approx(0.6)
+        assert out[0].embedding_score == pytest.approx(0.4)
+
+    def test_empty_list(self) -> None:
+        assert apply_file_type_boost([], boost=0.15) == []
+
+    def test_sorting_after_boost(self) -> None:
+        results = [
+            _make_result("r::a.md::0-10", 1.0),
+            _make_result("r::b.py::0-10", 0.90),
+            _make_result("r::c.md::0-10", 0.80),
+            _make_result("r::d.py::0-10", 0.60),
+        ]
+        out = apply_file_type_boost(results, boost=0.15)
+        scores = [r.score for r in out]
+        assert scores == sorted(scores, reverse=True)
+        # b.py (0.90+0.15=1.05) > a.md (1.0) > c.md (0.80) > d.py (0.60+0.15=0.75)
+        assert out[0].chunk_id == "r::b.py::0-10"
+        assert out[1].chunk_id == "r::a.md::0-10"

--- a/configs/baseline.yaml
+++ b/configs/baseline.yaml
@@ -143,6 +143,8 @@ retrieval:
     max_hops: 1
     max_nodes: 24
 
+  file_type_boost: 0.15            # score bonus for .py chunks (applied after reranking)
+
   citation_bias:
     prefer_previously_cited_chunks: true
     boost_recent_citations: 0.15

--- a/configs/photon_small.yaml
+++ b/configs/photon_small.yaml
@@ -76,6 +76,8 @@ retrieval:
     enabled: true
     model_id: "cross-encoder/ms-marco-MiniLM-L-6-v2"
 
+  file_type_boost: 0.15            # score bonus for .py chunks (applied after reranking)
+
   query_expansion:
     enabled: true
     include_symbol_aliases: true


### PR DESCRIPTION
## Summary

- `.py` ファイルにスコア boost (+0.15) を適用し、evidence pack 内の実装コード比率を向上
- **適用位置**: cross-encoder reranker の後（reranker が score を上書きするため、rerank 前の boost は無効）
- `retrieval.file_type_boost` で config から調整可能（0.0 で既存挙動と完全一致）

## Changes

- `baseline_reporag/retrieval/hybrid.py` — `_extract_extension()` + `apply_file_type_boost()` 追加
- `baseline_reporag/pipeline.py` — reranking 後に file-type boost 適用
- `configs/baseline.yaml`, `configs/photon_small.yaml` — `file_type_boost: 0.15` 追加
- `baseline_reporag/tests/test_hybrid.py` — 15 新規テスト

## Test plan

- [x] `ruff check .` — 0 warnings
- [x] `ruff format --check .` — 0 diffs
- [x] `pytest` — 114/114 passed (99 existing + 15 new)
- [ ] Static eval 120q で no-citation 21.7% → < 15% 確認（マージ後に実施）

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)