### PR TITLE
feat: file-type boost, generation improvement, eval experiments (v5b→v7)

### DIFF
--- a/baseline_reporag/generation/prompt.py
+++ b/baseline_reporag/generation/prompt.py
@@ -83,7 +83,51 @@ without `__dict__`.
 non-serializable value returned by a route handler would raise `ValueError` here.
 
 Most likely cause: a response model contains a field type not registered in \
-`ENCODERS_BY_TYPE` [C:2].\
+`ENCODERS_BY_TYPE` [C:2].
+
+Example 6 — impact analysis question (trace callers and dependents):
+Q: What would be affected if we rename the `get_current_user` dependency?
+A: Renaming `get_current_user` would have a wide impact across the codebase:
+
+1. **Definition site** [C:1]: The function is defined in `auth/dependencies.py` \
+and is imported by name in multiple modules.
+2. **Direct callers** [C:3] [C:5]: At least two route modules inject it via \
+`Depends(get_current_user)` — `routes/users.py` [C:3] and `routes/admin.py` [C:5]. \
+Every endpoint using this dependency would break at import time.
+3. **Test fixtures** [C:4]: The test suite patches `get_current_user` by its \
+fully-qualified path in `conftest.py` [C:4]. Renaming would silently disable the \
+patch and cause auth-related test failures.
+4. **OpenAPI schema** [C:2]: The dependency name appears in the generated \
+`securitySchemes` section [C:2]; renaming it would change the schema output and \
+may break client SDKs that depend on the current schema.
+
+Summary: renaming requires coordinated updates in at least 4 modules ([C:1] [C:2] \
+[C:3] [C:5]) plus the test fixtures [C:4].
+
+Example 7 — change planning question (structured recommendation with evidence):
+Q: Should we switch from synchronous `requests` to `httpx.AsyncClient` for \
+external API calls?
+A: Based on the current codebase patterns:
+
+**Current state** [C:1] [C:2]: External API calls use synchronous `requests.get()` \
+in `services/external.py` [C:1]. The call is wrapped in `run_in_executor` inside \
+`routes/proxy.py` [C:2] to avoid blocking the event loop.
+
+**Option A — Keep `requests` + executor** [C:2]:
+- Pros: No migration needed; `run_in_executor` already prevents blocking [C:2].
+- Cons: Adds thread-pool overhead per request; connection pooling is per-thread \
+rather than per-process.
+
+**Option B — Migrate to `httpx.AsyncClient`** [C:1] [C:3]:
+- Pros: Native async eliminates the executor wrapper; `httpx.AsyncClient` supports \
+connection pooling via `Limits` [C:3], reducing latency for repeated calls.
+- Cons: Requires updating all call sites in `services/external.py` [C:1] and \
+replacing the executor pattern in [C:2].
+
+**Recommendation**: Migrate to `httpx.AsyncClient`. The executor pattern in [C:2] \
+is a workaround that adds unnecessary thread overhead, and the existing connection \
+setup in [C:1] can be replaced with a shared `AsyncClient` instance following the \
+pattern already used for the database session in [C:3].\
 """
 
 _EVIDENCE_HEADER = (

--- a/baseline_reporag/pipeline.py
+++ b/baseline_reporag/pipeline.py
@@ -24,7 +24,7 @@ from .logger import RunLogger
 from .memory.session import SessionManager
 from .profiler import LatencyBreakdown, MemorySnapshot, TurnProfiler
 from .retrieval.graph_expansion import expand_with_graph
-from .retrieval.hybrid import hybrid_search
+from .retrieval.hybrid import apply_file_type_boost, hybrid_search
 from .retrieval.query_expansion import expand_query
 from .retrieval.reranker import CrossEncoderReranker
 
@@ -164,6 +164,11 @@ class RepoRAGPipeline:
                     top_k=cfg.retrieval.rerank_top_k,
                     rerank_query=expansion_terms,  # English terms for cross-encoder
                 )
+
+        # --- File-type boost (post-reranking) ---
+        file_type_boost = cfg.retrieval.get("file_type_boost", 0.0)
+        if file_type_boost:
+            raw = apply_file_type_boost(raw, boost=file_type_boost)
 
         # --- Graph expansion ---
         with prof.phase("graph_expansion"):

--- a/baseline_reporag/retrieval/hybrid.py
+++ b/baseline_reporag/retrieval/hybrid.py
@@ -98,3 +98,50 @@ def hybrid_search(
 
     results = sorted(merged.values(), key=lambda r: r.score, reverse=True)
     return results[:fused_top_k]
+
+
+def _extract_extension(chunk_id: str) -> str:
+    """Extract file extension from a chunk_id of the form ``repo::path::span``.
+
+    >>> _extract_extension("repo::src/app.py::0-120")
+    '.py'
+    >>> _extract_extension("repo::README.md::0-50")
+    '.md'
+    >>> _extract_extension("repo::Makefile::0-10")
+    ''
+    """
+    parts = chunk_id.split("::")
+    if len(parts) >= 2:
+        path = parts[1]
+        dot = path.rfind(".")
+        if dot != -1:
+            return path[dot:]
+    return ""
+
+
+def apply_file_type_boost(
+    results: list[RetrievalResult],
+    boost: float = 0.0,
+) -> list[RetrievalResult]:
+    """Add a score bonus to ``.py`` chunks and re-sort.
+
+    Designed to run **after** cross-encoder reranking (which overwrites
+    the hybrid score) so that implementation files rank higher than
+    docs/config files.  When *boost* is ``0.0`` the list is returned
+    unchanged (no copy, no re-sort) to preserve backward-compatibility.
+    """
+    if boost == 0.0:
+        return results
+    boosted = []
+    for r in results:
+        ext = _extract_extension(r.chunk_id)
+        new_score = r.score + boost if ext == ".py" else r.score
+        boosted.append(
+            RetrievalResult(
+                chunk_id=r.chunk_id,
+                score=new_score,
+                lexical_score=r.lexical_score,
+                embedding_score=r.embedding_score,
+            )
+        )
+    return sorted(boosted, key=lambda x: x.score, reverse=True)

--- a/baseline_reporag/tests/test_hybrid.py
+++ b/baseline_reporag/tests/test_hybrid.py
@@ -1,0 +1,119 @@
+"""Tests for hybrid retrieval helpers: _extract_extension and apply_file_type_boost."""
+
+from __future__ import annotations
+
+import pytest
+
+from baseline_reporag.retrieval.hybrid import (
+    RetrievalResult,
+    _extract_extension,
+    apply_file_type_boost,
+)
+
+
+# ---------------------------------------------------------------------------
+# _extract_extension
+# ---------------------------------------------------------------------------
+
+
+class TestExtractExtension:
+    def test_python_file(self) -> None:
+        assert _extract_extension("repo::src/app.py::0-120") == ".py"
+
+    def test_markdown_file(self) -> None:
+        assert _extract_extension("repo::docs/README.md::0-50") == ".md"
+
+    def test_yaml_file(self) -> None:
+        assert _extract_extension("repo::configs/base.yaml::0-30") == ".yaml"
+
+    def test_nested_path(self) -> None:
+        assert _extract_extension("repo::a/b/c/d.ts::10-20") == ".ts"
+
+    def test_no_extension(self) -> None:
+        assert _extract_extension("repo::Makefile::0-10") == ""
+
+    def test_dotfile(self) -> None:
+        # e.g. .gitignore -> ".gitignore"
+        assert _extract_extension("repo::.gitignore::0-5") == ".gitignore"
+
+    def test_missing_parts(self) -> None:
+        assert _extract_extension("single_part") == ""
+
+    def test_empty_string(self) -> None:
+        assert _extract_extension("") == ""
+
+    def test_two_parts_no_span(self) -> None:
+        assert _extract_extension("repo::main.go") == ".go"
+
+
+# ---------------------------------------------------------------------------
+# apply_file_type_boost
+# ---------------------------------------------------------------------------
+
+
+def _make_result(chunk_id: str, score: float) -> RetrievalResult:
+    return RetrievalResult(
+        chunk_id=chunk_id,
+        score=score,
+        lexical_score=0.0,
+        embedding_score=0.0,
+    )
+
+
+class TestApplyFileTypeBoost:
+    def test_zero_boost_returns_same_list(self) -> None:
+        results = [
+            _make_result("r::a.md::0-10", 1.0),
+            _make_result("r::b.py::0-10", 0.5),
+        ]
+        out = apply_file_type_boost(results, boost=0.0)
+        assert out is results  # identity — no copy
+
+    def test_boost_lifts_py_above_md(self) -> None:
+        results = [
+            _make_result("r::docs/guide.md::0-10", 0.80),
+            _make_result("r::src/main.py::0-10", 0.70),
+        ]
+        out = apply_file_type_boost(results, boost=0.15)
+        # .py score becomes 0.85, .md stays 0.80 -> .py should be first
+        assert out[0].chunk_id == "r::src/main.py::0-10"
+        assert out[0].score == pytest.approx(0.85)
+        assert out[1].chunk_id == "r::docs/guide.md::0-10"
+        assert out[1].score == pytest.approx(0.80)
+
+    def test_non_py_files_unchanged(self) -> None:
+        results = [
+            _make_result("r::a.yaml::0-10", 0.9),
+            _make_result("r::b.md::0-10", 0.8),
+        ]
+        out = apply_file_type_boost(results, boost=0.15)
+        assert out[0].score == pytest.approx(0.9)
+        assert out[1].score == pytest.approx(0.8)
+
+    def test_preserves_original_fields(self) -> None:
+        r = RetrievalResult(
+            chunk_id="r::x.py::0-5",
+            score=1.0,
+            lexical_score=0.6,
+            embedding_score=0.4,
+        )
+        out = apply_file_type_boost([r], boost=0.1)
+        assert out[0].lexical_score == pytest.approx(0.6)
+        assert out[0].embedding_score == pytest.approx(0.4)
+
+    def test_empty_list(self) -> None:
+        assert apply_file_type_boost([], boost=0.15) == []
+
+    def test_sorting_after_boost(self) -> None:
+        results = [
+            _make_result("r::a.md::0-10", 1.0),
+            _make_result("r::b.py::0-10", 0.90),
+            _make_result("r::c.md::0-10", 0.80),
+            _make_result("r::d.py::0-10", 0.60),
+        ]
+        out = apply_file_type_boost(results, boost=0.15)
+        scores = [r.score for r in out]
+        assert scores == sorted(scores, reverse=True)
+        # b.py (0.90+0.15=1.05) > a.md (1.0) > c.md (0.80) > d.py (0.60+0.15=0.75)
+        assert out[0].chunk_id == "r::b.py::0-10"
+        assert out[1].chunk_id == "r::a.md::0-10"

--- a/baseline_reporag/tests/test_pipeline_integration.py
+++ b/baseline_reporag/tests/test_pipeline_integration.py
@@ -77,9 +77,13 @@ def _build_test_pipeline(
             "lexical_top_k": 10,
             "embedding_top_k": 10,
             "fused_top_k": 8,
+            "rerank_top_k": 8,
             "weights": {"lexical": 0.5, "embedding": 0.5},
             "graph_expansion": {"max_hops": 1, "max_nodes": 16},
             "neighborhood_expansion": {"before": 1, "after": 1},
+            "query_expansion": {"enabled": False},
+            "reranker": {"enabled": False},
+            "file_type_boost": 0.0,
         },
         "evidence_pack": {
             "max_chunks": 16,
@@ -184,7 +188,7 @@ class TestPipelineEvidenceHeader:
         pipeline.query("test question", session_id="s1")
         messages = mock_gen.generate.call_args[0][0]
         user_content = messages[1]["content"]
-        assert "Example:" in user_content
+        assert "Example 1" in user_content
         assert "Q: Where is the main router defined?" in user_content
 
     def test_follow_up_turn_includes_few_shot(
@@ -201,7 +205,7 @@ class TestPipelineEvidenceHeader:
         # 2nd call args
         messages = mock_gen.generate.call_args[0][0]
         user_content = messages[1]["content"]
-        assert "Example:" in user_content
+        assert "Example 1" in user_content
         assert "Q: Where is the main router defined?" in user_content
 
 
@@ -219,9 +223,13 @@ def _build_postprocess_pipeline(
             "lexical_top_k": 10,
             "embedding_top_k": 10,
             "fused_top_k": 8,
+            "rerank_top_k": 8,
             "weights": {"lexical": 0.5, "embedding": 0.5},
             "graph_expansion": {"max_hops": 1, "max_nodes": 16},
             "neighborhood_expansion": {"before": 1, "after": 1},
+            "query_expansion": {"enabled": False},
+            "reranker": {"enabled": False},
+            "file_type_boost": 0.0,
         },
         "evidence_pack": {
             "max_chunks": 16,

--- a/baseline_reporag/tests/test_prompt.py
+++ b/baseline_reporag/tests/test_prompt.py
@@ -59,12 +59,12 @@ class TestFormatHintFewShot:
         assert re.search(r"\[C:\d+\]", _FEW_SHOT_EXAMPLES)
 
     def test_few_shot_examples_count(self) -> None:
-        """example 数が 2 であること（"Q:" で始まる行が 2 つ）。"""
+        """example 数が 7 であること（"Q:" で始まる行が 7 つ）。"""
         from baseline_reporag.generation.prompt import _FEW_SHOT_EXAMPLES
 
         q_count = len(re.findall(r"^Q:", _FEW_SHOT_EXAMPLES, re.MULTILINE))
-        assert q_count == 2
+        assert q_count == 7
 
     def test_format_hint_token_budget(self) -> None:
-        """_FORMAT_HINT が 500 トークン（約 2000 文字）以内であること。"""
-        assert len(_FORMAT_HINT) <= 2000
+        """_FORMAT_HINT が 1500 トークン（約 6000 文字）以内であること。"""
+        assert len(_FORMAT_HINT) <= 6000

--- a/configs/baseline.yaml
+++ b/configs/baseline.yaml
@@ -182,8 +182,8 @@ model:
   quantization: "4bit"
 
 generation:
-  max_new_tokens: 1024
-  temperature: 0.1
+  max_new_tokens: 768
+  temperature: 0.2
   top_p: 0.9
   repetition_penalty: 1.05
   do_sample: false

--- a/configs/baseline.yaml
+++ b/configs/baseline.yaml
@@ -143,7 +143,7 @@ retrieval:
     max_hops: 1
     max_nodes: 24
 
-  file_type_boost: 0.15            # score bonus for .py chunks (applied after reranking)
+  file_type_boost: 0.0             # disabled: v6 eval showed +2.5pp regression at 0.15
 
   citation_bias:
     prefer_previously_cited_chunks: true

--- a/configs/baseline.yaml
+++ b/configs/baseline.yaml
@@ -143,6 +143,8 @@ retrieval:
     max_hops: 1
     max_nodes: 24
 
+  file_type_boost: 0.15            # score bonus for .py chunks (applied after reranking)
+
   citation_bias:
     prefer_previously_cited_chunks: true
     boost_recent_citations: 0.15

--- a/configs/baseline.yaml
+++ b/configs/baseline.yaml
@@ -182,8 +182,8 @@ model:
   quantization: "4bit"
 
 generation:
-  max_new_tokens: 768
-  temperature: 0.2
+  max_new_tokens: 1024
+  temperature: 0.1
   top_p: 0.9
   repetition_penalty: 1.05
   do_sample: false

--- a/configs/photon_small.yaml
+++ b/configs/photon_small.yaml
@@ -134,8 +134,8 @@ model:
   intermediate_size: 2816
 
 generation:
-  max_new_tokens: 1024
-  temperature: 0.1
+  max_new_tokens: 768
+  temperature: 0.2
   top_p: 0.9
   repetition_penalty: 1.05
   do_sample: false

--- a/configs/photon_small.yaml
+++ b/configs/photon_small.yaml
@@ -134,8 +134,8 @@ model:
   intermediate_size: 2816
 
 generation:
-  max_new_tokens: 768
-  temperature: 0.2
+  max_new_tokens: 1024
+  temperature: 0.1
   top_p: 0.9
   repetition_penalty: 1.05
   do_sample: false

--- a/configs/photon_small.yaml
+++ b/configs/photon_small.yaml
@@ -76,7 +76,7 @@ retrieval:
     enabled: true
     model_id: "cross-encoder/ms-marco-MiniLM-L-6-v2"
 
-  file_type_boost: 0.15            # score bonus for .py chunks (applied after reranking)
+  file_type_boost: 0.0             # disabled: v6 eval showed +2.5pp regression at 0.15
 
   query_expansion:
     enabled: true

--- a/configs/photon_small.yaml
+++ b/configs/photon_small.yaml
@@ -76,6 +76,8 @@ retrieval:
     enabled: true
     model_id: "cross-encoder/ms-marco-MiniLM-L-6-v2"
 
+  file_type_boost: 0.15            # score bonus for .py chunks (applied after reranking)
+
   query_expansion:
     enabled: true
     include_symbol_aliases: true


### PR DESCRIPTION
## Summary

- **File-type boost** (#24): `.py` チャンクへのスコア boost 機能を実装。eval で逆効果と判明し 0.0 に無効化済み（コードは保持）
- **Generation 改善** (#30): impact_analysis / change_planning 向け few-shot Example 6,7 追加。temperature/max_new_tokens 調整は逆効果で revert 済み
- **Answerable/Unanswerable 分類**: 21 no-citation 中 7 件が unanswerable (FastAPI に存在しない概念)。True NC = **14/113 = 12.4%**

## Metrics

| 指標 | Gate 2 v1 (Apr 14) | 現在 (v5b baseline) | True NC |
|------|--------------------|--------------------|---------|
| Static NC | 44.2% | 17.5% | **12.4%** |
| MT NC | 30.6% | 13.3% | — |

## Eval experiments included

| Eval | Config change | Result | Status |
|------|--------------|--------|--------|
| v6 | file_type_boost=0.15 | 20.0% (+2.5pp) | ❌ reverted |
| v7 | temp=0.1, tokens=1024 | 20.8% (+3.3pp) | ❌ reverted |

## Changes since PR #28

- `baseline_reporag/retrieval/hybrid.py` — `apply_file_type_boost()` 追加
- `baseline_reporag/pipeline.py` — file-type boost phase 追加
- `baseline_reporag/generation/prompt.py` — Example 6, 7 追加
- `baseline_reporag/tests/test_hybrid.py` — 15 new tests
- `baseline_reporag/tests/test_prompt.py` — assertion updates
- `baseline_reporag/tests/test_pipeline_integration.py` — mock config fixes
- `configs/baseline.yaml` — file_type_boost=0.0, temp=0.2, tokens=768 (reverted)
- `configs/photon_small.yaml` — same

## Test plan

- [x] `ruff check .` — 0 warnings
- [x] `ruff format --check .` — 0 diffs
- [x] Static eval v5b: 17.5% (best baseline, unchanged)
- [x] True NC after answerable classification: 12.4%

🤖 Generated with [Claude Code](https://claude.com/claude-code)