### PR TITLE
feat(training): add multi-repo corpus expansion infrastructure (#38)

### DIFF
--- a/configs/photon_small.yaml
+++ b/configs/photon_small.yaml
@@ -176,11 +176,11 @@ training:
   enabled: true
   stage: "small"
 
-  train_corpus: "./data/processed/train_small.jsonl"
-  val_corpus: "./data/processed/val_small.jsonl"
+  train_corpus: "./data/processed/train_multi.jsonl"
+  val_corpus: "./data/processed/val_multi.jsonl"
 
   context_length: 2048
-  micro_batch_size: 2
+  micro_batch_size: 4
   gradient_accumulation_steps: 16
 
   learning_rate: 0.00015
@@ -189,7 +189,7 @@ training:
   weight_decay: 0.1
   max_grad_norm: 1.0
 
-  max_steps: 800
+  max_steps: 2000
   eval_every_steps: 100
   save_every_steps: 100
   log_every_steps: 20

--- a/scripts/expand_corpus.sh
+++ b/scripts/expand_corpus.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# expand_corpus.sh  –  Clone 5 repos, ingest, generate per-repo corpus, merge into multi.
+#
+# Usage:
+#     bash scripts/expand_corpus.sh
+#
+# Prerequisites:
+#     - Python environment with baseline_reporag + transformers installed
+#     - configs/baseline.yaml present
+#
+# Output:
+#     data/processed/train_multi.jsonl
+#     data/processed/val_multi.jsonl
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+RAW_DIR="${PROJECT_ROOT}/data/raw"
+PROCESSED_DIR="${PROJECT_ROOT}/data/processed"
+CONFIG="${PROJECT_ROOT}/configs/baseline.yaml"
+PHOTON_CONFIG="${PROJECT_ROOT}/configs/photon_small.yaml"
+
+# ── Target repositories ──────────────────────────────────────────────
+declare -a REPOS=(
+    "tiangolo/fastapi"
+    "pallets/flask"
+    "encode/starlette"
+    "encode/httpx"
+    "pydantic/pydantic"
+)
+
+mkdir -p "$RAW_DIR" "$PROCESSED_DIR"
+
+# ── Helper: derive repo_id from owner/name (e.g. tiangolo/fastapi -> tiangolo_fastapi) ──
+repo_id_from() {
+    echo "$1" | tr '/' '_'
+}
+
+# ── Phase 1: Clone (skip if already present) ─────────────────────────
+echo "=== Phase 1: Clone repositories ==="
+for repo in "${REPOS[@]}"; do
+    local_name="${repo##*/}"          # e.g. "fastapi"
+    clone_dir="${RAW_DIR}/${local_name}"
+    if [ -d "$clone_dir/.git" ]; then
+        echo "  [skip] ${repo} already cloned at ${clone_dir}"
+    else
+        echo "  [clone] ${repo} -> ${clone_dir}"
+        git clone --depth 1 "https://github.com/${repo}.git" "$clone_dir"
+    fi
+done
+
+# ── Phase 2: Ingest + generate per-repo corpus ──────────────────────
+echo ""
+echo "=== Phase 2: Ingest & generate per-repo corpus ==="
+for repo in "${REPOS[@]}"; do
+    local_name="${repo##*/}"
+    clone_dir="${RAW_DIR}/${local_name}"
+    rid="$(repo_id_from "$repo")"
+
+    echo ""
+    echo "--- ${repo} (repo_id=${rid}) ---"
+
+    # 2a. Ingest into chunk store
+    echo "  [ingest] ${clone_dir}"
+    python "${SCRIPT_DIR}/ingest_repo.py" \
+        --repo "$clone_dir" \
+        --repo-id "$rid" \
+        --commit HEAD \
+        --config "$CONFIG"
+
+    # 2b. Generate training corpus
+    echo "  [corpus] generating train/val for ${rid}"
+    python "${SCRIPT_DIR}/generate_training_corpus.py" \
+        --repo-id "$rid" \
+        --config "$CONFIG" \
+        --photon-config "$PHOTON_CONFIG" \
+        --output-dir "$PROCESSED_DIR" \
+        --val-ratio 0.1
+done
+
+# ── Phase 3: Merge into multi-repo corpus ────────────────────────────
+echo ""
+echo "=== Phase 3: Merge into train_multi.jsonl / val_multi.jsonl ==="
+
+TRAIN_MULTI="${PROCESSED_DIR}/train_multi.jsonl"
+VAL_MULTI="${PROCESSED_DIR}/val_multi.jsonl"
+
+# Clear previous output
+: > "$TRAIN_MULTI"
+: > "$VAL_MULTI"
+
+for repo in "${REPOS[@]}"; do
+    rid="$(repo_id_from "$repo")"
+    # The generate_training_corpus.py produces train_tiny.jsonl / val_tiny.jsonl
+    # (the full split) plus train_small.jsonl / val_small.jsonl (capped).
+    # We merge the full splits (train_tiny / val_tiny) for maximum coverage.
+    train_file="${PROCESSED_DIR}/train_tiny.jsonl"
+    val_file="${PROCESSED_DIR}/val_tiny.jsonl"
+
+    if [ -f "$train_file" ]; then
+        cat "$train_file" >> "$TRAIN_MULTI"
+        echo "  [merge] ${rid} train: $(wc -l < "$train_file") docs"
+    else
+        echo "  [warn] ${train_file} not found for ${rid}"
+    fi
+
+    if [ -f "$val_file" ]; then
+        cat "$val_file" >> "$VAL_MULTI"
+        echo "  [merge] ${rid} val:   $(wc -l < "$val_file") docs"
+    else
+        echo "  [warn] ${val_file} not found for ${rid}"
+    fi
+done
+
+TRAIN_TOTAL="$(wc -l < "$TRAIN_MULTI")"
+VAL_TOTAL="$(wc -l < "$VAL_MULTI")"
+
+echo ""
+echo "=== Done ==="
+echo "  train_multi.jsonl : ${TRAIN_TOTAL} documents"
+echo "  val_multi.jsonl   : ${VAL_TOTAL} documents"
+echo "  Location          : ${PROCESSED_DIR}/"


### PR DESCRIPTION
## Summary

- `scripts/expand_corpus.sh` — 5 repos (FastAPI, Flask, Starlette, httpx, Pydantic) のコーパス生成スクリプト
- `configs/photon_small.yaml` — 学習設定更新: max_steps 2000, batch_size 4, multi-repo corpus パス

## Test plan

- [x] `ruff check .` — 0 warnings
- [x] `ruff format --check .` — 0 diffs
- [ ] `./scripts/expand_corpus.sh` 実行は別途 (要 repo clone)

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)