### PR TITLE
fix(app): Streamlitアプリの状態ファイル同期をバックグラウンドスレッド化

### DIFF
--- a/app/photon_app.py
+++ b/app/photon_app.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import threading
 import time
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
@@ -19,6 +20,9 @@ import streamlit as st
 
 PROJECT_ROOT = Path(__file__).parent.parent
 STATE_FILE = PROJECT_ROOT / ".cache" / "photon_app_state.json"
+
+SYNC_INTERVAL_SECONDS = 30
+_LOG_TAIL_BYTES = 65536
 
 
 # ================================================================
@@ -155,6 +159,147 @@ def _read_training_progress(log_file: str) -> dict[str, Any]:
     return result
 
 
+def _read_log_tail(log_file: str, max_bytes: int = _LOG_TAIL_BYTES) -> str:
+    if not log_file:
+        return ""
+    path = Path(log_file)
+    if not path.exists():
+        return ""
+    try:
+        size = path.stat().st_size
+        with open(path, "rb") as f:
+            if size > max_bytes:
+                f.seek(-max_bytes, os.SEEK_END)
+            data = f.read()
+        return data.decode("utf-8", errors="replace")
+    except OSError:
+        return ""
+
+
+# ================================================================
+# Job status reconciliation (pure helpers — no Streamlit access)
+# ================================================================
+
+
+def _sync_training_job(job: TrainingJob, progress: dict[str, Any] | None) -> bool:
+    """Reconcile a training job against live process state and logs.
+
+    Returns True if any field on `job` was mutated.
+    """
+    changed = False
+
+    if progress:
+        step = int(progress.get("last_step", 0) or 0)
+        if step > job.last_step:
+            job.last_step = step
+            changed = True
+        val_loss = float(progress.get("val_loss", 0.0) or 0.0)
+        if val_loss > 0.0 and val_loss != job.val_loss:
+            job.val_loss = val_loss
+            changed = True
+
+    if job.status == "running" and not _is_process_running(job.pid):
+        tail = _read_log_tail(job.log_file)
+        if "Training complete" in tail or job.last_step > 0:
+            job.status = "completed"
+        else:
+            job.status = "failed"
+        changed = True
+
+    return changed
+
+
+def _sync_index_job(job: IndexJob) -> bool:
+    """Reconcile an index job against live process state and logs."""
+    changed = False
+
+    log_content = ""
+    if job.log_file:
+        path = Path(job.log_file)
+        if path.exists():
+            try:
+                log_content = path.read_text(errors="replace")
+            except OSError:
+                log_content = ""
+
+    if log_content and job.status == "running":
+        if "Phase 3" in log_content:
+            new_phase = "symbol_graph"
+        elif "Phase 2" in log_content:
+            new_phase = "bm25_embed"
+        elif "Phase 1" in log_content:
+            new_phase = "ingest"
+        else:
+            new_phase = job.phase
+        if new_phase != job.phase:
+            job.phase = new_phase
+            changed = True
+
+    if job.status == "running" and not _is_process_running(job.pid):
+        if "DONE" in log_content:
+            job.status = "completed"
+            job.phase = "completed"
+        else:
+            job.status = "failed"
+        changed = True
+
+    return changed
+
+
+def _sync_all_jobs(state: AppState) -> bool:
+    """Reconcile every training/index job in `state`. Returns True if mutated."""
+    changed = False
+    progress = _read_training_progress(str(PROJECT_ROOT / "logs" / "train_log.jsonl"))
+    for job in state.training_jobs.values():
+        if _sync_training_job(job, progress):
+            changed = True
+    for job in state.index_jobs.values():
+        if _sync_index_job(job):
+            changed = True
+    return changed
+
+
+_state_file_lock = threading.Lock()
+
+
+def _sync_state_file() -> bool:
+    """Load state file, reconcile job statuses, write back if anything changed."""
+    with _state_file_lock:
+        state = _load_state()
+        if _sync_all_jobs(state):
+            _save_state(state)
+            return True
+        return False
+
+
+_sync_thread_started = False
+_sync_thread_lock = threading.Lock()
+
+
+def _start_background_sync(interval_s: float = SYNC_INTERVAL_SECONDS) -> None:
+    """Start a daemon thread that keeps the state file authoritative.
+
+    Runs once per Streamlit server process: the thread survives browser
+    disconnects and script reruns, so job status keeps advancing even when
+    no UI is mounted. Re-runs are cheap — we no-op after the first call.
+    """
+    global _sync_thread_started
+    with _sync_thread_lock:
+        if _sync_thread_started:
+            return
+        _sync_thread_started = True
+
+    def _worker() -> None:
+        while True:
+            try:
+                _sync_state_file()
+            except Exception:
+                pass
+            time.sleep(interval_s)
+
+    threading.Thread(target=_worker, daemon=True, name="photon_app_state_sync").start()
+
+
 # ================================================================
 # Page: Training
 # ================================================================
@@ -274,18 +419,10 @@ def page_training():
         st.info("学習ジョブはありません")
         return
 
+    progress = _read_training_progress(str(PROJECT_ROOT / "logs" / "train_log.jsonl"))
     for job_id, job in sorted(state.training_jobs.items(), reverse=True):
-        running = _is_process_running(job.pid)
-        if job.status == "running" and not running:
-            job.status = "completed"
+        if _sync_training_job(job, progress):
             save()
-
-        progress = _read_training_progress(
-            str(PROJECT_ROOT / "logs" / "train_log.jsonl")
-        )
-        if progress["last_step"] > 0:
-            job.last_step = progress["last_step"]
-            job.val_loss = progress["val_loss"]
 
         icon = {
             "pending": "⏳",
@@ -433,28 +570,8 @@ def page_index():
         return
 
     for job_id, job in sorted(state.index_jobs.items(), reverse=True):
-        running = _is_process_running(job.pid)
-        if job.status == "running":
-            if not running:
-                # Check if DONE
-                log_path = Path(job.log_file)
-                if log_path.exists() and "DONE" in log_path.read_text():
-                    job.status = "completed"
-                    job.phase = "completed"
-                else:
-                    job.status = "failed"
-                save()
-            else:
-                # Update phase
-                log_path = Path(job.log_file)
-                if log_path.exists():
-                    content = log_path.read_text()
-                    if "Phase 3" in content:
-                        job.phase = "symbol_graph"
-                    elif "Phase 2" in content:
-                        job.phase = "bm25_embed"
-                    else:
-                        job.phase = "ingest"
+        if _sync_index_job(job):
+            save()
 
         icon = {
             "pending": "⏳",
@@ -728,6 +845,21 @@ def main():
         page_icon="🔬",
         layout="wide",
     )
+
+    # Background sync keeps the state file correct even when no browser is
+    # attached. On first script run we also do a synchronous pass so the UI
+    # never shows stale `running` rows for jobs that already finished.
+    if "initial_sync_done" not in st.session_state:
+        try:
+            _sync_state_file()
+        except Exception:
+            pass
+        st.session_state.initial_sync_done = True
+    _start_background_sync()
+
+    # Reload from disk on each rerun so background-thread updates are visible
+    # and any external edits are picked up.
+    st.session_state.app_state = _load_state()
 
     st.sidebar.title("🔬 PHOTON-RepoRAG")
     st.sidebar.markdown("---")

--- a/tests/test_photon_app_state_sync.py
+++ b/tests/test_photon_app_state_sync.py
@@ -1,0 +1,202 @@
+"""Tests for app/photon_app.py state sync helpers (Issue #59).
+
+The Streamlit app previously only reconciled job status during UI rendering,
+so closing the browser or stopping Streamlit left `.cache/photon_app_state.json`
+stuck at `status=running`. These tests cover the pure sync helpers that let a
+background thread (and a one-shot startup pass) keep the file authoritative.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "app"))
+
+import photon_app  # noqa: E402
+
+
+class TestSyncTrainingJob(unittest.TestCase):
+    def _make_job(self, **overrides) -> photon_app.TrainingJob:
+        defaults = dict(
+            job_id="t1",
+            repo_dir="/tmp/r",
+            config_path="/tmp/c.yaml",
+            pid=1,
+            started_at="2026-04-20T10:00:00",
+            status="running",
+            log_file="",
+            last_step=0,
+            max_steps=1000,
+            val_loss=0.0,
+        )
+        defaults.update(overrides)
+        return photon_app.TrainingJob(**defaults)
+
+    def test_running_process_keeps_status(self) -> None:
+        job = self._make_job()
+        with patch.object(photon_app, "_is_process_running", return_value=True):
+            photon_app._sync_training_job(job, None)
+        self.assertEqual(job.status, "running")
+
+    def test_progress_advances_last_step_and_val_loss(self) -> None:
+        job = self._make_job(last_step=10, val_loss=2.0)
+        with patch.object(photon_app, "_is_process_running", return_value=True):
+            changed = photon_app._sync_training_job(
+                job, {"last_step": 500, "val_loss": 1.2345, "max_steps": 1000}
+            )
+        self.assertTrue(changed)
+        self.assertEqual(job.last_step, 500)
+        self.assertAlmostEqual(job.val_loss, 1.2345)
+
+    def test_progress_does_not_regress(self) -> None:
+        job = self._make_job(last_step=800, val_loss=1.1)
+        with patch.object(photon_app, "_is_process_running", return_value=True):
+            photon_app._sync_training_job(
+                job, {"last_step": 100, "val_loss": 1.1, "max_steps": 1000}
+            )
+        self.assertEqual(job.last_step, 800)
+
+    def test_dead_process_with_training_complete_marks_completed(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            log = Path(td) / "train.log"
+            log.write_text("step 999\nTraining complete. Final loss: 0.0219\n")
+            job = self._make_job(log_file=str(log))
+            with patch.object(photon_app, "_is_process_running", return_value=False):
+                changed = photon_app._sync_training_job(job, None)
+        self.assertTrue(changed)
+        self.assertEqual(job.status, "completed")
+
+    def test_dead_process_with_steps_but_no_marker_marks_completed(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            log = Path(td) / "train.log"
+            log.write_text("step 999 done\n")
+            job = self._make_job(log_file=str(log), last_step=999)
+            with patch.object(photon_app, "_is_process_running", return_value=False):
+                photon_app._sync_training_job(job, None)
+        self.assertEqual(job.status, "completed")
+
+    def test_dead_process_with_no_progress_marks_failed(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            log = Path(td) / "train.log"
+            log.write_text("Traceback ...\n")
+            job = self._make_job(log_file=str(log), last_step=0)
+            with patch.object(photon_app, "_is_process_running", return_value=False):
+                photon_app._sync_training_job(job, None)
+        self.assertEqual(job.status, "failed")
+
+
+class TestSyncIndexJob(unittest.TestCase):
+    def _make_job(self, **overrides) -> photon_app.IndexJob:
+        defaults = dict(
+            job_id="i1",
+            repo_dir="/tmp/r",
+            repo_id="r",
+            config_path="configs/baseline.yaml",
+            pid=1,
+            started_at="2026-04-20T10:00:00",
+            status="running",
+            log_file="",
+            phase="ingest",
+            embedding_model="",
+        )
+        defaults.update(overrides)
+        return photon_app.IndexJob(**defaults)
+
+    def test_running_advances_phase_from_log(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            log = Path(td) / "idx.log"
+            log.write_text("Phase 1: Ingest\nPhase 2: BM25 + Embedding\n")
+            job = self._make_job(log_file=str(log))
+            with patch.object(photon_app, "_is_process_running", return_value=True):
+                photon_app._sync_index_job(job)
+        self.assertEqual(job.phase, "bm25_embed")
+        self.assertEqual(job.status, "running")
+
+    def test_dead_process_with_done_marks_completed(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            log = Path(td) / "idx.log"
+            log.write_text("Phase 3: Symbol Graph\nDONE\n")
+            job = self._make_job(log_file=str(log), phase="symbol_graph")
+            with patch.object(photon_app, "_is_process_running", return_value=False):
+                photon_app._sync_index_job(job)
+        self.assertEqual(job.status, "completed")
+        self.assertEqual(job.phase, "completed")
+
+    def test_dead_process_without_done_marks_failed(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            log = Path(td) / "idx.log"
+            log.write_text("Phase 1: Ingest\nError: not found\n")
+            job = self._make_job(log_file=str(log))
+            with patch.object(photon_app, "_is_process_running", return_value=False):
+                photon_app._sync_index_job(job)
+        self.assertEqual(job.status, "failed")
+
+
+class TestSyncStateFile(unittest.TestCase):
+    """_sync_state_file reads the JSON, reconciles, and writes back if changed."""
+
+    def test_running_to_completed_persisted_to_disk(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            state_file = Path(td) / "state.json"
+            log = Path(td) / "train.log"
+            log.write_text("Training complete. Final loss: 0.0219\n")
+            state_file.write_text(
+                json.dumps(
+                    {
+                        "training_jobs": {
+                            "t1": {
+                                "job_id": "t1",
+                                "repo_dir": "/tmp/r",
+                                "config_path": "/tmp/c.yaml",
+                                "pid": 1,
+                                "started_at": "2026-04-20T10:00:00",
+                                "status": "running",
+                                "log_file": str(log),
+                                "last_step": 0,
+                                "max_steps": 1000,
+                                "val_loss": 0.0,
+                            }
+                        },
+                        "index_jobs": {},
+                        "projects": {},
+                        "chat_histories": {},
+                    }
+                )
+            )
+
+            with (
+                patch.object(photon_app, "STATE_FILE", state_file),
+                patch.object(photon_app, "_is_process_running", return_value=False),
+            ):
+                changed = photon_app._sync_state_file()
+
+            data = json.loads(state_file.read_text())
+
+        self.assertTrue(changed)
+        self.assertEqual(data["training_jobs"]["t1"]["status"], "completed")
+
+    def test_no_running_jobs_is_noop(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            state_file = Path(td) / "state.json"
+            state_file.write_text(
+                json.dumps(
+                    {
+                        "training_jobs": {},
+                        "index_jobs": {},
+                        "projects": {},
+                        "chat_histories": {},
+                    }
+                )
+            )
+            with patch.object(photon_app, "STATE_FILE", state_file):
+                changed = photon_app._sync_state_file()
+        self.assertFalse(changed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Issue #59 を修正。`photon_app_state.json` が学習終了後も `status=running` のまま残る問題を解消。

## 変更内容

- `app/photon_app.py`: バックグラウンドスレッドで30秒ごとに状態ファイルを同期
  - `_read_log_tail()`: ログの末尾を読んで完了検知
  - `_sync_training_job()`, `_sync_index_job()`: プロセス状態をチェックして status/last_step/val_loss を更新
  - `_sync_all_jobs()`, `_sync_state_file()`, `_start_background_sync()`: 定期ポーリングの基盤

Streamlit UI レンダリング時以外でも、状態ファイルが正しく同期されるようになります。

## Test Plan

- [x] `ruff check .` - All checks passed
- [x] `python -m pytest` - 255 passed, 2 pre-existing failures (unrelated)
- [ ] アプリ起動→学習完了→ブラウザタブを閉じる→状態ファイル確認（手動）

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)