### PR TITLE
feat(photon): Early Stopping 実装でオーバーフィッティングを防止

### DIFF
--- a/app/photon_app.py
+++ b/app/photon_app.py
@@ -7,11 +7,14 @@ Launch:
 from __future__ import annotations
 
 import json
+import logging
 import os
+import re
 import subprocess
+import sys
 import threading
 import time
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, fields
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -23,6 +26,120 @@ STATE_FILE = PROJECT_ROOT / ".cache" / "photon_app_state.json"
 
 SYNC_INTERVAL_SECONDS = 30
 _LOG_TAIL_BYTES = 65536
+
+# Allowlist for repo_id / job_id path segments. Reject `/`, `\`, `..`,
+# spaces, and any other metacharacter so path composition stays safe.
+_SAFE_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+_logger = logging.getLogger(__name__)
+
+
+def _safe_id(value: str, *, label: str) -> str:
+    if not isinstance(value, str) or not _SAFE_ID_RE.match(value):
+        raise ValueError(f"Invalid {label}: {value!r}. Only [A-Za-z0-9_-]+ is allowed.")
+    return value
+
+
+def _filter_known_fields(dc_cls, raw: dict) -> dict:
+    """Return only keys that match dataclass fields of ``dc_cls``."""
+    known = {f.name for f in fields(dc_cls)}
+    unknown = set(raw) - known
+    if unknown:
+        _logger.warning(
+            "Ignoring unknown keys for %s: %s",
+            dc_cls.__name__,
+            sorted(unknown),
+        )
+    return {k: v for k, v in raw.items() if k in known}
+
+
+def _atomic_write_text(path: Path, data: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + ".tmp")
+    tmp.write_text(data, encoding="utf-8")
+    os.replace(tmp, path)
+
+
+# Driver executed in a child ``python -c`` to chain the 4 index-build
+# phases with argv-list subprocess.run calls (shell=False). No user input
+# is interpolated into this string — every user value arrives via sys.argv.
+_INDEX_PIPELINE_DRIVER = """
+import subprocess, sys
+repo_dir, repo_id, embed_model, config_path = sys.argv[1:5]
+
+def run(argv, phase):
+    print(f'>>> {phase}: ' + ' '.join(argv), flush=True)
+    subprocess.run(argv, check=True)
+
+# Phase 0: resolve commit SHA
+out = subprocess.run(
+    ['git', '-C', repo_dir, 'rev-parse', 'HEAD'],
+    check=True, capture_output=True, text=True,
+)
+commit = out.stdout.strip()
+print(f'Phase 1: Ingest (commit={commit})', flush=True)
+run(
+    [
+        sys.executable, '-m', 'scripts.ingest_repo',
+        '--repo', repo_dir, '--repo-id', repo_id,
+        '--commit', commit, '--config', config_path,
+    ],
+    'ingest',
+)
+print(f'Phase 2: BM25 + Embedding ({embed_model})', flush=True)
+run(
+    [
+        sys.executable, '-m', 'scripts.build_indexes',
+        '--repo-id', repo_id, '--commit', commit,
+        '--embedding-model', embed_model, '--config', config_path,
+    ],
+    'build_indexes',
+)
+print('Phase 3: Symbol Graph', flush=True)
+run(
+    [
+        sys.executable, '-m', 'scripts.build_symbol_graph',
+        '--repo-id', repo_id, '--commit', commit, '--config', config_path,
+    ],
+    'build_symbol_graph',
+)
+print('DONE', flush=True)
+"""
+
+
+def _discover_checkpoints(ckpt_dir: Path) -> list[tuple[int, str, str]]:
+    """Discover checkpoint directories under ``ckpt_dir``.
+
+    Returns a list of ``(priority, path, label)`` tuples, sorted so that
+    ``best/`` entries come first, then ``final/``, then ``step_XXXXXX/``.
+    ``.tmp`` directories (e.g. the transient ``best.tmp/`` created during
+    atomic checkpoint replacement) are excluded so the UI never surfaces a
+    path that may vanish moments later.
+    """
+    entries: list[tuple[int, str, str]] = []
+    if not ckpt_dir.exists():
+        return entries
+    for weights in ckpt_dir.rglob("weights.npz"):
+        ck_path = weights.parent
+        name = ck_path.name
+        # Skip atomic-write scratch directories such as best.tmp.
+        if name.endswith(".tmp"):
+            continue
+        if name == "best":
+            priority = 0
+            label = f"[best] {ck_path}"
+        elif name == "final":
+            priority = 1
+            label = f"[final] {ck_path}"
+        elif name.startswith("step_"):
+            priority = 2
+            label = f"[{name}] {ck_path}"
+        else:
+            priority = 3
+            label = str(ck_path)
+        entries.append((priority, str(ck_path), label))
+    entries.sort(key=lambda t: (t[0], -len(t[1]), t[1]))
+    return entries
 
 
 # ================================================================
@@ -42,6 +159,10 @@ class TrainingJob:
     last_step: int = 0
     max_steps: int = 0
     val_loss: float = 0.0
+    # Issue #60: per-job progress log (`<log_dir>/train_log.jsonl`).
+    # Empty string means the job predates the run-namespaced layout; the
+    # UI will render "ログ未リンク" in that case.
+    progress_log_file: str = ""
 
 
 @dataclass
@@ -89,27 +210,28 @@ def _load_state() -> AppState:
             data = json.loads(STATE_FILE.read_text())
             state = AppState()
             for k, v in data.get("training_jobs", {}).items():
-                state.training_jobs[k] = TrainingJob(**v)
+                state.training_jobs[k] = TrainingJob(
+                    **_filter_known_fields(TrainingJob, v)
+                )
             for k, v in data.get("index_jobs", {}).items():
-                state.index_jobs[k] = IndexJob(**v)
+                state.index_jobs[k] = IndexJob(**_filter_known_fields(IndexJob, v))
             for k, v in data.get("projects", {}).items():
-                state.projects[k] = Project(**v)
+                state.projects[k] = Project(**_filter_known_fields(Project, v))
             state.chat_histories = data.get("chat_histories", {})
             return state
-        except Exception:
-            pass
+        except Exception as exc:
+            _logger.warning("Failed to load app state: %s", exc)
     return AppState()
 
 
 def _save_state(state: AppState) -> None:
-    STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
     data = {
         "training_jobs": {k: asdict(v) for k, v in state.training_jobs.items()},
         "index_jobs": {k: asdict(v) for k, v in state.index_jobs.items()},
         "projects": {k: asdict(v) for k, v in state.projects.items()},
         "chat_histories": state.chat_histories,
     }
-    STATE_FILE.write_text(json.dumps(data, ensure_ascii=False, indent=2))
+    _atomic_write_text(STATE_FILE, json.dumps(data, ensure_ascii=False, indent=2))
 
 
 def get_state() -> AppState:
@@ -138,24 +260,53 @@ def _is_process_running(pid: int | None) -> bool:
 
 
 def _read_training_progress(log_file: str) -> dict[str, Any]:
-    """Read last step and val_loss from training log."""
-    result: dict[str, Any] = {"last_step": 0, "val_loss": 0.0, "max_steps": 0}
+    """Read latest progress from a per-job training log.
+
+    Returns a default result dict with ``last_step``, ``val_loss``,
+    ``max_steps`` and Issue #60 early-stopping fields.  If ``log_file``
+    is empty or missing, the default (all zeros / False) is returned so
+    the UI can render "ログ未リンク" without crashing.
+    """
+    result: dict[str, Any] = {
+        "last_step": 0,
+        "val_loss": 0.0,
+        "max_steps": 0,
+        "best_step": 0,
+        "best_val_loss": 0.0,
+        "patience_counter": 0,
+        "early_stopped": False,
+    }
+    if not log_file:
+        return result
     log_path = Path(log_file)
     if not log_path.exists():
         return result
     try:
         lines = log_path.read_text().strip().split("\n")
+        seen_eval = False
         for line in reversed(lines):
             try:
                 rec = json.loads(line)
-                if "step" in rec:
-                    result["last_step"] = max(result["last_step"], rec["step"])
-                if "val_loss" in rec:
-                    result["val_loss"] = rec["val_loss"]
             except json.JSONDecodeError:
                 continue
-    except Exception:
-        pass
+            if "step" in rec:
+                result["last_step"] = max(result["last_step"], rec["step"])
+            # eval entries: grab all known fields from the most recent one
+            if "val_loss" in rec and not seen_eval:
+                result["val_loss"] = rec.get("val_loss", result["val_loss"])
+                result["best_step"] = rec.get("best_step", result["best_step"])
+                result["best_val_loss"] = rec.get(
+                    "best_val_loss", result["best_val_loss"]
+                )
+                result["patience_counter"] = rec.get(
+                    "patience_counter", result["patience_counter"]
+                )
+                result["early_stopped"] = rec.get(
+                    "early_stopped", result["early_stopped"]
+                )
+                seen_eval = True
+    except Exception as exc:
+        _logger.warning("progress read failed (%s): %s", log_file, exc)
     return result
 
 
@@ -339,6 +490,20 @@ def page_training():
             repo_name = Path(repo_dir).name
             repo_id = repo_name.replace("-", "_").replace(" ", "_")
 
+            try:
+                repo_id = _safe_id(repo_id, label="repo_id")
+                job_id = _safe_id(job_id, label="job_id")
+            except ValueError as exc:
+                st.error(str(exc))
+                st.stop()
+
+            # Run-specific checkpoint/log directories (Issue #60).
+            run_ckpt_dir = PROJECT_ROOT / "checkpoints" / repo_id / job_id
+            run_log_dir = PROJECT_ROOT / "logs" / job_id
+            run_ckpt_dir.mkdir(parents=True, exist_ok=True)
+            run_log_dir.mkdir(parents=True, exist_ok=True)
+            progress_log_file = str(run_log_dir / "train_log.jsonl")
+
             # Generate config
             config_path = str(PROJECT_ROOT / "configs" / f"photon_{repo_id}.yaml")
             _generate_photon_config(
@@ -388,13 +553,27 @@ def page_training():
             ]
             subprocess.run(corpus_cmd, cwd=str(PROJECT_ROOT), capture_output=True)
 
-            # Step 2: Start training in background
+            # Step 2: Start training in background (argv list + shell=False).
             train_log = str(PROJECT_ROOT / "logs" / f"{job_id}.log")
-            train_cmd = f"python -u -m scripts.train_photon --config {config_path} > {train_log} 2>&1"
+            train_cmd = [
+                "python",
+                "-u",
+                "-m",
+                "scripts.train_photon",
+                "--config",
+                config_path,
+                "--checkpoint-dir",
+                str(run_ckpt_dir),
+                "--log-dir",
+                str(run_log_dir),
+            ]
+            train_log_fp = open(train_log, "w", encoding="utf-8")
             proc = subprocess.Popen(
                 train_cmd,
-                shell=True,
+                shell=False,
                 cwd=str(PROJECT_ROOT),
+                stdout=train_log_fp,
+                stderr=subprocess.STDOUT,
             )
 
             job = TrainingJob(
@@ -406,6 +585,7 @@ def page_training():
                 status="running",
                 log_file=train_log,
                 max_steps=max_steps,
+                progress_log_file=progress_log_file,
             )
             state.training_jobs[job_id] = job
             save()
@@ -419,8 +599,13 @@ def page_training():
         st.info("学習ジョブはありません")
         return
 
-    progress = _read_training_progress(str(PROJECT_ROOT / "logs" / "train_log.jsonl"))
     for job_id, job in sorted(state.training_jobs.items(), reverse=True):
+        # Prefer the per-job progress log (Issue #60). Legacy jobs without
+        # progress_log_file fall back to the global train_log.jsonl.
+        job_log = job.progress_log_file or str(
+            PROJECT_ROOT / "logs" / "train_log.jsonl"
+        )
+        progress = _read_training_progress(job_log)
         if _sync_training_job(job, progress):
             save()
 
@@ -445,6 +630,25 @@ def page_training():
 
             if job.val_loss > 0:
                 st.metric("最新 val_loss", f"{job.val_loss:.4f}")
+
+            # Early stopping status (Issue #60)
+            if progress.get("best_step", 0) > 0:
+                es_col1, es_col2, es_col3 = st.columns(3)
+                es_col1.metric("best_step", str(progress.get("best_step", 0)))
+                bvl = progress.get("best_val_loss", 0.0)
+                es_col2.metric(
+                    "best_val_loss",
+                    f"{bvl:.4f}" if bvl else "—",
+                )
+                es_col3.metric(
+                    "patience",
+                    str(progress.get("patience_counter", 0)),
+                )
+            if progress.get("early_stopped"):
+                st.warning("Early stopping が発動しました")
+
+            if not job.progress_log_file:
+                st.caption("ログ未リンク (旧ジョブのため run 別パスなし)")
 
             st.text(f"Config: {job.config_path}")
             st.text(f"リポジトリ: {job.repo_dir}")
@@ -476,9 +680,11 @@ def _generate_photon_config(
     cfg["training"]["train_corpus"] = "./data/processed/train_tiny.jsonl"
     cfg["training"]["val_corpus"] = "./data/processed/val_tiny.jsonl"
 
-    Path(path).parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "w") as f:
-        yaml.dump(cfg, f, default_flow_style=False, allow_unicode=True)
+    # Atomic write: serialize to a string and hand off to the shared
+    # temp-file + os.replace helper so a crash mid-write cannot leave a
+    # partial YAML behind for scripts.train_photon to load.
+    payload = yaml.dump(cfg, default_flow_style=False, allow_unicode=True)
+    _atomic_write_text(Path(path), payload)
 
 
 # ================================================================
@@ -522,26 +728,49 @@ def page_index():
         if not Path(repo_dir).is_dir():
             st.error(f"ディレクトリが見つかりません: {repo_dir}")
         else:
-            job_id = f"idx_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
-            log_file = str(PROJECT_ROOT / "logs" / f"{job_id}.log")
+            # Validate repo_id with allowlist before passing to argv.
+            try:
+                repo_id = _safe_id(repo_id, label="repo_id")
+            except ValueError as exc:
+                st.error(str(exc))
+                st.stop()
 
-            # Run all 3 steps in background
-            # Get actual commit SHA so build_indexes/symbol_graph use it
-            cmd = (
-                f"REPO_COMMIT=$(git -C {repo_dir} rev-parse HEAD) && "
-                f'echo "Phase 1: Ingest (commit=$REPO_COMMIT)" && '
-                f"python -m scripts.ingest_repo --repo {repo_dir} --repo-id {repo_id} --commit $REPO_COMMIT --config configs/baseline.yaml && "
-                f"echo 'Phase 2: BM25 + Embedding ({embedding_model_id})' && "
-                f"python -m scripts.build_indexes --repo-id {repo_id} --commit $REPO_COMMIT --embedding-model {embedding_model_id} --config configs/baseline.yaml && "
-                f"echo 'Phase 3: Symbol Graph' && "
-                f"python -m scripts.build_symbol_graph --repo-id {repo_id} --commit $REPO_COMMIT --config configs/baseline.yaml && "
-                f"echo 'DONE'"
-            )
+            job_id = f"idx_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+            try:
+                job_id = _safe_id(job_id, label="job_id")
+            except ValueError as exc:
+                st.error(str(exc))
+                st.stop()
+
+            log_file = str(PROJECT_ROOT / "logs" / f"{job_id}.log")
+            Path(log_file).parent.mkdir(parents=True, exist_ok=True)
+
+            # Chain the 4 phases (git rev-parse, ingest, build_indexes,
+            # build_symbol_graph) in a Python driver that spawns each phase
+            # with ``subprocess.run([...], shell=False)``. We pass the driver
+            # to a background ``python -c`` so the Streamlit UI returns
+            # immediately while the pipeline runs in the background. All
+            # user-controlled values (repo_dir, repo_id, embedding_model_id,
+            # config_path) arrive as argv and are never interpolated into a
+            # shell string.
+            driver = _INDEX_PIPELINE_DRIVER
+            config_path = "configs/baseline.yaml"
+            cmd_argv = [
+                sys.executable,
+                "-u",
+                "-c",
+                driver,
+                repo_dir,
+                repo_id,
+                embedding_model_id,
+                config_path,
+            ]
+            log_fp = open(log_file, "w", encoding="utf-8")
             proc = subprocess.Popen(
-                cmd,
-                shell=True,
+                cmd_argv,
+                shell=False,
                 cwd=str(PROJECT_ROOT),
-                stdout=open(log_file, "w"),
+                stdout=log_fp,
                 stderr=subprocess.STDOUT,
             )
 
@@ -549,7 +778,7 @@ def page_index():
                 job_id=job_id,
                 repo_dir=repo_dir,
                 repo_id=repo_id,
-                config_path="configs/baseline.yaml",
+                config_path=config_path,
                 pid=proc.pid,
                 started_at=datetime.now().isoformat(),
                 status="running",
@@ -621,16 +850,19 @@ def page_projects():
         options=available_indexes if available_indexes else ["(なし — 先にDB作成)"],
     )
 
-    # Available checkpoints
+    # Available checkpoints: recursively discover any dir containing weights.npz
+    # (supports the new layout checkpoints/<repo>/<job>/{best,final,step_XXXXXX}).
+    # ``.tmp`` scratch dirs created during atomic replacement are excluded.
     ckpt_dir = PROJECT_ROOT / "checkpoints"
-    available_ckpts = ["(なし — baseline のみ)"]
-    if ckpt_dir.exists():
-        for d in sorted(ckpt_dir.iterdir()):
-            if d.is_dir() and (d / "weights.npz").exists():
-                available_ckpts.append(str(d))
+    none_label = "(なし — baseline のみ)"
+    ckpt_entries = _discover_checkpoints(ckpt_dir)
+    available_ckpts = [none_label] + [t[2] for t in ckpt_entries]
+    # Map display label back to path for selection.
+    label_to_path = {t[2]: t[1] for t in ckpt_entries}
 
-    checkpoint = st.selectbox("PHOTON モデル (checkpoint)", options=available_ckpts)
-    use_photon = checkpoint != "(なし — baseline のみ)"
+    selected_label = st.selectbox("PHOTON モデル (checkpoint)", options=available_ckpts)
+    checkpoint = label_to_path.get(selected_label, selected_label)
+    use_photon = selected_label != none_label
 
     # Config selection
     available_configs = sorted(

--- a/configs/photon_600m_paper.yaml
+++ b/configs/photon_600m_paper.yaml
@@ -172,6 +172,11 @@ training:
   save_every_steps: 500
   log_every_steps: 20
 
+  # Early stopping (Issue #60): explicit opt-out for this reference-only
+  # config (training.enabled is false; no real run is launched from it).
+  early_stopping:
+    enabled: false
+
 inference:
   hierarchical_prefill: true
   recgen_enabled: true

--- a/configs/photon_small.yaml
+++ b/configs/photon_small.yaml
@@ -194,6 +194,13 @@ training:
   save_every_steps: 100
   log_every_steps: 20
 
+  # Early stopping (Issue #60): enabled for production small config.
+  early_stopping:
+    enabled: true
+    patience: 3
+    min_delta: 0.001
+    restore_best: true
+
 inference:
   hierarchical_prefill: true
   recgen_enabled: true

--- a/configs/photon_tiny.yaml
+++ b/configs/photon_tiny.yaml
@@ -172,6 +172,10 @@ training:
   save_every_steps: 500
   log_every_steps: 20
 
+  # Early stopping (Issue #60): explicit opt-out for the dev config.
+  early_stopping:
+    enabled: false
+
 inference:
   hierarchical_prefill: true
   recgen_enabled: false

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -156,9 +156,16 @@ python scripts/train_photon.py --config configs/my_project_photon.yaml
 
 所要時間: 500 steps で約 1 時間、1000 steps で約 2 時間 (M3 Ultra)。
 
-学習中の val_loss を確認:
+**Early Stopping (Issue #60)**: `training.early_stopping.enabled: true` を設定すると、`patience` 回続けて `val_loss` が改善しない場合に学習を自動停止し、`restore_best: true` なら `final/` に最良チェックポイントを復元します。
+
+学習中の val_loss を確認 (手動 CLI 実行時のデフォルト):
 ```bash
 tail -f logs/train_log.jsonl
+```
+
+Streamlit アプリから起動した場合は run 別の log ディレクトリに分離されます:
+```bash
+tail -f logs/<job_id>/train_log.jsonl
 ```
 
 ---
@@ -264,7 +271,20 @@ configs/
 └── my_project_photon.yaml   # PHOTON 用
 │
 checkpoints/                 # PHOTON 学習済みモデル
-└── final/
+├── best/                    # Early Stopping 有効時に最良 val_loss の重み
+│   ├── weights.npz
+│   └── state.json
+└── final/                   # 学習終了時点の重み (restore_best=true なら best/ と同内容)
     ├── weights.npz
     └── state.json
+```
+
+Streamlit アプリから起動した場合は run 単位で名前空間が分離されます:
+
+```
+checkpoints/<repo_id>/<job_id>/
+├── best/
+├── final/
+└── step_XXXXXX/
+logs/<job_id>/train_log.jsonl
 ```

--- a/photon_mlx/tests/test_training.py
+++ b/photon_mlx/tests/test_training.py
@@ -120,7 +120,9 @@ class TestCheckpoint:
         mx.random.seed(42)
         cfg = _tiny_cfg()
         model = PhotonModel(cfg)
-        state = TrainState(step=100, best_val_loss=2.5)
+        state = TrainState(
+            step=100, best_val_loss=2.5, best_step=50, patience_counter=2
+        )
 
         ckpt_dir = tmp_path / "ckpt"
         save_checkpoint(model, state, ckpt_dir)
@@ -134,6 +136,31 @@ class TestCheckpoint:
         state2 = load_checkpoint(model2, ckpt_dir)
         assert state2.step == 100
         assert state2.best_val_loss == 2.5
+        assert state2.best_step == 50
+        assert state2.patience_counter == 2
+
+    def test_load_checkpoint_ignores_unknown_state_keys(self, tmp_path: Path) -> None:
+        """load_checkpoint should drop unknown keys from state.json (forward compat)."""
+        import json as _json
+
+        mx.random.seed(42)
+        cfg = _tiny_cfg()
+        model = PhotonModel(cfg)
+        state = TrainState(step=42, best_val_loss=1.2)
+
+        ckpt_dir = tmp_path / "ckpt"
+        save_checkpoint(model, state, ckpt_dir)
+
+        # Inject an unknown key (simulating a future schema extension)
+        state_path = ckpt_dir / "state.json"
+        data = _json.loads(state_path.read_text(encoding="utf-8"))
+        data["future_unknown_key"] = "ignored"
+        state_path.write_text(_json.dumps(data), encoding="utf-8")
+
+        model2 = PhotonModel(cfg)
+        state2 = load_checkpoint(model2, ckpt_dir)
+        assert state2.step == 42
+        assert state2.best_val_loss == 1.2
 
 
 # ---------------------------------------------------------------
@@ -271,7 +298,13 @@ def _write_dummy_corpus(path: Path, n_docs: int = 10, seq_len: int = 32) -> None
 
 
 def _tiny_train_cfg(tmp_path: Path, **overrides) -> PhotonConfig:
-    """Create a tiny config with TrainingConfig for testing train()."""
+    """Create a tiny config with TrainingConfig for testing train().
+
+    Note: this helper does not set ``early_stopping``; the default
+    ``EarlyStoppingConfig()`` (enabled=False) is inherited via
+    ``TrainingConfig.early_stopping``'s default_factory so existing tests
+    keep their pre-Issue#60 behaviour (runs full max_steps).
+    """
     train_path = tmp_path / "train.jsonl"
     val_path = tmp_path / "val.jsonl"
     _write_dummy_corpus(train_path, n_docs=10, seq_len=32)
@@ -321,6 +354,8 @@ class TestTrainFunction:
         train(cfg, checkpoint_dir=tmp_path / "ckpt", log_dir=tmp_path / "logs")
         assert (tmp_path / "ckpt" / "step_000005").exists()
         assert (tmp_path / "ckpt" / "final").exists()
+        # Early stopping is disabled by default, so best/ should NOT exist.
+        assert not (tmp_path / "ckpt" / "best").exists()
 
     def test_train_gradient_accumulation(self, tmp_path: Path) -> None:
         """train() with gradient_accumulation_steps > 1 should complete."""
@@ -383,3 +418,327 @@ class TestTrainFunction:
         state = train(cfg, checkpoint_dir=tmp_path / "ckpt", log_dir=tmp_path / "logs")
         assert len(state.train_losses) > 1
         assert state.train_losses[-1] < state.train_losses[0]
+
+
+# ---------------------------------------------------------------
+# Early stopping tests (Issue #60)
+# ---------------------------------------------------------------
+
+
+def _patch_evaluate_with_series(monkeypatch, losses: list[float]) -> None:
+    """Patch photon_mlx.trainer.evaluate to yield the given val_loss series."""
+    import photon_mlx.trainer as _trainer_mod
+
+    seq = iter(losses)
+
+    def fake_evaluate(model, val_batches, recursive_loss_weight=0.0):
+        try:
+            return next(seq)
+        except StopIteration:
+            # Keep returning the last value so patient tests don't crash.
+            return losses[-1]
+
+    monkeypatch.setattr(_trainer_mod, "evaluate", fake_evaluate)
+
+
+class TestEarlyStopping:
+    def test_early_stopping_disabled_runs_full_max_steps(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """enabled=false => loop runs for the full max_steps even if val_loss never improves."""
+        _patch_evaluate_with_series(monkeypatch, [2.0, 2.0, 2.0, 2.0, 2.0, 2.0])
+        cfg = _tiny_train_cfg(
+            tmp_path,
+            max_steps=5,
+            eval_every_steps=1,
+            log_every_steps=100,
+            save_every_steps=100,
+        )
+        # early_stopping defaults to enabled=False
+        state = train(cfg, checkpoint_dir=tmp_path / "ckpt", log_dir=tmp_path / "logs")
+        assert state.step == 5
+
+    def test_early_stopping_triggers_on_patience(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """After `patience` evals without improvement, training must stop early."""
+        from torch_ref.config import EarlyStoppingConfig
+
+        # val_losses: improve at step 1 (2.0 -> 1.5), then plateau.
+        # With patience=2, step 2 counter=1, step 3 counter=2 => stop after step 3.
+        _patch_evaluate_with_series(monkeypatch, [2.0, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5])
+        cfg = _tiny_train_cfg(
+            tmp_path,
+            max_steps=10,
+            eval_every_steps=1,
+            log_every_steps=100,
+            save_every_steps=100,
+        )
+        cfg.training.early_stopping = EarlyStoppingConfig(
+            enabled=True, patience=2, min_delta=0.0, restore_best=False
+        )
+        state = train(cfg, checkpoint_dir=tmp_path / "ckpt", log_dir=tmp_path / "logs")
+        # Must stop before reaching max_steps
+        assert state.step < 10
+        assert state.best_step == 2  # step where val_loss first improved to 1.5
+        assert state.patience_counter >= 2
+
+    def test_early_stopping_min_delta_ignores_tiny_improvement(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Improvements smaller than min_delta should not reset patience."""
+        from torch_ref.config import EarlyStoppingConfig
+
+        # Tiny improvements well under min_delta=0.01
+        _patch_evaluate_with_series(
+            monkeypatch, [2.0, 1.995, 1.990, 1.985, 1.980, 1.975]
+        )
+        cfg = _tiny_train_cfg(
+            tmp_path,
+            max_steps=10,
+            eval_every_steps=1,
+            log_every_steps=100,
+            save_every_steps=100,
+        )
+        cfg.training.early_stopping = EarlyStoppingConfig(
+            enabled=True, patience=2, min_delta=0.01, restore_best=False
+        )
+        state = train(cfg, checkpoint_dir=tmp_path / "ckpt", log_dir=tmp_path / "logs")
+        # patience should fire quickly since each improvement is < min_delta
+        assert state.step < 10
+
+    def test_early_stopping_saves_best_checkpoint(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """`best/` dir is created once an improvement happens."""
+        from torch_ref.config import EarlyStoppingConfig
+
+        _patch_evaluate_with_series(monkeypatch, [2.0, 1.5, 1.6, 1.7, 1.8])
+        cfg = _tiny_train_cfg(
+            tmp_path,
+            max_steps=5,
+            eval_every_steps=1,
+            log_every_steps=100,
+            save_every_steps=100,
+        )
+        cfg.training.early_stopping = EarlyStoppingConfig(
+            enabled=True, patience=5, min_delta=0.0, restore_best=False
+        )
+        train(cfg, checkpoint_dir=tmp_path / "ckpt", log_dir=tmp_path / "logs")
+        best_dir = tmp_path / "ckpt" / "best"
+        assert best_dir.exists()
+        assert (best_dir / "weights.npz").exists()
+        assert (best_dir / "state.json").exists()
+
+    def test_early_stopping_restore_best(self, tmp_path: Path, monkeypatch) -> None:
+        """restore_best=true => final/state.json.step == best_step."""
+        import json as _json
+        from torch_ref.config import EarlyStoppingConfig
+
+        _patch_evaluate_with_series(monkeypatch, [2.0, 1.0, 1.5, 1.5, 1.5, 1.5])
+        cfg = _tiny_train_cfg(
+            tmp_path,
+            max_steps=10,
+            eval_every_steps=1,
+            log_every_steps=100,
+            save_every_steps=100,
+        )
+        cfg.training.early_stopping = EarlyStoppingConfig(
+            enabled=True, patience=2, min_delta=0.0, restore_best=True
+        )
+        train(cfg, checkpoint_dir=tmp_path / "ckpt", log_dir=tmp_path / "logs")
+        final_state_path = tmp_path / "ckpt" / "final" / "state.json"
+        best_state_path = tmp_path / "ckpt" / "best" / "state.json"
+        assert final_state_path.exists()
+        final_data = _json.loads(final_state_path.read_text(encoding="utf-8"))
+        best_data = _json.loads(best_state_path.read_text(encoding="utf-8"))
+        # final/ should match best/ on the critical fields
+        assert final_data["step"] == best_data["step"]
+        assert final_data["best_step"] == best_data["best_step"]
+
+    def test_early_stopping_no_restore_best(self, tmp_path: Path, monkeypatch) -> None:
+        """restore_best=false => final/ reflects stop-time step, not best_step."""
+        import json as _json
+        from torch_ref.config import EarlyStoppingConfig
+
+        _patch_evaluate_with_series(monkeypatch, [2.0, 1.0, 1.5, 1.5, 1.5, 1.5])
+        cfg = _tiny_train_cfg(
+            tmp_path,
+            max_steps=10,
+            eval_every_steps=1,
+            log_every_steps=100,
+            save_every_steps=100,
+        )
+        cfg.training.early_stopping = EarlyStoppingConfig(
+            enabled=True, patience=2, min_delta=0.0, restore_best=False
+        )
+        state = train(cfg, checkpoint_dir=tmp_path / "ckpt", log_dir=tmp_path / "logs")
+        final_state_path = tmp_path / "ckpt" / "final" / "state.json"
+        assert final_state_path.exists()
+        final_data = _json.loads(final_state_path.read_text(encoding="utf-8"))
+        # stop-time step is strictly after best_step (1)
+        assert final_data["step"] == state.step
+        assert final_data["step"] > state.best_step
+
+    def test_early_stopping_best_dir_missing_graceful_fallback(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """If best/ disappears mid-run, train() still exits and writes final/."""
+        import shutil as _shutil
+        from torch_ref.config import EarlyStoppingConfig
+
+        # Small loss series that triggers patience quickly.
+        _patch_evaluate_with_series(monkeypatch, [2.0, 1.0, 1.5, 1.5, 1.5, 1.5])
+        cfg = _tiny_train_cfg(
+            tmp_path,
+            max_steps=10,
+            eval_every_steps=1,
+            log_every_steps=100,
+            save_every_steps=100,
+        )
+        cfg.training.early_stopping = EarlyStoppingConfig(
+            enabled=True, patience=2, min_delta=0.0, restore_best=True
+        )
+
+        # Monkeypatch load_checkpoint to fail (simulating corrupt/missing best/)
+        import photon_mlx.trainer as _trainer_mod
+
+        original_load = _trainer_mod.load_checkpoint
+
+        def raising_load(model, path):
+            # Remove best/ before calling original to simulate race.
+            p = Path(path)
+            if p.name == "best" and p.exists():
+                _shutil.rmtree(p)
+                raise FileNotFoundError(f"best dir gone: {p}")
+            return original_load(model, path)
+
+        monkeypatch.setattr(_trainer_mod, "load_checkpoint", raising_load)
+
+        train(cfg, checkpoint_dir=tmp_path / "ckpt", log_dir=tmp_path / "logs")
+        # final/ must still be present even after the fake failure.
+        assert (tmp_path / "ckpt" / "final" / "weights.npz").exists()
+        assert (tmp_path / "ckpt" / "final" / "state.json").exists()
+
+    def test_early_stopping_best_state_json_malformed_graceful_fallback(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """If best/state.json is JSON-parsable but not a dict (e.g. "oops"),
+        train() should still finish and write final/ with stop-time weights,
+        rather than crashing on ValueError from load_checkpoint.
+        """
+        from torch_ref.config import EarlyStoppingConfig
+
+        _patch_evaluate_with_series(monkeypatch, [2.0, 1.0, 1.5, 1.5, 1.5, 1.5])
+        cfg = _tiny_train_cfg(
+            tmp_path,
+            max_steps=10,
+            eval_every_steps=1,
+            log_every_steps=100,
+            save_every_steps=100,
+        )
+        cfg.training.early_stopping = EarlyStoppingConfig(
+            enabled=True, patience=2, min_delta=0.0, restore_best=True
+        )
+
+        import photon_mlx.trainer as _trainer_mod
+
+        original_load = _trainer_mod.load_checkpoint
+
+        def corrupt_then_load(model, path):
+            p = Path(path)
+            # Let save_checkpoint happen as usual, but right before the
+            # end-of-train restore_best load, replace state.json with a
+            # malformed-but-parsable payload ("oops" decodes to a str).
+            if p.name == "best" and (p / "state.json").exists():
+                (p / "state.json").write_text('"oops"', encoding="utf-8")
+            return original_load(model, p)
+
+        monkeypatch.setattr(_trainer_mod, "load_checkpoint", corrupt_then_load)
+
+        train(cfg, checkpoint_dir=tmp_path / "ckpt", log_dir=tmp_path / "logs")
+        # final/ must still be present with stop-time weights, even though
+        # load_checkpoint(best/) raised ValueError under the hood.
+        assert (tmp_path / "ckpt" / "final" / "weights.npz").exists()
+        assert (tmp_path / "ckpt" / "final" / "state.json").exists()
+
+    def test_train_log_jsonl_contains_early_stop_fields(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """eval entries in train_log.jsonl must carry early-stop fields."""
+        import json as _json
+        from torch_ref.config import EarlyStoppingConfig
+
+        _patch_evaluate_with_series(monkeypatch, [2.0, 1.0, 1.0, 1.0, 1.0])
+        cfg = _tiny_train_cfg(
+            tmp_path,
+            max_steps=5,
+            eval_every_steps=1,
+            log_every_steps=100,
+            save_every_steps=100,
+        )
+        cfg.training.early_stopping = EarlyStoppingConfig(
+            enabled=True, patience=2, min_delta=0.0, restore_best=False
+        )
+        train(cfg, checkpoint_dir=tmp_path / "ckpt", log_dir=tmp_path / "logs")
+        log_path = tmp_path / "logs" / "train_log.jsonl"
+        assert log_path.exists()
+        eval_entries = [
+            _json.loads(line)
+            for line in log_path.read_text(encoding="utf-8").strip().split("\n")
+            if "val_loss" in _json.loads(line)
+        ]
+        assert eval_entries, "No eval entries found"
+        for entry in eval_entries:
+            assert "best_step" in entry
+            assert "best_val_loss" in entry
+            assert "patience_counter" in entry
+            assert "early_stopped" in entry
+
+    def test_train_log_has_no_eval_only_fields(self, tmp_path: Path) -> None:
+        """train (log_every_steps) entries must not carry eval-only fields."""
+        import json as _json
+
+        cfg = _tiny_train_cfg(
+            tmp_path,
+            max_steps=5,
+            eval_every_steps=100,  # disable eval
+            log_every_steps=1,
+            save_every_steps=100,
+        )
+        train(cfg, checkpoint_dir=tmp_path / "ckpt", log_dir=tmp_path / "logs")
+        log_path = tmp_path / "logs" / "train_log.jsonl"
+        assert log_path.exists()
+        for line in log_path.read_text(encoding="utf-8").strip().split("\n"):
+            entry = _json.loads(line)
+            # No eval entry should be here (val_loss never written)
+            assert "val_loss" not in entry
+            assert "best_step" not in entry
+            assert "best_val_loss" not in entry
+            assert "patience_counter" not in entry
+            assert "early_stopped" not in entry
+
+    def test_eval_log_always_has_val_loss(self, tmp_path: Path, monkeypatch) -> None:
+        """Every eval entry must include val_loss (schema invariant)."""
+        import json as _json
+
+        _patch_evaluate_with_series(monkeypatch, [2.0, 1.5, 1.0, 0.8, 0.6])
+        cfg = _tiny_train_cfg(
+            tmp_path,
+            max_steps=5,
+            eval_every_steps=1,
+            log_every_steps=100,
+            save_every_steps=100,
+        )
+        train(cfg, checkpoint_dir=tmp_path / "ckpt", log_dir=tmp_path / "logs")
+        log_path = tmp_path / "logs" / "train_log.jsonl"
+        assert log_path.exists()
+        lines = log_path.read_text(encoding="utf-8").strip().split("\n")
+        # Find entries that look like eval (have best/best_step/etc) and confirm val_loss
+        found_eval = False
+        for line in lines:
+            entry = _json.loads(line)
+            if "best" in entry or "best_step" in entry or "patience_counter" in entry:
+                assert "val_loss" in entry
+                found_eval = True
+        assert found_eval

--- a/photon_mlx/trainer.py
+++ b/photon_mlx/trainer.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import json
+import logging
+import os
+import shutil
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 from pathlib import Path
 from typing import Any
 
@@ -19,13 +22,22 @@ from .model import PhotonModel
 import sys
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
-from torch_ref.config import PhotonConfig, TrainingConfig, load_photon_config  # noqa: E402
+from torch_ref.config import (  # noqa: E402
+    EarlyStoppingConfig,
+    PhotonConfig,
+    TrainingConfig,
+    load_photon_config,
+)
+
+_logger = logging.getLogger(__name__)
 
 
 @dataclass
 class TrainState:
     step: int = 0
     best_val_loss: float = float("inf")
+    best_step: int = 0
+    patience_counter: int = 0
     train_losses: list[float] = field(default_factory=list)
     val_losses: list[float] = field(default_factory=list)
 
@@ -40,18 +52,24 @@ def save_checkpoint(
     # Save model weights
     weights = dict(model.parameters())
     mx.savez(str(path / "weights.npz"), **_flatten(weights))
-    # Save state
-    (path / "state.json").write_text(
+    # Save state atomically: tmp file + os.replace so a crash mid-write
+    # doesn't leave a partial state.json behind.
+    state_path = path / "state.json"
+    tmp_path = path / "state.json.tmp"
+    tmp_path.write_text(
         json.dumps(
             {
                 "step": state.step,
                 "best_val_loss": state.best_val_loss,
+                "best_step": state.best_step,
+                "patience_counter": state.patience_counter,
                 "train_losses": state.train_losses[-100:],
                 "val_losses": state.val_losses[-100:],
             }
         ),
         encoding="utf-8",
     )
+    os.replace(tmp_path, state_path)
 
 
 def load_checkpoint(
@@ -62,7 +80,49 @@ def load_checkpoint(
     weights = mx.load(str(path / "weights.npz"))
     model.load_weights(list(weights.items()))
     state_data = json.loads((path / "state.json").read_text(encoding="utf-8"))
-    return TrainState(**state_data)
+    if not isinstance(state_data, dict):
+        raise ValueError(
+            f"state.json must decode to a dict, got {type(state_data).__name__}"
+        )
+    # Filter to known TrainState fields (forward compat: future schema
+    # additions or hand-edited keys won't crash an older trainer).
+    known = {f.name for f in fields(TrainState)}
+    unknown = set(state_data) - known
+    if unknown:
+        _logger.warning("Ignoring unknown state.json keys: %s", sorted(unknown))
+    filtered = {k: v for k, v in state_data.items() if k in known}
+    return TrainState(**filtered)
+
+
+def _save_named_checkpoint(
+    model: PhotonModel,
+    state: TrainState,
+    checkpoint_dir: Path,
+    name: str,
+    *,
+    verbose: bool = True,
+) -> Path:
+    """Save a checkpoint under checkpoint_dir/name.
+
+    For name == "best", write to best.tmp/ first and then os.replace the
+    directory, so an interrupted save can never leave a partially-written
+    best/ around. Other names are written in-place (consistent with
+    historical behavior for step_XXXXXX/ and final/).
+    """
+    target = Path(checkpoint_dir) / name
+    if name == "best":
+        tmp = Path(checkpoint_dir) / "best.tmp"
+        if tmp.exists():
+            shutil.rmtree(tmp)
+        save_checkpoint(model, state, tmp)
+        if target.exists():
+            shutil.rmtree(target)
+        os.replace(tmp, target)
+    else:
+        save_checkpoint(model, state, target)
+    if verbose:
+        print(f"  [ckpt] saved -> {target}")
+    return target
 
 
 def load_model(
@@ -138,6 +198,58 @@ def evaluate(
     return total_loss / max(len(val_batches), 1)
 
 
+def _update_early_stopping(
+    state: TrainState,
+    val_loss: float,
+    es_cfg: EarlyStoppingConfig,
+) -> tuple[bool, bool]:
+    """Update state for the given val_loss and return (improved, should_stop).
+
+    Pure helper – no I/O – so unit tests can drive patience logic directly.
+    """
+    improved = val_loss < state.best_val_loss - es_cfg.min_delta
+    if improved:
+        state.best_val_loss = val_loss
+        state.best_step = state.step
+        state.patience_counter = 0
+    else:
+        state.patience_counter += 1
+    should_stop = bool(es_cfg.enabled) and state.patience_counter >= es_cfg.patience
+    return improved, should_stop
+
+
+def _write_train_log(log_path: Path, entry: dict) -> None:
+    """Append a train-only log record.
+
+    Invariant: train entries never contain eval-only keys (val_loss,
+    best, best_step, best_val_loss, patience_counter, early_stopped,
+    early_stop_reason).
+    """
+    eval_only = {
+        "val_loss",
+        "best",
+        "best_step",
+        "best_val_loss",
+        "patience_counter",
+        "early_stopped",
+        "early_stop_reason",
+    }
+    clean = {k: v for k, v in entry.items() if k not in eval_only}
+    with log_path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(clean, ensure_ascii=False) + "\n")
+
+
+def _write_eval_log(log_path: Path, entry: dict) -> None:
+    """Append an eval-only log record.
+
+    Invariant: eval entries must always include val_loss.
+    """
+    if "val_loss" not in entry:
+        raise ValueError("eval log entry must include val_loss")
+    with log_path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
 def train(
     cfg: PhotonConfig,
     checkpoint_dir: str | Path,
@@ -149,6 +261,7 @@ def train(
 
     # Training config (use defaults if not provided)
     t_cfg = cfg.training if cfg.training is not None else TrainingConfig()
+    es_cfg = t_cfg.early_stopping
 
     # Build model
     model = PhotonModel(cfg)
@@ -221,6 +334,7 @@ def train(
     batch_idx = 0
     accumulated_grads = None
     micro_step = 0
+    early_stopped = False
 
     while state.step < max_steps:
         batch = train_batches[batch_idx % len(train_batches)]
@@ -274,32 +388,44 @@ def train(
                 "elapsed_s": round(elapsed, 1),
             }
             log_entry.update(breakdown)
-            with log_path.open("a", encoding="utf-8") as f:
-                f.write(json.dumps(log_entry) + "\n")
+            _write_train_log(log_path, log_entry)
 
         # Eval
         if state.step % eval_every == 0:
             val_loss = evaluate(model, val_batches, rec_w)
             state.val_losses.append(val_loss)
-            improved = val_loss < state.best_val_loss
-            if improved:
-                state.best_val_loss = val_loss
+            improved, should_stop = _update_early_stopping(state, val_loss, es_cfg)
             print(
                 f"  [eval] step {state.step}  val_loss {val_loss:.4f}"
                 f"  best {state.best_val_loss:.4f}"
                 f"{'  *' if improved else ''}"
             )
-            with log_path.open("a", encoding="utf-8") as f:
-                f.write(
-                    json.dumps(
-                        {
-                            "step": state.step,
-                            "val_loss": val_loss,
-                            "best": improved,
-                        }
-                    )
-                    + "\n"
+            eval_entry = {
+                "step": state.step,
+                "val_loss": val_loss,
+                "best": improved,
+                "best_step": state.best_step,
+                "best_val_loss": state.best_val_loss,
+                "patience_counter": state.patience_counter,
+                "early_stopped": should_stop,
+            }
+            if should_stop:
+                eval_entry["early_stop_reason"] = "patience_exhausted"
+            _write_eval_log(log_path, eval_entry)
+
+            # Save best/ on improvement (only when early stopping is enabled;
+            # keeps disabled path 100% backward compatible with existing tests
+            # and on-disk layouts).
+            if es_cfg.enabled and improved:
+                _save_named_checkpoint(model, state, checkpoint_dir, "best")
+
+            if should_stop:
+                early_stopped = True
+                print(
+                    f"  [early stop] patience exhausted at step {state.step} "
+                    f"(best_step={state.best_step}, best_val_loss={state.best_val_loss:.4f})"
                 )
+                break
 
         # Checkpoint
         if state.step % save_every == 0:
@@ -307,9 +433,41 @@ def train(
             save_checkpoint(model, state, ckpt_path)
             print(f"  [ckpt] saved -> {ckpt_path}")
 
-    # Final checkpoint
+    # Final checkpoint: when early stopping is enabled with restore_best,
+    # reload best/ into the live model so final/ == best. Otherwise write
+    # the stop-time weights.
+    best_dir = checkpoint_dir / "best"
+    if es_cfg.enabled and es_cfg.restore_best and best_dir.exists():
+        try:
+            restored = load_checkpoint(model, best_dir)
+            state = restored
+            print(f"  [restore_best] loaded best/ at step {state.best_step}")
+        except (
+            FileNotFoundError,
+            json.JSONDecodeError,
+            OSError,
+            ValueError,
+            TypeError,
+        ) as exc:
+            _logger.warning("best/ restore failed: %s; keeping stop-time weights", exc)
+            # Emit a trailing eval-style entry so downstream log readers can
+            # surface the fallback reason.
+            _write_eval_log(
+                log_path,
+                {
+                    "step": state.step,
+                    "val_loss": state.best_val_loss,
+                    "best": False,
+                    "best_step": state.best_step,
+                    "best_val_loss": state.best_val_loss,
+                    "patience_counter": state.patience_counter,
+                    "early_stopped": early_stopped,
+                    "early_stop_reason": "best_restore_failed",
+                },
+            )
     save_checkpoint(model, state, checkpoint_dir / "final")
-    print(f"\nTraining complete. Final loss: {state.train_losses[-1]:.4f}")
+    final_loss = state.train_losses[-1] if state.train_losses else float("nan")
+    print(f"\nTraining complete. Final loss: {final_loss:.4f}")
     return state
 
 

--- a/scripts/build_indexes.py
+++ b/scripts/build_indexes.py
@@ -23,7 +23,9 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Build lexical and embedding indexes")
     parser.add_argument("--repo-id", required=True)
     parser.add_argument("--config", default="configs/baseline.yaml")
-    parser.add_argument("--commit", default=None, help="Override repo_commit from config")
+    parser.add_argument(
+        "--commit", default=None, help="Override repo_commit from config"
+    )
     parser.add_argument(
         "--embedding-model",
         default=None,

--- a/scripts/build_symbol_graph.py
+++ b/scripts/build_symbol_graph.py
@@ -22,7 +22,9 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Build the symbol graph")
     parser.add_argument("--repo-id", required=True)
     parser.add_argument("--config", default="configs/baseline.yaml")
-    parser.add_argument("--commit", default=None, help="Override repo_commit from config")
+    parser.add_argument(
+        "--commit", default=None, help="Override repo_commit from config"
+    )
     args = parser.parse_args()
 
     cfg = load_config(args.config)

--- a/scripts/generate_photon.py
+++ b/scripts/generate_photon.py
@@ -1,10 +1,19 @@
 """
 generate_photon.py  –  Greedy decode from a trained PHOTON checkpoint.
 
-Usage:
+Usage (manual CLI training – final/ is the stop-time weights unless
+restore_best=true):
     python scripts/generate_photon.py \
         --config configs/photon_tiny.yaml \
-        --checkpoint checkpoints/photon_tiny/step_005000 \
+        --checkpoint checkpoints/final \
+        --prompt "def get_current_user(" \
+        --max-new-tokens 96
+
+Usage (Streamlit-app-launched run – per-run namespace; best/ exists only
+when early_stopping is enabled, otherwise point at final/):
+    python scripts/generate_photon.py \
+        --config configs/photon_<repo_id>.yaml \
+        --checkpoint checkpoints/<repo_id>/<job_id>/best \
         --prompt "def get_current_user(" \
         --max-new-tokens 96
 """

--- a/scripts/train_photon.py
+++ b/scripts/train_photon.py
@@ -1,28 +1,90 @@
 """
 train_photon.py  –  Train a PHOTON model.
 
-Usage:
+Usage (manual CLI – uses YAML paths: section as default):
     python scripts/train_photon.py --config configs/photon_tiny.yaml
+
+Usage (Streamlit app / run-namespaced run):
+    python -u -m scripts.train_photon \\
+        --config configs/photon_fastapi.yaml \\
+        --checkpoint-dir checkpoints/fastapi/train_20260420_101500 \\
+        --log-dir logs/train_20260420_101500
+
+Environment variable fallbacks (used only when --checkpoint-dir / --log-dir
+are omitted):
+    PHOTON_CHECKPOINT_DIR
+    PHOTON_LOG_DIR
+
+If neither CLI nor env vars are supplied, the script falls back to the YAML
+`paths.checkpoint_root` / `paths.log_root` values (original behavior).
 """
 
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from torch_ref.config import load_photon_config
-from photon_mlx.trainer import train
+from torch_ref.config import load_photon_config  # noqa: E402
+from photon_mlx.trainer import train  # noqa: E402
 
-import yaml
+import yaml  # noqa: E402
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+CHECKPOINT_ROOT = (PROJECT_ROOT / "checkpoints").resolve()
+LOG_ROOT = (PROJECT_ROOT / "logs").resolve()
+
+
+def _normalize_under(root: Path, raw: str | os.PathLike) -> Path:
+    """Normalize ``raw`` and ensure it resolves under ``root``.
+
+    Rejects ``..`` escapes and absolute paths that land outside ``root``.
+    Relative paths are resolved against the project root.
+    """
+    p = Path(raw)
+    if not p.is_absolute():
+        p = (PROJECT_ROOT / p).resolve(strict=False)
+    else:
+        p = p.resolve(strict=False)
+    try:
+        p.relative_to(root)
+    except ValueError as exc:
+        raise ValueError(f"Path {p} is outside the allowed root {root}") from exc
+    return p
+
+
+def _resolve_dir(
+    *,
+    cli_value: str | None,
+    env_var: str,
+    yaml_fallback: str,
+    allowed_root: Path,
+) -> Path:
+    """Resolve a directory from CLI > env > YAML, under ``allowed_root``."""
+    raw = cli_value or os.environ.get(env_var) or yaml_fallback
+    return _normalize_under(allowed_root, raw)
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Train a PHOTON model")
     parser.add_argument("--config", required=True)
     parser.add_argument("--resume", default="")
+    parser.add_argument(
+        "--checkpoint-dir",
+        default=None,
+        help="Override checkpoint root (falls back to PHOTON_CHECKPOINT_DIR "
+        "env var then YAML paths.checkpoint_root).",
+    )
+    parser.add_argument(
+        "--log-dir",
+        default=None,
+        help="Override log root (falls back to PHOTON_LOG_DIR env var then "
+        "YAML paths.log_root).",
+    )
     args = parser.parse_args()
 
     cfg = load_photon_config(args.config)
@@ -30,11 +92,24 @@ def main() -> None:
     with open(args.config, encoding="utf-8") as f:
         raw = yaml.safe_load(f)
 
-    paths = raw.get("paths", {})
+    paths = raw.get("paths", {}) or {}
+    checkpoint_dir = _resolve_dir(
+        cli_value=args.checkpoint_dir,
+        env_var="PHOTON_CHECKPOINT_DIR",
+        yaml_fallback=paths.get("checkpoint_root", "checkpoints"),
+        allowed_root=CHECKPOINT_ROOT,
+    )
+    log_dir = _resolve_dir(
+        cli_value=args.log_dir,
+        env_var="PHOTON_LOG_DIR",
+        yaml_fallback=paths.get("log_root", "logs"),
+        allowed_root=LOG_ROOT,
+    )
+
     train(
         cfg=cfg,
-        checkpoint_dir=paths.get("checkpoint_root", "checkpoints"),
-        log_dir=paths.get("log_root", "logs"),
+        checkpoint_dir=checkpoint_dir,
+        log_dir=log_dir,
         resume_from=args.resume or None,
     )
 

--- a/tests/test_photon_app_helpers.py
+++ b/tests/test_photon_app_helpers.py
@@ -1,0 +1,137 @@
+"""Unit tests for pure helpers in app/photon_app.py.
+
+These tests avoid importing Streamlit by importing the module via its file
+path and relying only on the helper functions that do not touch ``st``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).parent.parent
+PHOTON_APP_PATH = PROJECT_ROOT / "app" / "photon_app.py"
+
+
+def _load_photon_app_module():
+    module_name = "photon_app_under_test"
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+    spec = importlib.util.spec_from_file_location(module_name, PHOTON_APP_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    # Register in sys.modules BEFORE exec so dataclass introspection works.
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+photon_app = _load_photon_app_module()
+
+
+# ---------------------------------------------------------------
+# CB-002: checkpoint discovery excludes `.tmp` directories
+# ---------------------------------------------------------------
+
+
+class TestDiscoverCheckpoints:
+    def test_discover_excludes_best_tmp(self, tmp_path: Path) -> None:
+        """best.tmp/ (the atomic-save scratch dir) must NOT appear in listings."""
+        # Simulated on-disk layout captured mid atomic replacement.
+        (tmp_path / "repo" / "job" / "best").mkdir(parents=True)
+        (tmp_path / "repo" / "job" / "best" / "weights.npz").write_bytes(b"\x00")
+        (tmp_path / "repo" / "job" / "best.tmp").mkdir(parents=True)
+        (tmp_path / "repo" / "job" / "best.tmp" / "weights.npz").write_bytes(b"\x00")
+
+        entries = photon_app._discover_checkpoints(tmp_path)
+        paths = [e[1] for e in entries]
+        assert any(p.endswith("/best") for p in paths)
+        assert not any(p.endswith("/best.tmp") for p in paths)
+        assert not any("best.tmp" in e[2] for e in entries)
+
+    def test_discover_returns_empty_for_missing_dir(self, tmp_path: Path) -> None:
+        missing = tmp_path / "does_not_exist"
+        assert photon_app._discover_checkpoints(missing) == []
+
+    def test_discover_sorts_best_then_final_then_step(self, tmp_path: Path) -> None:
+        for name in ("step_000100", "final", "best", "step_000050"):
+            (tmp_path / "repo" / "job" / name).mkdir(parents=True)
+            (tmp_path / "repo" / "job" / name / "weights.npz").write_bytes(b"\x00")
+
+        entries = photon_app._discover_checkpoints(tmp_path)
+        priorities = [e[0] for e in entries]
+        # Sorted ascending by priority: best(0), final(1), step(2), step(2)
+        assert priorities == sorted(priorities)
+        assert entries[0][1].endswith("/best")
+        assert entries[1][1].endswith("/final")
+
+
+# ---------------------------------------------------------------
+# CB-001: page_index no longer uses shell=True, and _safe_id rejects injection
+# ---------------------------------------------------------------
+
+
+class TestSafeId:
+    def test_safe_id_accepts_allowlist(self) -> None:
+        assert photon_app._safe_id("my_repo_01", label="repo_id") == "my_repo_01"
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "foo; rm -rf /",
+            "foo|bar",
+            "foo && bar",
+            "../etc/passwd",
+            "foo/bar",
+            "foo\\bar",
+            "foo bar",  # space
+            "foo$bar",
+            "",
+        ],
+    )
+    def test_safe_id_rejects_metacharacters(self, bad: str) -> None:
+        with pytest.raises(ValueError):
+            photon_app._safe_id(bad, label="repo_id")
+
+
+class TestPageIndexNoShellTrue:
+    """Guardrail: no `shell=True` should remain in photon_app.py.
+
+    This is a smoke-style regression test rather than a full UI test, since
+    the goal is to prevent future regressions that reintroduce shell=True in
+    ANY subprocess spawn inside the app module.
+    """
+
+    def test_source_has_no_shell_true(self) -> None:
+        src = PHOTON_APP_PATH.read_text(encoding="utf-8")
+        # Strip single-line Python comments so a comment-level mention of
+        # shell=True wouldn't fail the guardrail. Adequate for this file's
+        # coding style (no multi-line strings contain the literal).
+        code_lines = [
+            line for line in src.splitlines() if not line.lstrip().startswith("#")
+        ]
+        # Strip the module docstring too (a triple-quoted block at the top)
+        # to keep the check focused on actual executable code.
+        joined = "\n".join(code_lines)
+        # Quick and simple: remove the first triple-double-quoted block if
+        # it starts at the very beginning of the file.
+        if joined.startswith('"""'):
+            end = joined.find('"""', 3)
+            if end >= 0:
+                joined = joined[end + 3 :]
+        assert "shell=True" not in joined, (
+            "shell=True must not appear in app/photon_app.py — use argv list + shell=False"
+        )
+
+
+class TestSubprocessImportAvailable:
+    """Smoke: photon_app imports ``subprocess`` so argv-list spawns work."""
+
+    def test_subprocess_module_referenced(self) -> None:
+        assert subprocess.Popen  # sanity
+        src = PHOTON_APP_PATH.read_text(encoding="utf-8")
+        assert "import subprocess" in src

--- a/torch_ref/config.py
+++ b/torch_ref/config.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import logging
+import math
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 import yaml
+
+_logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -46,6 +50,58 @@ class TokenizerConfig:
 
 
 @dataclass
+class EarlyStoppingConfig:
+    """Early stopping configuration (opt-in; Issue #60).
+
+    Fields:
+      - enabled: master on/off switch. Default False for backward compat.
+      - patience: number of eval rounds without improvement before stopping.
+      - min_delta: minimum decrease in val_loss to count as improvement.
+      - restore_best: when True, the final/ checkpoint at end of train() is
+                      populated from the best checkpoint rather than from the
+                      stop-time weights.
+    """
+
+    enabled: bool = False
+    patience: int = 3
+    min_delta: float = 0.0
+    restore_best: bool = True
+
+    def __post_init__(self) -> None:  # pragma: no cover - trivial validation
+        if not isinstance(self.enabled, bool):
+            raise TypeError(
+                f"EarlyStoppingConfig.enabled must be bool, got {type(self.enabled)}"
+            )
+        if not isinstance(self.restore_best, bool):
+            raise TypeError(
+                "EarlyStoppingConfig.restore_best must be bool, "
+                f"got {type(self.restore_best)}"
+            )
+        if not isinstance(self.patience, int) or isinstance(self.patience, bool):
+            raise TypeError(
+                f"EarlyStoppingConfig.patience must be int, got {type(self.patience)}"
+            )
+        if self.enabled and self.patience < 1:
+            raise ValueError(
+                f"EarlyStoppingConfig.patience must be >= 1 when enabled, "
+                f"got {self.patience}"
+            )
+        if not isinstance(self.min_delta, (int, float)) or isinstance(
+            self.min_delta, bool
+        ):
+            raise TypeError(
+                f"EarlyStoppingConfig.min_delta must be float, "
+                f"got {type(self.min_delta)}"
+            )
+        self.min_delta = float(self.min_delta)
+        if not math.isfinite(self.min_delta) or self.min_delta < 0.0:
+            raise ValueError(
+                f"EarlyStoppingConfig.min_delta must be finite and >= 0.0, "
+                f"got {self.min_delta}"
+            )
+
+
+@dataclass
 class TrainingConfig:
     learning_rate: float = 2e-4
     min_learning_rate: float = 0.0
@@ -61,6 +117,7 @@ class TrainingConfig:
     log_every_steps: int = 20
     train_corpus: str = ""
     val_corpus: str = ""
+    early_stopping: EarlyStoppingConfig = field(default_factory=EarlyStoppingConfig)
 
 
 @dataclass
@@ -86,5 +143,32 @@ def load_photon_config(path: str | Path) -> PhotonConfig:
     _set_fields(cfg.tokenizer, raw.get("tokenizer", {}))
     if "training" in raw:
         cfg.training = TrainingConfig()
-        _set_fields(cfg.training, raw["training"])
+        training_raw = dict(raw["training"] or {})
+        # Nested early_stopping dataclass: pop first so _set_fields doesn't
+        # assign a raw dict to the field (which would break typing).
+        # Explicit kwargs expansion here lets typos surface as TypeError.
+        es_raw = training_raw.pop("early_stopping", None)
+        _set_fields(cfg.training, training_raw)
+        if es_raw is not None:
+            if not isinstance(es_raw, dict):
+                raise TypeError(
+                    "training.early_stopping must be a mapping, "
+                    f"got {type(es_raw).__name__}"
+                )
+            cfg.training.early_stopping = EarlyStoppingConfig(**es_raw)
+        # Soft check: warn when patience * eval_every_steps would prevent any
+        # stop from ever firing within max_steps.
+        es = cfg.training.early_stopping
+        if (
+            es.enabled
+            and cfg.training.eval_every_steps > 0
+            and es.patience * cfg.training.eval_every_steps >= cfg.training.max_steps
+        ):
+            _logger.warning(
+                "Early stopping may not trigger within max_steps: "
+                "patience=%d * eval_every_steps=%d >= max_steps=%d",
+                es.patience,
+                cfg.training.eval_every_steps,
+                cfg.training.max_steps,
+            )
     return cfg

--- a/torch_ref/tests/test_model.py
+++ b/torch_ref/tests/test_model.py
@@ -196,6 +196,11 @@ class TestTrainingConfig:
         assert tc.train_corpus == ""
         assert tc.val_corpus == ""
         assert tc.context_length == 2048
+        # Early stopping defaults (opt-in; Issue #60)
+        assert tc.early_stopping.enabled is False
+        assert tc.early_stopping.patience == 3
+        assert tc.early_stopping.min_delta == 0.0
+        assert tc.early_stopping.restore_best is True
 
     def test_photon_config_backward_compat(self) -> None:
         """PhotonConfig without training should still work (Optional[None])."""
@@ -293,3 +298,71 @@ class TestTrainingConfig:
 
         cfg = load_photon_config(str(p))
         assert cfg.training is None
+
+    def test_load_config_with_early_stopping(self, tmp_path) -> None:
+        """YAML nested early_stopping block should be parsed into EarlyStoppingConfig."""
+        import yaml
+        from torch_ref.config import load_photon_config
+
+        cfg_dict = {
+            "model": {
+                "hidden_size": 64,
+                "intermediate_size": 128,
+                "num_attention_heads": 4,
+                "num_key_value_heads": 4,
+                "head_dim": 16,
+                "base_embed_dim": 16,
+            },
+            "hierarchy": {"levels": 2},
+            "tokenizer": {"vocab_size": 256},
+            "training": {
+                "max_steps": 100,
+                "early_stopping": {
+                    "enabled": True,
+                    "patience": 5,
+                    "min_delta": 0.01,
+                    "restore_best": False,
+                },
+            },
+        }
+        p = tmp_path / "cfg.yaml"
+        p.write_text(yaml.dump(cfg_dict), encoding="utf-8")
+
+        cfg = load_photon_config(str(p))
+        assert cfg.training is not None
+        assert cfg.training.early_stopping.enabled is True
+        assert cfg.training.early_stopping.patience == 5
+        assert cfg.training.early_stopping.min_delta == 0.01
+        assert cfg.training.early_stopping.restore_best is False
+
+    def test_load_photon_config_early_stopping_unknown_key_raises(
+        self, tmp_path
+    ) -> None:
+        """Unknown key under training.early_stopping should raise TypeError (typo detection)."""
+        import yaml
+        from torch_ref.config import load_photon_config
+
+        cfg_dict = {
+            "model": {
+                "hidden_size": 64,
+                "intermediate_size": 128,
+                "num_attention_heads": 4,
+                "num_key_value_heads": 4,
+                "head_dim": 16,
+                "base_embed_dim": 16,
+            },
+            "hierarchy": {"levels": 2},
+            "tokenizer": {"vocab_size": 256},
+            "training": {
+                "max_steps": 100,
+                "early_stopping": {
+                    "enabled": True,
+                    "patiance": 5,  # typo
+                },
+            },
+        }
+        p = tmp_path / "cfg.yaml"
+        p.write_text(yaml.dump(cfg_dict), encoding="utf-8")
+
+        with pytest.raises(TypeError):
+            load_photon_config(str(p))


### PR DESCRIPTION
## Summary

Issue #60 を実装。PHOTON学習で val_loss が悪化してもストップしない問題を解消。

## 変更内容

- `torch_ref/config.py`: `EarlyStoppingConfig` (patience / min_delta / restore_best) を追加
- `photon_mlx/trainer.py`: 評価ループに patience カウンタ・early stop 判定・best/ チェックポイント保存・終了時の best 復元を実装
- `configs/photon_{tiny,small,600m_paper}.yaml`: `early_stopping` セクションを追加
- `scripts/train_photon.py`, `scripts/generate_photon.py`: CLI 引数で checkpoint_dir/log_dir を受け取れるよう改修（run 別名前空間）
- `app/photon_app.py`: early stop 状態・best step / val_loss の表示対応
- `photon_mlx/tests/test_training.py`, `tests/test_photon_app_helpers.py`: early stopping の単体テスト追加

## 実装確認

- [x] `ruff check .` - All checks passed
- [x] `ruff format --check .` - 89 files already formatted
- [x] `python -m pytest` - 273 passed, 2 pre-existing failures (unrelated)
- [x] 37/37 受入条件 (AC) 合格

## マージ注意

`app/photon_app.py` が #59 と共通のため、**#59 マージ後に本PR をrebase** が必要になる可能性があります。

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)