### PR TITLE
feat(photon): make context_length configurable up to 65,536 tokens

### DIFF
--- a/baseline_reporag/photon_pipeline.py
+++ b/baseline_reporag/photon_pipeline.py
@@ -166,6 +166,11 @@ def _build_photon_deps(cfg: Config) -> dict[str, Any]:
         TokenizerConfig,
     )
 
+    # Issue #55: wire long-context RoPE fields from baseline cfg so
+    # `photon_long_context.yaml` reaches PhotonModel unchanged.  When the
+    # baseline cfg lacks these keys (e.g. legacy 2048 profiles), we fall
+    # back to ModelConfig defaults via ``rope_scaling_from``.
+    scaling, factor = ModelConfig.rope_scaling_from(cfg.model)
     model_cfg = ModelConfig(
         architecture=cfg.model.get("architecture", "photon_decoder"),
         base_embed_dim=cfg.model.base_embed_dim,
@@ -173,6 +178,11 @@ def _build_photon_deps(cfg: Config) -> dict[str, Any]:
         intermediate_size=cfg.model.intermediate_size,
         num_attention_heads=cfg.model.get("num_heads", 4),
         num_key_value_heads=cfg.model.get("num_heads", 4),
+        head_dim=getattr(cfg.model, "head_dim", 64),
+        max_position_embeddings=getattr(cfg.model, "max_position_embeddings", 2048),
+        rope_theta=getattr(cfg.model, "rope_theta", 1_000_000.0),
+        rope_scaling=scaling,
+        rope_scale_factor=factor,
     )
     hierarchy_cfg = HierarchyConfig(
         levels=cfg.hierarchy.levels,

--- a/baseline_reporag/tests/test_photon_pipeline.py
+++ b/baseline_reporag/tests/test_photon_pipeline.py
@@ -1552,3 +1552,84 @@ class TestPruneEvidenceFailureFailsClosed:
             "(fail-closed, CB-002); returning a ranked prefix of the input "
             "list is a bug."
         )
+
+
+# ---------------------------------------------------------------------------
+# Issue #55: RoPE scaling propagates through _build_photon_deps
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPhotonDepsWiresRopeScaling:
+    """_build_photon_deps must wire rope_scaling / rope_scale_factor from the
+    baseline config into the ModelConfig passed to PhotonModel (Issue #55).
+    """
+
+    def test_build_deps_wires_rope_scaling(self, tmp_path):
+        """When baseline YAML specifies rope_scaling='ntk', the constructed
+        ModelConfig.rope_scaling must equal 'ntk'."""
+        from baseline_reporag.config import load_config
+        from baseline_reporag.photon_pipeline import _build_photon_deps
+
+        cfg_file = tmp_path / "photon_long.yaml"
+        cfg_file.write_text(
+            "model:\n"
+            "  provider: photon\n"
+            "  architecture: photon_decoder\n"
+            "  base_embed_dim: 64\n"
+            "  hidden_size: 128\n"
+            "  intermediate_size: 256\n"
+            "  num_heads: 4\n"
+            "  vocab_size: 1000\n"
+            "  head_dim: 32\n"
+            "  max_position_embeddings: 8192\n"
+            "  rope_theta: 10000000.0\n"
+            "  rope_scaling: ntk\n"
+            "  rope_scale_factor: 4.0\n"
+            "hierarchy:\n"
+            "  levels: 2\n"
+            "  chunk_sizes: [4, 4]\n"
+            "  encoder_layers_per_level: [2, 2]\n"
+            "  decoder_layers_per_level: [2, 2]\n"
+            "inference:\n"
+            "  hierarchical_prefill: true\n"
+            "  safe_recgen_enabled: false\n"
+        )
+        cfg = load_config(str(cfg_file))
+        deps = _build_photon_deps(cfg)
+        photon_cfg = deps["photon_cfg"]
+        assert photon_cfg.model.rope_scaling == "ntk"
+        assert photon_cfg.model.rope_scale_factor == 4.0
+        assert photon_cfg.model.max_position_embeddings == 8192
+        assert photon_cfg.model.rope_theta == 10000000.0
+
+    def test_build_deps_defaults_when_rope_scaling_missing(self, tmp_path):
+        """Without rope_scaling in YAML, ModelConfig must fall back to 'none'."""
+        from baseline_reporag.config import load_config
+        from baseline_reporag.photon_pipeline import _build_photon_deps
+
+        cfg_file = tmp_path / "photon_vanilla.yaml"
+        cfg_file.write_text(
+            "model:\n"
+            "  provider: photon\n"
+            "  architecture: photon_decoder\n"
+            "  base_embed_dim: 64\n"
+            "  hidden_size: 128\n"
+            "  intermediate_size: 256\n"
+            "  num_heads: 4\n"
+            "  vocab_size: 1000\n"
+            "hierarchy:\n"
+            "  levels: 2\n"
+            "  chunk_sizes: [4, 4]\n"
+            "  encoder_layers_per_level: [2, 2]\n"
+            "  decoder_layers_per_level: [2, 2]\n"
+            "inference:\n"
+            "  hierarchical_prefill: true\n"
+            "  safe_recgen_enabled: false\n"
+        )
+        cfg = load_config(str(cfg_file))
+        deps = _build_photon_deps(cfg)
+        photon_cfg = deps["photon_cfg"]
+        # Legacy fallback: ModelConfig defaults apply.
+        assert photon_cfg.model.rope_scaling == "none"
+        assert photon_cfg.model.rope_scale_factor == 1.0
+        assert photon_cfg.model.max_position_embeddings == 2048

--- a/bench/reports/kv_cache_speedup_20260421_041655.json
+++ b/bench/reports/kv_cache_speedup_20260421_041655.json
@@ -1,0 +1,55 @@
+{
+  "config": "/Users/maenokota/share/work/github_kewton/photon-mlx-feature-issue-55-context-length-65k/configs/photon_long_context.yaml",
+  "prompt_len": 1024,
+  "max_new_tokens": 4,
+  "n_runs": 1,
+  "cached": {
+    "avg_sec": 0.216,
+    "per_token_ms": 54.012,
+    "tokens_per_sec": 18.51,
+    "peak_mb": 2940.89,
+    "runs_sec": [
+      0.216
+    ],
+    "phases": {
+      "prefill": {
+        "count": 1,
+        "mean_ms": 50.6598,
+        "p50_ms": 50.6598,
+        "p95_ms": 50.6598,
+        "total_ms": 50.6598
+      },
+      "encoder_replay": {
+        "count": 3,
+        "mean_ms": 4.9584,
+        "p50_ms": 4.9734,
+        "p95_ms": 4.9843,
+        "total_ms": 14.8751
+      },
+      "top_level_increment": {
+        "count": 3,
+        "mean_ms": 24.0389,
+        "p50_ms": 20.0423,
+        "p95_ms": 32.1101,
+        "total_ms": 72.1168
+      },
+      "local_tail_decode": {
+        "count": 3,
+        "mean_ms": 25.5911,
+        "p50_ms": 25.5553,
+        "p95_ms": 25.7892,
+        "total_ms": 76.7732
+      }
+    }
+  },
+  "nocache": {
+    "avg_sec": 0.2016,
+    "per_token_ms": 50.409,
+    "tokens_per_sec": 19.84,
+    "peak_mb": 3162.43,
+    "runs_sec": [
+      0.2016
+    ]
+  },
+  "speedup_x": 0.93
+}

--- a/bench/reports/kv_cache_speedup_20260421_041723.json
+++ b/bench/reports/kv_cache_speedup_20260421_041723.json
@@ -1,0 +1,55 @@
+{
+  "config": "/Users/maenokota/share/work/github_kewton/photon-mlx-feature-issue-55-context-length-65k/configs/photon_long_context.yaml",
+  "prompt_len": 16384,
+  "max_new_tokens": 8,
+  "n_runs": 1,
+  "cached": {
+    "avg_sec": 6.9233,
+    "per_token_ms": 865.412,
+    "tokens_per_sec": 1.16,
+    "peak_mb": 20773.74,
+    "runs_sec": [
+      6.9233
+    ],
+    "phases": {
+      "prefill": {
+        "count": 1,
+        "mean_ms": 862.5497,
+        "p50_ms": 862.5497,
+        "p95_ms": 862.5497,
+        "total_ms": 862.5497
+      },
+      "encoder_replay": {
+        "count": 7,
+        "mean_ms": 77.5688,
+        "p50_ms": 76.717,
+        "p95_ms": 82.8421,
+        "total_ms": 542.9813
+      },
+      "top_level_increment": {
+        "count": 7,
+        "mean_ms": 431.5518,
+        "p50_ms": 427.6836,
+        "p95_ms": 506.107,
+        "total_ms": 3020.8624
+      },
+      "local_tail_decode": {
+        "count": 7,
+        "mean_ms": 356.1311,
+        "p50_ms": 354.8771,
+        "p95_ms": 366.1183,
+        "total_ms": 2492.9175
+      }
+    }
+  },
+  "nocache": {
+    "avg_sec": 6.1589,
+    "per_token_ms": 769.865,
+    "tokens_per_sec": 1.3,
+    "peak_mb": 13138.12,
+    "runs_sec": [
+      6.1589
+    ]
+  },
+  "speedup_x": 0.89
+}

--- a/configs/photon_long_context.yaml
+++ b/configs/photon_long_context.yaml
@@ -1,0 +1,254 @@
+version: 1
+
+project:
+  name: "photon-reporag"
+  mode: "photon_long_context"
+
+run:
+  name_prefix: "photon_long_context"
+  seed: 42
+  deterministic: true
+
+paths:
+  data_root: "./data"
+  raw_root: "./data/raw"
+  processed_root: "./data/processed"
+  index_root: "./data/indexes"
+  eval_root: "./data/eval_sets"
+  log_root: "./logs"
+  report_root: "./reports"
+  checkpoint_root: "./checkpoints"
+  cache_root: "./.cache"
+
+runtime:
+  device: "auto"
+  dtype: "float16"
+  num_workers: 8
+  profile_latency: true
+  profile_memory: true
+  compile_decode_step: true
+
+repo:
+  repo_id: "fastapi_fastapi"
+  repo_path: "./data/raw/fastapi"
+  repo_commit: "eba8942c81dbf990d25fbae34e6601bdbc21e74b"
+
+ingestion:
+  chunking:
+    strategy: "code_aware"
+    max_chars: 2400
+    overlap_chars: 300
+    max_lines: 120
+    overlap_lines: 12
+    keep_function_boundary: true
+    keep_class_boundary: true
+    attach_section_headers: true
+    attach_file_header: true
+
+indexing:
+  lexical:
+    enabled: true
+    engine: "bm25"
+
+  embedding:
+    enabled: true
+    provider: "local"
+    model_id: "sentence-transformers/all-MiniLM-L6-v2"
+    batch_size: 64
+    normalize: true
+
+  symbol_graph:
+    enabled: true
+
+retrieval:
+  mode: "hybrid"
+  lexical_top_k: 20
+  embedding_top_k: 20
+  fused_top_k: 16
+  rerank_top_k: 12
+
+  weights:
+    lexical: 0.45
+    embedding: 0.45
+    graph: 0.10
+
+  reranker:
+    enabled: true
+    model_id: "cross-encoder/ms-marco-MiniLM-L-6-v2"
+
+  file_type_boost: 0.0
+
+  query_expansion:
+    enabled: true
+    include_symbol_aliases: true
+    include_filename_hints: true
+
+  neighborhood_expansion:
+    enabled: true
+    before: 1
+    after: 1
+
+  graph_expansion:
+    enabled: true
+    max_hops: 1
+    max_nodes: 24
+
+evidence_pack:
+  max_chunks: 16
+  max_tokens: 16000
+  include_neighbors: true
+  include_section_headers: true
+
+  local_refresh:
+    enabled: true
+    top_k: 4
+    refresh_before_answer: true
+    refresh_on_exact_quote: true
+    refresh_on_diff_or_patch: true
+
+session_memory:
+  mode: "photon"
+  max_turns: 8
+  summary_max_tokens: 800
+  pin_recent_chunks_max: 8
+  pin_cited_chunks_max: 12
+  track_topic_state: true
+
+tokenizer:
+  tokenizer_id: "mlx-community/Qwen2.5-Coder-14B-Instruct-4bit"
+  vocab_size: 152064
+
+# Issue #55: all model fields live under `model:` (unlike photon_small.yaml
+# which has a known schema bug with model fields placed under `generation:`).
+# This lets NTK-aware RoPE scaling fields reach ModelConfig correctly.
+model:
+  architecture: "photon_decoder"
+
+  provider: "photon"
+  model_id: "mlx-community/Qwen2.5-Coder-14B-Instruct-4bit"
+
+  base_embed_dim: 256
+  hidden_size: 1024
+  intermediate_size: 2816
+
+  num_attention_heads: 16
+  num_key_value_heads: 16
+  head_dim: 64
+
+  # Long-context extensions (Issue #55)
+  max_position_embeddings: 65536
+  rope_theta: 10000000.0
+  rope_scaling: ntk
+  rope_scale_factor: 32.0
+
+  norm_eps: 0.00001
+  tie_word_embeddings: false
+  dropout: 0.0
+  bias: false
+
+generation:
+  max_new_tokens: 768
+  temperature: 0.2
+  top_p: 0.9
+  repetition_penalty: 1.05
+  do_sample: false
+
+hierarchy:
+  levels: 2
+
+  chunk_sizes: [4, 4]
+  converter_prefix_lengths: [2, 2]
+
+  chunker:
+    level1_type: "concat"
+    upper_type: "linear"
+
+  encoder_layers_per_level: [3, 3]
+  decoder_layers_per_level: [3, 3]
+
+  context_encoder_arch: "llama_decoder_style"
+  context_decoder_arch: "llama_decoder_style"
+  context_converter_type: "conv1d"
+
+  recursive_loss_weight: 0.0
+  bottleneck_consistency_target: "top_level"
+
+training:
+  enabled: true
+  stage: "long_context"
+
+  train_corpus: "./data/processed/train_multi.jsonl"
+  val_corpus: "./data/processed/val_multi.jsonl"
+
+  # Issue #55 v1: inference-only long context. Training remains at 32768
+  # (<= max_position_embeddings, multiple of prod(chunk_sizes)=16).
+  context_length: 32768
+  micro_batch_size: 1
+  gradient_accumulation_steps: 32
+
+  learning_rate: 0.00015
+  min_learning_rate: 0.000015
+  warmup_ratio: 0.03
+  weight_decay: 0.1
+  max_grad_norm: 1.0
+
+  max_steps: 2000
+  eval_every_steps: 100
+  save_every_steps: 100
+  log_every_steps: 20
+
+  early_stopping:
+    enabled: true
+    patience: 3
+    min_delta: 0.001
+    restore_best: true
+
+inference:
+  hierarchical_prefill: true
+  recgen_enabled: true
+  safe_recgen_enabled: true
+  evidence_pruning_enabled: true
+  pruned_max_chunks: 8
+
+  answer_max_new_tokens: 768
+  temperature: 0.2
+  top_p: 0.9
+  do_sample: false
+
+safe_recgen:
+  enabled: true
+
+  triggers:
+    exact_quote: true
+    diff_or_patch: true
+    high_risk_query: true
+    topic_shift: true
+    latent_drift: true
+    low_confidence: false
+
+  thresholds:
+    latent_cosine_drift: 0.50
+    topic_shift_score: 0.65
+    confidence_floor: 0.40
+    logit_kl: 0.75
+
+  fallback_actions:
+    re_retrieve: true
+    strengthen_local_refresh: true
+    reprefill_hierarchy: true
+    fallback_to_baseline_path: true
+
+drift_monitoring:
+  enabled: true
+  track_latent_cosine_drift: true
+  track_token_agreement: true
+  track_logit_kl: true
+  save_turn_level_metrics: true
+
+logging:
+  level: "INFO"
+  save_hidden_stats: true
+  save_drift_metrics: true
+  save_latency_breakdown: true
+  save_memory_metrics: true
+  save_fallback_reasons: true

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -117,3 +117,23 @@ top -pid $(pgrep -f baseline_reporag)
 1. **Eval set exists?** Ensure evaluation data is present under `data/eval_sets/`.
 2. **Indexes built?** Run the full indexing pipeline before evaluation.
 3. **Config matches?** Ensure the `--config` flag points to the correct YAML file.
+
+---
+
+## 長コンテキストで RAM 不足 (Issue #55)
+
+**Symptom**: `configs/photon_long_context.yaml` + 長 prompt（16k+ トークン）で OOM または極端に遅い。
+
+**Checklist**:
+
+1. **`use_kv_cache=False` を試す**: 実測では 16,384 prompt 時、KV cache 無効の方が **RAM 約 7 GB 節約** かつ **11% 高速**。top-level KV cache の encoder_replay / top_level_increment / local_tail_decode の累積コストが、nocache prefill を上回るため。`PhotonInference.generate(..., use_kv_cache=False)` もしくは設定で `photon.use_kv_cache: false`（実装に応じて）。
+
+2. **`training.context_length` を段階的に下げる**: 65,536 → 32,768 → 16,384 の順で試す。RoPE テーブル自体は 65,536 固定でも、実際に流す prompt 長を下げれば attention 側のメモリが二次的に減る。
+
+3. **YAML タイポを疑う**: `rope_scale` (typo) は silently 無視されるため warning ログで検出。ログに `unknown config key ignored: rope_scale` が出ていないか確認。正しくは `rope_scaling: ntk`。
+
+4. **`rope_scaling: none` と `rope_scale_factor: 32.0` を併記していないか**: この組み合わせは factor が silently 無視される（WARNING ログが出る）。`rope_scaling: ntk` に修正する。
+
+5. **`torch_ref` 経路で長コンテキスト**: `torch_ref` は 128 位置までしか扱えない。長コンテキストは必ず MLX 経路（`PhotonModel`）で使うこと。`torch_ref/_precompute_rope` で `scaling != "none"` を渡すと `NotImplementedError` が明示的に raise される（silent fallback なし）。
+
+参考: `reports/issue-55-long-context.md`

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -170,6 +170,40 @@ tail -f logs/<job_id>/train_log.jsonl
 
 ---
 
+## 長コンテキスト推論 (Issue #55)
+
+`configs/photon_long_context.yaml` を指定すると、NTK-aware RoPE scaling により 2048 で学習済みのチェックポイントのまま最大 65,536 トークンの入力を受け取れます。**MLX 経路のみ** — `torch_ref` (PyTorch リファレンス) は従来通り 128 位置までしか扱えません（`scaling != "none"` で `NotImplementedError`）。
+
+```yaml
+# configs/photon_long_context.yaml (抜粋)
+model:
+  max_position_embeddings: 65536
+  rope_theta: 10000000.0          # YAML 互換な数値リテラル。`10_000_000.0` は不可
+  rope_scaling: ntk                # v1 は {"none", "ntk"} のみ
+  rope_scale_factor: 32.0          # 2048 → 65536 で 32 倍
+training:
+  context_length: 32768
+```
+
+### ピーク メモリの実測値（ランダム重み、学習済みなしの参考値）
+
+| prompt_len | KV cache あり | KV cache なし | 速度比 (cache / nocache) |
+|---|---|---|---|
+| 1,024 | 2.9 GB | 3.2 GB | 0.93x |
+| 16,384 | **20.8 GB** | **13.1 GB** | **0.89x** |
+
+- 長 prompt では **`use_kv_cache=False` の方が速くメモリも少なく消費**する場合があります（`top_level_increment` と `local_tail_decode` の累積が nocache の prefill を上回るため）
+- 設計見積りより実測が大幅に大きいため、小メモリ環境（~32GB）では `use_kv_cache=False` を推奨
+- 32,768 / 65,536 の実測は学習済みチェックポイントが整った段階で bench 再実行予定
+
+詳細は `reports/issue-55-long-context.md` を参照。
+
+### トラブルシュート
+
+メモリ不足・速度劣化が起きた場合は `docs/troubleshooting.md` の「長コンテキストで RAM 不足」節を参照。
+
+---
+
 ## Step 7: PHOTON-RAG で使う
 
 ### サーバモード

--- a/photon_mlx/blocks.py
+++ b/photon_mlx/blocks.py
@@ -13,14 +13,57 @@ import mlx.nn as nn
 KVCache = tuple[mx.array, mx.array]
 
 
+def _effective_positions_and_theta(
+    dim: int,
+    max_len: int,
+    theta: float,
+    scaling: str,
+    scale_factor: float,
+) -> tuple[mx.array, float]:
+    """Return ``(positions, effective_theta)`` for the requested RoPE scaling.
+
+    - ``scaling="none"``: identity (positions = arange(max_len), theta unchanged).
+    - ``scaling="ntk"``: NTK-aware RoPE — positions unchanged, theta rescaled
+      by ``scale_factor ** (dim / (dim - 2))``.
+
+    Any other ``scaling`` value is treated as ``"none"``; the caller
+    (``ModelConfig.__post_init__``) is responsible for validating the
+    allowed set, so this helper stays permissive.
+    """
+    positions = mx.arange(max_len)
+    if scaling == "ntk":
+        eff_theta = theta * (scale_factor ** (dim / (dim - 2)))
+        return positions, float(eff_theta)
+    return positions, theta
+
+
 def precompute_rope(
     dim: int,
     max_len: int,
     theta: float = 1_000_000.0,
+    *,
+    scaling: str = "none",
+    scale_factor: float = 1.0,
 ) -> tuple[mx.array, mx.array]:
-    """Return (cos, sin) each of shape (max_len, dim // 2)."""
-    freqs = 1.0 / (theta ** (mx.arange(0, dim, 2).astype(mx.float32) / dim))
-    t = mx.arange(max_len).astype(mx.float32)
+    """Return ``(cos, sin)`` each of shape ``(max_len, dim // 2)``.
+
+    Args:
+        dim: head dimension (``head_dim``).
+        max_len: number of positions to precompute.
+        theta: base RoPE frequency (e.g. ``1e6`` for LLaMA-style).
+        scaling: RoPE position-scaling method. ``"none"`` (default) uses
+            vanilla RoPE; ``"ntk"`` rescales ``theta`` per NTK-aware
+            interpolation (Su et al. follow-up).
+        scale_factor: multiplicative scale for ``"ntk"`` (must be >= 1.0).
+            ``scaling="ntk"`` with ``scale_factor=1.0`` is mathematically
+            equivalent to ``scaling="none"`` (the rescaling term
+            ``scale_factor ** (dim / (dim - 2))`` collapses to 1.0).
+    """
+    t, eff_theta = _effective_positions_and_theta(
+        dim, max_len, theta, scaling, scale_factor
+    )
+    freqs = 1.0 / (eff_theta ** (mx.arange(0, dim, 2).astype(mx.float32) / dim))
+    t = t.astype(mx.float32)
     angles = t[:, None] * freqs[None, :]  # (max_len, dim//2)
     return mx.cos(angles), mx.sin(angles)
 

--- a/photon_mlx/model.py
+++ b/photon_mlx/model.py
@@ -31,7 +31,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
-from torch_ref.config import PhotonConfig  # noqa: E402
+from torch_ref.config import ModelConfig, PhotonConfig  # noqa: E402
 
 
 # ================================================================
@@ -152,8 +152,16 @@ class PhotonModel(nn.Module):
 
         # ── Pre-computed RoPE ───────────────────────────────────
         max_local = max(c * (p + 1) for c, p in zip(CS, PL))
+        # Issue #55: top-level RoPE supports NTK-aware scaling for long
+        # contexts. Local RoPE deliberately stays vanilla — max_local is
+        # well within the training range so scaling would only add drift.
+        scaling, factor = ModelConfig.rope_scaling_from(m)
         self._rope_cos, self._rope_sin = precompute_rope(
-            m.head_dim, m.max_position_embeddings, m.rope_theta
+            m.head_dim,
+            m.max_position_embeddings,
+            m.rope_theta,
+            scaling=scaling,
+            scale_factor=factor,
         )
         self._local_cos, self._local_sin = precompute_rope(
             m.head_dim, max_local, m.rope_theta

--- a/photon_mlx/tests/test_blocks.py
+++ b/photon_mlx/tests/test_blocks.py
@@ -1,0 +1,196 @@
+"""Tests for ``photon_mlx.blocks.precompute_rope`` RoPE scaling extensions.
+
+Covers Issue #55 Phase 2:
+
+- ``scaling='none'`` equivalence with the legacy (no-kwarg) call.
+- ``scaling='ntk'`` with ``scale_factor=1.0`` equals ``scaling='none'``.
+- ``scale_factor=32.0`` produces different cos/sin than ``scale_factor=1.0``.
+- YAML→ModelConfig→precompute_rope integration (Phase 2 → Phase 4 bridge).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import mlx.core as mx
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from photon_mlx.blocks import precompute_rope  # noqa: E402
+from torch_ref.config import ModelConfig  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# scaling='none' equivalence
+# ---------------------------------------------------------------------------
+
+
+def test_rope_scaling_none_equivalence() -> None:
+    """``scaling='none', scale_factor=1.0`` must match the legacy signature.
+
+    The legacy call (no scaling kwargs) must produce byte-equal tables to
+    the explicit ``scaling='none', scale_factor=1.0`` call so existing
+    checkpoints keep loading unchanged.
+    """
+    cos_legacy, sin_legacy = precompute_rope(dim=64, max_len=2048, theta=1e6)
+    cos_new, sin_new = precompute_rope(
+        dim=64,
+        max_len=2048,
+        theta=1e6,
+        scaling="none",
+        scale_factor=1.0,
+    )
+    assert mx.array_equal(cos_legacy, cos_new).item()
+    assert mx.array_equal(sin_legacy, sin_new).item()
+
+
+# ---------------------------------------------------------------------------
+# scaling='ntk' + scale_factor=1.0 equivalence with 'none'
+# ---------------------------------------------------------------------------
+
+
+def test_rope_ntk_scale_factor_one_equals_none() -> None:
+    """NTK with ``scale_factor=1.0`` collapses to vanilla RoPE (array-equal).
+
+    ``theta * (1.0 ** (dim / (dim - 2))) == theta``, so the result must be
+    bit-identical to ``scaling='none'``.
+    """
+    cos_none, sin_none = precompute_rope(
+        dim=64,
+        max_len=2048,
+        theta=1e6,
+        scaling="none",
+        scale_factor=1.0,
+    )
+    cos_ntk, sin_ntk = precompute_rope(
+        dim=64,
+        max_len=2048,
+        theta=1e6,
+        scaling="ntk",
+        scale_factor=1.0,
+    )
+    assert mx.array_equal(cos_none, cos_ntk).item()
+    assert mx.array_equal(sin_none, sin_ntk).item()
+
+
+# ---------------------------------------------------------------------------
+# scaling='ntk' + scale_factor=32.0 differs from 1.0
+# ---------------------------------------------------------------------------
+
+
+def test_rope_ntk_scale_factor_32_differs() -> None:
+    """``scale_factor=32`` must produce a different (cos, sin) than ``1.0``.
+
+    Otherwise the NTK path is effectively a no-op.
+    """
+    cos_1, sin_1 = precompute_rope(
+        dim=64,
+        max_len=2048,
+        theta=1e6,
+        scaling="ntk",
+        scale_factor=1.0,
+    )
+    cos_32, sin_32 = precompute_rope(
+        dim=64,
+        max_len=2048,
+        theta=1e6,
+        scaling="ntk",
+        scale_factor=32.0,
+    )
+    assert not mx.array_equal(cos_1, cos_32).item()
+    assert not mx.array_equal(sin_1, sin_32).item()
+
+
+# ---------------------------------------------------------------------------
+# YAML/ModelConfig → precompute_rope propagation integration
+# ---------------------------------------------------------------------------
+
+
+def test_rope_scaling_propagation_integration() -> None:
+    """ModelConfig.rope_scaling_from → precompute_rope must not raise.
+
+    Verifies the round trip from ModelConfig field to precompute_rope
+    kwargs works cleanly (the concrete types and keyword names line up).
+    """
+    cfg_model = ModelConfig(
+        head_dim=64,
+        max_position_embeddings=2048,
+        rope_theta=1e6,
+        rope_scaling="ntk",
+        rope_scale_factor=4.0,
+    )
+    scaling, factor = ModelConfig.rope_scaling_from(cfg_model)
+    cos, sin = precompute_rope(
+        cfg_model.head_dim,
+        cfg_model.max_position_embeddings,
+        cfg_model.rope_theta,
+        scaling=scaling,
+        scale_factor=factor,
+    )
+    assert cos.shape == (2048, 32)
+    assert sin.shape == (2048, 32)
+
+
+# ---------------------------------------------------------------------------
+# Phase 4: local RoPE must NOT apply scaling
+# ---------------------------------------------------------------------------
+
+
+def test_local_rope_scaling_is_none() -> None:
+    """PhotonModel._local_cos/_local_sin must be vanilla RoPE even when the
+    top-level RoPE uses ``rope_scaling='ntk'``.
+
+    The local decoder only covers ``max_local`` positions (well within the
+    training range), so NTK-style extrapolation is unnecessary — and
+    applying it would silently drift the local attention.
+    """
+    from photon_mlx.model import PhotonModel
+    from torch_ref.config import (
+        HierarchyConfig,
+        PhotonConfig,
+        TokenizerConfig,
+    )
+
+    cfg = PhotonConfig(
+        model=ModelConfig(
+            base_embed_dim=16,
+            hidden_size=64,
+            intermediate_size=128,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            head_dim=16,
+            max_position_embeddings=128,
+            rope_theta=1e6,
+            rope_scaling="ntk",
+            rope_scale_factor=32.0,
+        ),
+        hierarchy=HierarchyConfig(
+            levels=2,
+            chunk_sizes=[4, 4],
+            converter_prefix_lengths=[2, 2],
+            encoder_layers_per_level=[1, 1],
+            decoder_layers_per_level=[1, 1],
+        ),
+        tokenizer=TokenizerConfig(vocab_size=256),
+    )
+
+    mx.random.seed(0)
+    model = PhotonModel(cfg)
+
+    # Recompute the expected local RoPE with NO scaling applied.
+    m = cfg.model
+    CS = cfg.hierarchy.chunk_sizes
+    PL = cfg.hierarchy.converter_prefix_lengths
+    max_local = max(c * (p + 1) for c, p in zip(CS, PL))
+    vanilla_cos, vanilla_sin = precompute_rope(m.head_dim, max_local, m.rope_theta)
+
+    assert mx.array_equal(model._local_cos, vanilla_cos).item()
+    assert mx.array_equal(model._local_sin, vanilla_sin).item()
+
+    # Sanity: the TOP-level RoPE *must* differ from vanilla because
+    # scaling='ntk', factor=32 is in effect there.
+    top_vanilla_cos, _ = precompute_rope(
+        m.head_dim, m.max_position_embeddings, m.rope_theta
+    )
+    assert not mx.array_equal(model._rope_cos, top_vanilla_cos).item()

--- a/photon_mlx/tests/test_config.py
+++ b/photon_mlx/tests/test_config.py
@@ -1,0 +1,240 @@
+"""Tests for ``torch_ref.config`` extensions introduced by Issue #55.
+
+Covers:
+
+- ``ModelConfig.__post_init__`` validation of ``rope_scaling`` and
+  ``rope_scale_factor``.
+- ``ModelConfig.rope_scaling_from`` classmethod (MagicMock-compatible).
+- ``_set_fields`` WARNING on unknown YAML keys (DR1-007).
+- ``load_photon_config`` cross-config validation between
+  ``training.context_length``, ``hierarchy.chunk_sizes`` and
+  ``model.max_position_embeddings``.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from torch_ref.config import (  # noqa: E402
+    HierarchyConfig,
+    ModelConfig,
+    TrainingConfig,
+    _set_fields,
+    load_photon_config,
+)
+
+
+# ---------------------------------------------------------------------------
+# ModelConfig.__post_init__ validation
+# ---------------------------------------------------------------------------
+
+
+def test_modelconfig_accepts_rope_scaling_ntk() -> None:
+    """rope_scaling='ntk' with scale_factor>=1 must be accepted."""
+    cfg = ModelConfig(rope_scaling="ntk", rope_scale_factor=32.0)
+    assert cfg.rope_scaling == "ntk"
+    assert cfg.rope_scale_factor == 32.0
+
+
+def test_modelconfig_rejects_invalid_rope_scaling() -> None:
+    """Anything outside ROPE_SCALING_CHOICES must raise ValueError."""
+    with pytest.raises(ValueError, match="invalid rope_scaling"):
+        ModelConfig(rope_scaling="linear")
+
+
+def test_modelconfig_rejects_rope_scale_factor_below_one() -> None:
+    """rope_scale_factor < 1.0 must raise ValueError (NTK is extrapolation)."""
+    with pytest.raises(ValueError, match="rope_scale_factor must be >= 1.0"):
+        ModelConfig(rope_scale_factor=0.5)
+
+
+def test_modelconfig_warns_on_unused_scale_factor(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """rope_scaling='none' + rope_scale_factor != 1.0 must emit WARNING log."""
+    with caplog.at_level(logging.WARNING, logger="torch_ref.config"):
+        ModelConfig(rope_scaling="none", rope_scale_factor=32.0)
+
+    assert any(
+        rec.levelno == logging.WARNING
+        and rec.name == "torch_ref.config"
+        and "ignored because rope_scaling='none'" in rec.getMessage()
+        for rec in caplog.records
+    ), "expected warning about ignored rope_scale_factor"
+
+
+# ---------------------------------------------------------------------------
+# ModelConfig.rope_scaling_from
+# ---------------------------------------------------------------------------
+
+
+def test_rope_scaling_from_handles_magicmock() -> None:
+    """rope_scaling_from must fall back to defaults when attributes missing.
+
+    ``MagicMock()`` returns a new ``MagicMock`` for any unknown attribute
+    access.  ``rope_scaling_from`` uses ``getattr(m, name, default)`` with
+    concrete fallbacks, so when ``m`` is a ``MagicMock`` WITHOUT explicit
+    ``rope_scaling`` / ``rope_scale_factor`` attributes set, it must return
+    the pair ``("none", 1.0)``.
+    """
+    m = MagicMock(spec=["architecture"])  # no rope_scaling / rope_scale_factor
+    scaling, factor = ModelConfig.rope_scaling_from(m)
+    assert scaling == "none"
+    assert factor == 1.0
+
+    # When the attributes ARE set, they must propagate.
+    m2 = MagicMock(spec=["rope_scaling", "rope_scale_factor"])
+    m2.rope_scaling = "ntk"
+    m2.rope_scale_factor = 8.0
+    scaling, factor = ModelConfig.rope_scaling_from(m2)
+    assert scaling == "ntk"
+    assert factor == 8.0
+
+
+# ---------------------------------------------------------------------------
+# _set_fields warning on unknown YAML keys
+# ---------------------------------------------------------------------------
+
+
+def test_set_fields_warns_on_unknown_key(caplog: pytest.LogCaptureFixture) -> None:
+    """Unknown YAML keys must emit a WARNING but not raise (backward compat)."""
+    cfg = ModelConfig()
+    with caplog.at_level(logging.WARNING, logger="torch_ref.config"):
+        _set_fields(cfg, {"rope_scale": "ntk"})  # typo for rope_scaling
+
+    matched = [
+        rec
+        for rec in caplog.records
+        if rec.levelno == logging.WARNING
+        and rec.name == "torch_ref.config"
+        and "unknown config key ignored" in rec.getMessage()
+        and "rope_scale" in rec.getMessage()
+    ]
+    assert matched, (
+        "expected WARNING mentioning 'unknown config key ignored' and the key "
+        f"name 'rope_scale'; got records: {[r.getMessage() for r in caplog.records]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# load_photon_config cross-config validation
+# ---------------------------------------------------------------------------
+
+
+def _write_yaml(tmp_path: Path, body: str) -> Path:
+    p = tmp_path / "config.yaml"
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+def test_load_photon_config_rejects_invalid_context_length(tmp_path: Path) -> None:
+    """context_length not a multiple of prod(chunk_sizes) must raise."""
+    path = _write_yaml(
+        tmp_path,
+        """
+model:
+  max_position_embeddings: 64
+hierarchy:
+  chunk_sizes: [4, 4]
+tokenizer:
+  vocab_size: 256
+training:
+  context_length: 17
+""",
+    )
+    with pytest.raises(ValueError, match="must be a multiple of"):
+        load_photon_config(path)
+
+
+def test_load_photon_config_rejects_context_length_exceeds_max_pos(
+    tmp_path: Path,
+) -> None:
+    """context_length greater than max_position_embeddings must raise."""
+    path = _write_yaml(
+        tmp_path,
+        """
+model:
+  max_position_embeddings: 64
+hierarchy:
+  chunk_sizes: [4, 4]
+tokenizer:
+  vocab_size: 256
+training:
+  context_length: 128
+""",
+    )
+    with pytest.raises(ValueError, match="must be <="):
+        load_photon_config(path)
+
+
+def test_load_photon_config_accepts_valid_context_length(tmp_path: Path) -> None:
+    """Sanity: valid context_length loads without error."""
+    path = _write_yaml(
+        tmp_path,
+        """
+model:
+  max_position_embeddings: 64
+hierarchy:
+  chunk_sizes: [4, 4]
+tokenizer:
+  vocab_size: 256
+training:
+  context_length: 32
+""",
+    )
+    cfg = load_photon_config(path)
+    assert cfg.training is not None
+    assert cfg.training.context_length == 32
+
+
+def test_load_photon_config_no_training_skips_cross_validation(tmp_path: Path) -> None:
+    """Without 'training' block, cross-validation is skipped."""
+    path = _write_yaml(
+        tmp_path,
+        """
+model:
+  max_position_embeddings: 64
+hierarchy:
+  chunk_sizes: [4, 4]
+tokenizer:
+  vocab_size: 256
+""",
+    )
+    cfg = load_photon_config(path)
+    assert cfg.training is None
+
+
+def test_load_photon_config_rejects_invalid_rope_scaling(tmp_path: Path) -> None:
+    """Setting rope_scaling to an invalid value via YAML must raise ValueError."""
+    path = _write_yaml(
+        tmp_path,
+        """
+model:
+  rope_scaling: bogus
+""",
+    )
+    with pytest.raises(ValueError, match="invalid rope_scaling"):
+        load_photon_config(path)
+
+
+# Regression fixture for TrainingConfig instance (indirect check that the
+# cross-config helper works on bare dataclass instances too, not just YAML).
+def test_validate_cross_config_on_bare_dataclasses() -> None:
+    from torch_ref.config import _validate_cross_config
+
+    m = ModelConfig(max_position_embeddings=128)
+    h = HierarchyConfig(chunk_sizes=[4, 4])
+    t = TrainingConfig(context_length=32)
+    # Valid: should not raise.
+    _validate_cross_config(m, h, t)
+
+    t_bad = TrainingConfig(context_length=33)
+    with pytest.raises(ValueError, match="multiple"):
+        _validate_cross_config(m, h, t_bad)

--- a/photon_mlx/tests/test_training.py
+++ b/photon_mlx/tests/test_training.py
@@ -742,3 +742,154 @@ class TestEarlyStopping:
                 assert "val_loss" in entry
                 found_eval = True
         assert found_eval
+
+
+# ---------------------------------------------------------------
+# Issue #55: long-context + NTK RoPE integration tests
+# ---------------------------------------------------------------
+
+
+class TestLongContextConfig:
+    """Sanity tests for configs/photon_long_context.yaml (Issue #55)."""
+
+    def test_long_context_config_loads(self) -> None:
+        """configs/photon_long_context.yaml must load without error.
+
+        Cross-config validation is strict:
+        training.context_length (32768) must be a multiple of
+        prod(chunk_sizes)=16 and <= max_position_embeddings (65536).
+        """
+        from torch_ref.config import load_photon_config
+
+        cfg = load_photon_config("configs/photon_long_context.yaml")
+        assert cfg.model.max_position_embeddings == 65536
+        assert cfg.model.rope_scaling == "ntk"
+        assert cfg.model.rope_scale_factor == 32.0
+        assert cfg.training is not None
+        assert cfg.training.context_length == 32768
+
+
+class TestCrossConfigCheckpointLoad:
+    """Checkpoints trained with a small max_position_embeddings must still
+    load into a PhotonModel configured with a larger max_position_embeddings
+    (Issue #55 backward-compat)."""
+
+    def test_cross_config_checkpoint_load(self, tmp_path: Path) -> None:
+        """Save under tiny config (max_pos=128), load into a larger-context
+        config (max_pos=512) and run generate() without error.
+
+        Note: the plan mentions 65536; we downscale to 512 to keep the
+        PhotonModel instantiation within a reasonable unit-test memory
+        budget (65536 * 65536 causal-mask style buffers would OOM).
+        """
+        mx.random.seed(42)
+        cfg_small = _tiny_cfg()
+        model = PhotonModel(cfg_small)
+        state = TrainState(step=10, best_val_loss=1.0)
+
+        ckpt_dir = tmp_path / "ckpt"
+        save_checkpoint(model, state, ckpt_dir)
+
+        # Larger-context config: still tiny hidden size, but bigger
+        # max_position_embeddings + NTK scaling.
+        cfg_long = PhotonConfig(
+            model=ModelConfig(
+                base_embed_dim=16,
+                hidden_size=64,
+                intermediate_size=128,
+                num_attention_heads=4,
+                num_key_value_heads=4,
+                head_dim=16,
+                max_position_embeddings=512,
+                rope_scaling="ntk",
+                rope_scale_factor=4.0,  # 128 -> 512
+            ),
+            hierarchy=HierarchyConfig(
+                levels=2,
+                chunk_sizes=[4, 4],
+                converter_prefix_lengths=[2, 2],
+                encoder_layers_per_level=[1, 1],
+                decoder_layers_per_level=[1, 1],
+            ),
+            tokenizer=TokenizerConfig(vocab_size=256),
+        )
+        model2 = PhotonModel(cfg_long)
+        load_checkpoint(model2, ckpt_dir)
+
+        # generate() at prompt_len=64, max_new=4 must not raise.
+        ids = mx.random.randint(0, 256, (1, 64))
+        out_ids, _ = model2.generate(ids, max_new_tokens=4)
+        mx.eval(out_ids)
+        assert out_ids.shape == (1, 64 + 4)
+
+
+class TestNtkRopeLongInference:
+    """2048-trained PHOTON weights + NTK RoPE scaling must produce valid
+    inference outputs beyond the training context (Issue #55 accept-criteria
+    surrogate — scaled down to keep unit tests fast)."""
+
+    def test_ntk_rope_long_inference(self) -> None:
+        """Construct a tiny PhotonModel with rope_scaling='ntk',
+        rope_scale_factor=2.0, max_position_embeddings=2048 and run
+        generate(prompt_len=64, max_new=4) without raising."""
+        mx.random.seed(0)
+        cfg = PhotonConfig(
+            model=ModelConfig(
+                base_embed_dim=16,
+                hidden_size=64,
+                intermediate_size=128,
+                num_attention_heads=4,
+                num_key_value_heads=4,
+                head_dim=16,
+                max_position_embeddings=2048,
+                rope_theta=1_000_000.0,
+                rope_scaling="ntk",
+                rope_scale_factor=2.0,
+            ),
+            hierarchy=HierarchyConfig(
+                levels=2,
+                chunk_sizes=[4, 4],
+                converter_prefix_lengths=[2, 2],
+                encoder_layers_per_level=[1, 1],
+                decoder_layers_per_level=[1, 1],
+            ),
+            tokenizer=TokenizerConfig(vocab_size=256),
+        )
+        model = PhotonModel(cfg)
+        ids = mx.random.randint(0, 256, (1, 64))
+        out_ids, _ = model.generate(ids, max_new_tokens=4)
+        mx.eval(out_ids)
+        assert out_ids.shape == (1, 64 + 4)
+
+
+class TestLongContextModelInit:
+    """PhotonModel(load_photon_config('configs/photon_long_context.yaml'))
+    must not raise (Issue #55 basic-init receipt).
+
+    Gated behind a hidden_size downscale done at PhotonConfig level so we
+    don't actually allocate weights for the full 1024-dim 65536-position
+    model in unit tests.
+    """
+
+    def test_long_context_model_init(self) -> None:
+        from torch_ref.config import load_photon_config
+
+        cfg = load_photon_config("configs/photon_long_context.yaml")
+        # Downscale the heavy dims (hidden_size/intermediate/layers) to keep
+        # this test fast; the 65536 max_position_embeddings path is what we
+        # want to exercise.  Do NOT touch max_position_embeddings, rope_theta,
+        # rope_scaling, rope_scale_factor — those are the actual Issue #55
+        # surface under test.
+        cfg.model.base_embed_dim = 16
+        cfg.model.hidden_size = 64
+        cfg.model.intermediate_size = 128
+        cfg.model.num_attention_heads = 4
+        cfg.model.num_key_value_heads = 4
+        cfg.model.head_dim = 16
+        cfg.hierarchy.encoder_layers_per_level = [1, 1]
+        cfg.hierarchy.decoder_layers_per_level = [1, 1]
+        cfg.tokenizer.vocab_size = 256
+
+        model = PhotonModel(cfg)
+        # Touch the top-level RoPE table to confirm it got allocated.
+        assert model._rope_cos.shape[0] == 65536

--- a/reports/issue-55-long-context.md
+++ b/reports/issue-55-long-context.md
@@ -1,0 +1,104 @@
+# Issue #55 長コンテキスト実測レポート
+
+**実施日**: 2026-04-21
+**対象**: `configs/photon_long_context.yaml` (`max_position_embeddings: 65536`, `rope_scaling: ntk`, `rope_scale_factor: 32.0`)
+**ハード**: Apple Silicon（統合メモリ 256GB）
+**PHOTON**: 学習済みチェックポイントなし（ランダム重み）での実測
+**関連コミット**: branch `feature/issue-55-context-length-65k`
+
+## TL;DR
+
+1. **長コンテキスト構築自体は動く**: `max_position_embeddings: 65536` + `rope_scaling: ntk` で `PhotonModel.__init__` が例外なく完了、16,384 トークン prompt での `generate()` も成功。
+2. **メモリ見積りは大幅に過小**だった。設計方針書の見積り（16,384 で ~0.75GB）に対し、実測は **cached=20.7GB / nocache=13.1GB**。約 20 倍。設計方針書のメモリテーブルは更新が必要。
+3. **KV cache は長コンテキストで負の speedup**: 16,384 prompt / 8 gen で speedup **0.89x**（cache の方が遅い）。原因は encoder_replay / top_level_increment / local_tail_decode の合計が nocache prefill を上回る。実運用では use_kv_cache=False の方が良いケースあり → troubleshooting.md に記載。
+4. **`bench/issue61_prune_batch.py` は 32768 実測不可**: PR #69 で `PhotonInference.__init__(..., tokenizer)` が必須化されたが、bench script が未更新で TypeError。**これは Issue #55 とは無関係の pre-existing bug**。別 Issue で修正が必要。
+
+## 詳細
+
+### 1. kv_cache_speedup.py @ prompt-len=1024（smoke test）
+
+```
+python bench/kv_cache_speedup.py --config configs/photon_long_context.yaml --prompt-len 1024 --gen 4 --runs 1
+```
+
+| 項目 | cached | nocache |
+|---|---|---|
+| avg_sec | 0.2163 | 0.2016 |
+| per_token_ms | 54.0 | 50.4 |
+| tokens_per_sec | 18.5 | 19.8 |
+| peak_mb | **2,940.9** | **3,162.4** |
+
+Speedup: **0.93x** (cache わずかに遅い)
+
+### 2. kv_cache_speedup.py @ prompt-len=16384（本命）
+
+```
+python bench/kv_cache_speedup.py --config configs/photon_long_context.yaml --prompt-len 16384 --gen 8 --runs 1
+```
+
+| 項目 | cached | nocache |
+|---|---|---|
+| avg_sec | 6.9233 | 6.1589 |
+| per_token_ms | 865.4 | 769.9 |
+| tokens_per_sec | 1.16 | 1.30 |
+| peak_mb | **20,773.7** | **13,138.1** |
+
+Speedup: **0.89x** (cache が nocache より 11% 遅い)
+
+#### cached 経路の phase breakdown
+
+| phase | count | mean_ms | total_ms |
+|---|---|---|---|
+| prefill | 1 | 862.5 | 862.5 |
+| encoder_replay | 7 | 77.6 | 543.0 |
+| top_level_increment | 7 | 431.6 | 3,020.9 |
+| local_tail_decode | 7 | 356.1 | 2,492.9 |
+
+top-level increment が dominant。16,384 prompt 時の T/16 = 1,024 において top-level attention が二次的コストを取る。
+
+### 3. issue61_prune_batch.py @ max-len=32768（未実施）
+
+**エラー**: pre-existing bug により実行不可。
+
+```
+python bench/issue61_prune_batch.py --max-len 32768 --n-chunks 16 --warmup 1 --measure 3
+```
+
+```
+TypeError: PhotonInference.__init__() missing 1 required positional argument: 'tokenizer'
+```
+
+原因は `bench/issue61_prune_batch.py:242` の `PhotonInference(model, cfg)` 呼び出し。PR #69（commit `720953d`）で `PhotonInference.__init__` に tokenizer 引数が必須化されたが、bench script は追随更新されていない。**Issue #55 とは無関係**。別 Issue（例: "fix(bench): update issue61_prune_batch.py for tokenizer-required PhotonInference"）として切り出す。
+
+## メモリ見積りの再計算（設計方針書への follow-up）
+
+| コンテキスト長 | 設計見積り (KV cache 込) | 実測 (nocache) | 実測 (cached) | 見積りとの乖離 |
+|---|---|---|---|---|
+| 1,024 | - | 3.2 GB | 2.9 GB | - |
+| 16,384 | ~0.8 GB | 13.1 GB | 20.8 GB | **約 25 倍** |
+| 32,768 | ~0.95 GB | - | - | 未実測 |
+| 65,536 | ~1.30 GB | - | - | 未実測 |
+
+**原因の推定**:
+- 設計見積りでは `top-level attention score = layers × heads × (T/16)^2 × 2B (fp16)` のみ計上していたが、hidden_size=1024 の `cached_top_out` および local RoPE / encoder 側のメモリが含まれていない
+- cached 経路の `cached_top_out (B, T/16, hidden_size) × 2B` = `1 × 1024 × 1024 × 2B` = 2MB（これ自体は小さい）
+- 実測の 20GB は、おそらく (a) local decoder の中間 tensor (b) attention score の precompute (c) 結合した大きな buffer の一時確保 による
+
+**Issue #55 の実用性判断**:
+- 16,384 prompt で nocache 13GB、cached 21GB — **256GB 統合メモリでは十分実用可能**（設計は『2桁誤っても余裕』と明記済み、これは 1.5 桁程度の乖離に収まっている）
+- ただし、M3/M4 laptop の 16–48GB RAM 環境では cached 経路は厳しく、16,384 超の prompt で制限される可能性
+- **結論**: v1（推論時のみ拡張）は 256GB 環境で動作確認済み。小メモリ環境向けには `use_kv_cache=False` を推奨
+
+## 推奨事項
+
+1. **docs/troubleshooting.md** に以下を追記:
+   - 長コンテキスト入力でメモリ不足になる場合は `use_kv_cache=False` を指定
+   - 実測では 16,384 prompt で nocache が 7GB 節約 + 11% 高速（このワークロード条件下）
+2. **docs/tutorial.md** の「長コンテキスト推論」節に実測値（16,384 で約 20GB）を記載
+3. **別 Issue** として `bench/issue61_prune_batch.py` の tokenizer 追加を切り出し
+4. **Future Work**: 32,768 / 65,536 での実測は、学習済み checkpoint が利用可能になってから再実施
+
+## Raw JSON 出力
+
+- `bench/reports/kv_cache_speedup_20260421_041655.json` (prompt-len=1024)
+- `bench/reports/kv_cache_speedup_20260421_041723.json` (prompt-len=16384)

--- a/torch_ref/config.py
+++ b/torch_ref/config.py
@@ -13,6 +13,11 @@ import yaml
 _logger = logging.getLogger(__name__)
 
 
+# v1 scope: only "none" (vanilla RoPE) and "ntk" (NTK-aware interpolated RoPE).
+# Extend this set when adding new scaling methods (e.g. "linear", "yarn").
+ROPE_SCALING_CHOICES: frozenset[str] = frozenset({"none", "ntk"})
+
+
 @dataclass
 class ModelConfig:
     architecture: str = "photon_decoder"
@@ -24,10 +29,44 @@ class ModelConfig:
     head_dim: int = 64
     max_position_embeddings: int = 2048
     rope_theta: float = 1_000_000.0
+    rope_scaling: str = "none"
+    rope_scale_factor: float = 1.0
     norm_eps: float = 1e-5
     tie_word_embeddings: bool = False
     dropout: float = 0.0
     bias: bool = False
+
+    def __post_init__(self) -> None:
+        if self.rope_scaling not in ROPE_SCALING_CHOICES:
+            raise ValueError(
+                f"invalid rope_scaling: {self.rope_scaling!r} "
+                f"(expected one of {sorted(ROPE_SCALING_CHOICES)})"
+            )
+        if self.rope_scale_factor < 1.0:
+            raise ValueError(
+                f"rope_scale_factor must be >= 1.0 (got {self.rope_scale_factor})"
+            )
+        if self.rope_scaling == "none" and self.rope_scale_factor != 1.0:
+            _logger.warning(
+                "rope_scale_factor=%s is ignored because rope_scaling='none'; "
+                "set rope_scaling='ntk' to apply the scale factor.",
+                self.rope_scale_factor,
+            )
+
+    @classmethod
+    def rope_scaling_from(cls, m: Any) -> tuple[str, float]:
+        """Single source of defaults for ``rope_scaling`` / ``rope_scale_factor``.
+
+        Handles MagicMock-based configs in tests (unknown attrs return
+        ``MagicMock`` instances), so we use ``getattr`` with concrete
+        fallbacks.  ``scaling="ntk"`` with ``scale_factor=1.0`` is
+        mathematically equivalent to ``scaling="none"`` (the scale factor
+        term collapses to ``theta * 1.0``).
+        """
+        return (
+            getattr(m, "rope_scaling", "none"),
+            float(getattr(m, "rope_scale_factor", 1.0)),
+        )
 
 
 @dataclass
@@ -132,6 +171,45 @@ def _set_fields(dc: Any, raw: dict) -> None:
     for k, v in raw.items():
         if hasattr(dc, k):
             setattr(dc, k, v)
+        else:
+            _logger.warning(
+                "unknown config key ignored: %s (in %s)",
+                k,
+                type(dc).__name__,
+            )
+
+
+def _prod(xs: list[int]) -> int:
+    result = 1
+    for x in xs:
+        result *= int(x)
+    return result
+
+
+def _validate_cross_config(
+    model: ModelConfig,
+    hierarchy: HierarchyConfig,
+    training: TrainingConfig,
+) -> None:
+    """Enforce cross-dataclass invariants that can only be checked at load time.
+
+    - ``training.context_length`` must be a multiple of ``prod(hierarchy.chunk_sizes)``
+      so PHOTON can chunk the sequence cleanly into hierarchical tiles.
+    - ``training.context_length`` must not exceed ``model.max_position_embeddings``
+      since the RoPE table is precomputed to that length.
+    """
+    cl = int(training.context_length)
+    cl_mult = _prod(hierarchy.chunk_sizes)
+    if cl_mult > 0 and cl % cl_mult != 0:
+        raise ValueError(
+            f"training.context_length ({cl}) must be a multiple of "
+            f"prod(hierarchy.chunk_sizes)={cl_mult}"
+        )
+    if cl > int(model.max_position_embeddings):
+        raise ValueError(
+            f"training.context_length ({cl}) must be <= "
+            f"model.max_position_embeddings ({model.max_position_embeddings})"
+        )
 
 
 def load_photon_config(path: str | Path) -> PhotonConfig:
@@ -139,6 +217,9 @@ def load_photon_config(path: str | Path) -> PhotonConfig:
         raw = yaml.safe_load(f)
     cfg = PhotonConfig()
     _set_fields(cfg.model, raw.get("model", {}))
+    # Re-run ModelConfig.__post_init__ to validate fields set via _set_fields
+    # (setattr does not trigger __post_init__).
+    cfg.model.__post_init__()
     _set_fields(cfg.hierarchy, raw.get("hierarchy", {}))
     _set_fields(cfg.tokenizer, raw.get("tokenizer", {}))
     if "training" in raw:
@@ -171,4 +252,6 @@ def load_photon_config(path: str | Path) -> PhotonConfig:
                 cfg.training.eval_every_steps,
                 cfg.training.max_steps,
             )
+    if cfg.training is not None:
+        _validate_cross_config(cfg.model, cfg.hierarchy, cfg.training)
     return cfg

--- a/torch_ref/model.py
+++ b/torch_ref/model.py
@@ -31,7 +31,30 @@ class RMSNorm(nn.Module):
         return (x.float() * norm).type_as(x) * self.weight
 
 
-def _precompute_rope(dim: int, max_len: int, theta: float) -> torch.Tensor:
+def _precompute_rope(
+    dim: int,
+    max_len: int,
+    theta: float,
+    *,
+    scaling: str = "none",
+    scale_factor: float = 1.0,
+) -> torch.Tensor:
+    """Precompute complex64 RoPE table.
+
+    Issue #55: signature kept in sync with ``photon_mlx.blocks.precompute_rope``
+    for LSP (Liskov Substitution) compatibility.  The torch_ref reference is
+    NOT expected to support RoPE scaling — it exists primarily to validate
+    correctness of the vanilla forward pass.  Passing any ``scaling`` value
+    other than ``"none"`` raises ``NotImplementedError`` to make the
+    limitation explicit (long-context inference must use the MLX path).
+    """
+    if scaling != "none":
+        raise NotImplementedError(
+            "torch_ref does not support RoPE scaling; use photon_mlx"
+        )
+    # scale_factor is silently ignored when scaling='none' (consistent with
+    # ModelConfig.__post_init__ which only emits a warning in that case).
+    del scale_factor
     freqs = 1.0 / (theta ** (torch.arange(0, dim, 2).float() / dim))
     t = torch.arange(max_len).float()
     angles = torch.outer(t, freqs)

--- a/torch_ref/tests/test_rope.py
+++ b/torch_ref/tests/test_rope.py
@@ -1,0 +1,44 @@
+"""Tests for ``torch_ref.model._precompute_rope`` RoPE-scaling signature sync.
+
+Issue #55: ``_precompute_rope`` accepts the same ``scaling`` / ``scale_factor``
+kwargs as the MLX counterpart to keep the two APIs substitutable (LSP),
+but raises ``NotImplementedError`` for anything other than ``scaling='none'``
+because the torch_ref reference is not meant to handle long contexts.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from torch_ref.model import _precompute_rope  # noqa: E402
+
+
+def test_precompute_rope_none_unchanged() -> None:
+    """Default call (no kwargs) must produce a valid complex64 RoPE table."""
+    rope = _precompute_rope(64, 2048, 1e6)
+    assert rope.shape == (2048, 32)
+    assert rope.dtype == torch.complex64
+    # The modulus of every polar-form element must be ~1.0.
+    mod = rope.abs()
+    assert torch.allclose(mod, torch.ones_like(mod), atol=1e-6)
+
+    # Explicit scaling='none', scale_factor=1.0 must return the same table.
+    rope_explicit = _precompute_rope(64, 2048, 1e6, scaling="none", scale_factor=1.0)
+    assert torch.equal(rope, rope_explicit)
+
+
+def test_precompute_rope_scaling_raises() -> None:
+    """Passing scaling != 'none' must raise NotImplementedError."""
+    with pytest.raises(NotImplementedError, match="does not support RoPE scaling"):
+        _precompute_rope(64, 2048, 1e6, scaling="ntk")
+
+    # scale_factor != 1.0 alone (with scaling='none') is tolerated; torch_ref
+    # matches ModelConfig's warning-only contract for that silent misuse.
+    rope = _precompute_rope(64, 2048, 1e6, scaling="none", scale_factor=4.0)
+    assert rope.shape == (2048, 32)


### PR DESCRIPTION
## Summary

Issue #55 を実装。`max_position_embeddings: 2048` のハードコードを解除し、最大 65,536 トークンまで設定可能にする。RoPE theta スケーリングとチャンク整合バリデーションを追加。

## 変更内容

- `torch_ref/config.py`: `max_position_embeddings` バリデーション追加
- `torch_ref/model.py`, `torch_ref/tests/test_rope.py`: RoPE テーブル拡張対応
- `photon_mlx/blocks.py`: `precompute_rope()` の theta スケーリングオプション
- `photon_mlx/model.py`: 長コンテキスト対応の RoPE 初期化
- `photon_mlx/tests/{test_blocks.py, test_config.py}`: 新規テスト
- `configs/photon_long_context.yaml`: 32,768トークン向けプロファイル（新規）
- `reports/issue-55-long-context.md`: 実測ベンチマーク結果
- `docs/troubleshooting.md`, `docs/tutorial.md`: 使い方更新
- `bench/reports/kv_cache_speedup_*.json`: 参考ベンチマーク

## 実装確認

- [x] `ruff check .` - All checks passed
- [x] `ruff format --check .` - 96 files already formatted
- [x] `pytest` - 285 passed
- [x] Design review: 18 findings applied
- [x] 設計見積りの20倍誤差を実測で訂正

## 関連スピンオフ（推奨）

- fix(bench): pass tokenizer to PhotonInference in issue61_prune_batch (既に #72 登録済み)
- chore(config): fix photon_small.yaml schema bug
- perf(photon): investigate KV cache negative speedup at long prompts

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)