### PR TITLE
feat(photon): add find_relevant_past_turn() for turn-regression detection

### DIFF
--- a/photon_mlx/session.py
+++ b/photon_mlx/session.py
@@ -520,6 +520,62 @@ class PhotonSessionState:
         mx.eval(aggregated)
         return aggregated
 
+    def find_relevant_past_turn(
+        self, current_state: HierarchicalState | None
+    ) -> TurnState | None:
+        """現在の質問に最も関連する過去ターンを検索.
+
+        現在のターンを除く過去ターンそれぞれとコサイン類似度を計算し、
+        閾値 ``self.working_memory_cfg.relevant_turn_threshold``
+        （デフォルト ``0.7``）以上であれば最も近い ``TurnState`` を返す。
+        working memory が無効、``current_state`` が ``None``、または比較対象が
+        無い場合は ``None`` を fail-closed で返す（``PhotonSessionState.current_state``
+        自体が ``HierarchicalState | None`` なのでこの契約が必要）。
+
+        Contract (design §4):
+            * 呼び出し元は ``session.update()`` の後で呼ぶ想定。``turn_history``
+              には既に現ターンが append 済みなので、比較ループでは
+              ``turn_history[:-1]`` を走査して現ターンを除外する。
+            * ``current_state.level_states[-1]`` は単一サンプル前提
+              （``(T, D)`` / ``(1, T, D)``）。``B > 1`` の batched state は
+              本 API のサポート対象外。
+            * 非有限類似度（NaN / Inf）のターンはランキング対象から除外し、
+              全滅時は ``None`` を返す（fail-closed）。
+            * 同点類似度は最新 ``turn_id`` 優先。
+            * 戻り値 ``TurnState`` は ``turn_history`` 内部参照の借用であり、
+              consumer 側が mutate すると session state を破壊するため
+              read-only として扱うこと（設計 §10）。
+
+        Refs: Issue #78, design policy §4.4 / §4.5.
+        """
+        if not self.working_memory_cfg.enabled:  # step 1
+            return None
+        if len(self.turn_history) <= 1:  # step 2
+            return None
+        if current_state is None or not current_state.level_states:  # step 3
+            return None
+
+        curr_top = current_state.level_states[-1]
+
+        scores: list[tuple[TurnState, float]] = []
+        for past_turn in self.turn_history[:-1]:  # step 4
+            past_levels = past_turn.hierarchical_state.level_states
+            if not past_levels:
+                continue
+            sim = 1.0 - cosine_distance(curr_top, past_levels[-1])
+            if not math.isfinite(sim):
+                continue
+            scores.append((past_turn, sim))
+
+        if not scores:  # step 5
+            return None
+
+        scores.sort(key=lambda x: (x[1], x[0].turn_id), reverse=True)  # step 6-1
+        best_turn, best_sim = scores[0]
+        if best_sim >= self.working_memory_cfg.relevant_turn_threshold:  # step 6-2
+            return best_turn
+        return None
+
     def reset_working_memory(self) -> None:
         """Clear stale latents and turn history for fail-closed recovery.
 

--- a/photon_mlx/tests/test_session.py
+++ b/photon_mlx/tests/test_session.py
@@ -945,6 +945,254 @@ class TestWorkingMemory:
             assert abs(d_on.latent_cosine_drift - d_off.latent_cosine_drift) < 1e-6
             assert abs(d_on.logit_kl - d_off.logit_kl) < 1e-6
 
+    # ----------------------------------------------------------------
+    # Issue #78 — find_relevant_past_turn()
+    # ----------------------------------------------------------------
+    #
+    # T1..T11 cover the reference implementation in the design doc §4.5.
+    # ``_mk_state(v)`` (defined above) yields a constant top-level vector and
+    # therefore only produces cosine similarities of sign(v1)*sign(v2); tests
+    # that need fractional similarities or non-finite values build the
+    # ``HierarchicalState`` directly via ``_mk_state_vec`` / ``_mk_state_nan``.
+
+    @staticmethod
+    def _mk_state_vec(vec: list[float]) -> HierarchicalState:
+        """Build a HierarchicalState whose top-level state is the given 1-D vector.
+
+        The vector is wrapped to ``(1, 1, D)`` so ``mean_pool`` produces the
+        same ``(D,)`` values back — giving tests deterministic control over the
+        cosine similarity between states.
+        """
+        arr = mx.array([[vec]], dtype=mx.float32)
+        return HierarchicalState(level_states=[arr])
+
+    @staticmethod
+    def _mk_state_nan() -> HierarchicalState:
+        """Build a HierarchicalState guaranteed to yield a non-finite similarity."""
+        import math as _math
+
+        arr = mx.array([[[_math.nan, 0.0, 0.0, 0.0]]], dtype=mx.float32)
+        return HierarchicalState(level_states=[arr])
+
+    def test_find_relevant_past_turn_empty_history(self) -> None:
+        """T1: turn_history is empty → None (no update() has been called)."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(enabled=True),
+        )
+        assert session.turn_history == []
+        assert session.find_relevant_past_turn(_mk_state(1.0)) is None
+
+    def test_find_relevant_past_turn_single_turn(self) -> None:
+        """T2: only the current turn is recorded (len == 1) → None."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(enabled=True),
+        )
+        session.update(_mk_state(1.0), question_text="q1")
+        assert len(session.turn_history) == 1
+        # current_state is the just-updated state, so this emulates the
+        # production call pattern (update() then find_relevant_past_turn()).
+        assert session.find_relevant_past_turn(session.current_state) is None
+
+    def test_find_relevant_past_turn_returns_best_match(self) -> None:
+        """T3: multiple past turns above threshold → highest similarity wins."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True, relevant_turn_threshold=0.7
+            ),
+        )
+        # past turn 1: identical direction to current → sim = 1.0
+        session.update(self._mk_state_vec([1.0, 0.0, 0.0, 0.0]), question_text="past1")
+        # past turn 2: cos_sim = 4/5 = 0.8 against current (above threshold)
+        session.update(self._mk_state_vec([4.0, 3.0, 0.0, 0.0]), question_text="past2")
+        # current turn (turn_history[-1])
+        current = self._mk_state_vec([1.0, 0.0, 0.0, 0.0])
+        session.update(current, question_text="current")
+
+        result = session.find_relevant_past_turn(current)
+        assert result is not None
+        # past1 (turn_id=1) has sim=1.0, past2 (turn_id=2) has sim=0.8.
+        assert result.turn_id == 1
+        assert result.question_text == "past1"
+
+    def test_find_relevant_past_turn_below_threshold(self) -> None:
+        """T4: no past turn clears the threshold → None."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True, relevant_turn_threshold=0.7
+            ),
+        )
+        # past1: sim = 3/5 = 0.6 vs current [1, 0, 0, 0] (below 0.7)
+        session.update(self._mk_state_vec([3.0, 4.0, 0.0, 0.0]), question_text="p1")
+        # past2: sim = 0.0 (orthogonal)
+        session.update(self._mk_state_vec([0.0, 1.0, 0.0, 0.0]), question_text="p2")
+        current = self._mk_state_vec([1.0, 0.0, 0.0, 0.0])
+        session.update(current, question_text="current")
+
+        assert session.find_relevant_past_turn(current) is None
+
+    def test_find_relevant_past_turn_at_threshold_boundary(self) -> None:
+        """T5: sim exactly equal to threshold → returned (>= admits equality)."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True, relevant_turn_threshold=1.0
+            ),
+        )
+        # past1 and current share the same unit direction → sim == 1.0 == threshold
+        session.update(_mk_state(1.0), question_text="past1")
+        current = _mk_state(1.0)
+        session.update(current, question_text="current")
+
+        result = session.find_relevant_past_turn(current)
+        assert result is not None
+        assert result.turn_id == 1
+        assert result.question_text == "past1"
+
+    def test_find_relevant_past_turn_disabled_returns_none(self) -> None:
+        """T6: enabled=False → None, without mutating session state."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(enabled=False),
+        )
+        # Real update() won't populate turn_history when disabled. We manually
+        # append two TurnStates to prove the enabled-gate fires independently
+        # of the len(turn_history) guard.
+        session.turn_history.append(
+            TurnState(turn_id=1, hierarchical_state=_mk_state(1.0), question_text="p1")
+        )
+        session.turn_history.append(
+            TurnState(turn_id=2, hierarchical_state=_mk_state(1.0), question_text="cur")
+        )
+        before_len = len(session.turn_history)
+
+        assert session.find_relevant_past_turn(_mk_state(1.0)) is None
+        # No side effects on turn_history.
+        assert len(session.turn_history) == before_len
+        assert [t.turn_id for t in session.turn_history] == [1, 2]
+
+    def test_find_relevant_past_turn_skips_non_finite(self) -> None:
+        """T7: non-finite sim on one past turn is skipped, best finite wins."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True, relevant_turn_threshold=0.5
+            ),
+        )
+        # past1: contains NaN → cos_sim produces NaN → skipped
+        session.update(self._mk_state_nan(), question_text="nan_turn")
+        # past2: sim = 1.0 with current (same direction)
+        session.update(_mk_state(1.0), question_text="finite_turn")
+        current = _mk_state(1.0)
+        session.update(current, question_text="current")
+
+        result = session.find_relevant_past_turn(current)
+        assert result is not None
+        # Only the finite past turn (turn_id=2) is eligible.
+        assert result.turn_id == 2
+        assert result.question_text == "finite_turn"
+
+    def test_find_relevant_past_turn_tiebreak_by_latest_turn_id(self) -> None:
+        """T8: identical similarities → latest turn_id wins."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True, relevant_turn_threshold=0.7
+            ),
+        )
+        # Two past turns with the same direction as the current turn.
+        session.update(_mk_state(1.0), question_text="older")
+        session.update(_mk_state(1.0), question_text="newer")
+        current = _mk_state(1.0)
+        session.update(current, question_text="current")
+
+        result = session.find_relevant_past_turn(current)
+        assert result is not None
+        # Latest past turn (turn_id=2) wins over older past (turn_id=1).
+        assert result.turn_id == 2
+        assert result.question_text == "newer"
+
+    def test_find_relevant_past_turn_skips_empty_level_states(self) -> None:
+        """T9: one past turn with empty level_states is skipped, others evaluated."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True, relevant_turn_threshold=0.7
+            ),
+        )
+        # past1: normal turn with sim = 1.0
+        session.update(_mk_state(1.0), question_text="normal_past")
+        # past2 with empty level_states (hand-crafted to bypass update()'s own
+        # invariant — we replace the HierarchicalState on an existing turn).
+        session.update(_mk_state(1.0), question_text="empty_past")
+        session.turn_history[-1].hierarchical_state = HierarchicalState(level_states=[])
+        current = _mk_state(1.0)
+        session.update(current, question_text="current")
+
+        result = session.find_relevant_past_turn(current)
+        assert result is not None
+        # The empty-level_states turn must be skipped.
+        assert result.turn_id == 1
+        assert result.question_text == "normal_past"
+
+    def test_find_relevant_past_turn_all_past_level_states_empty(self) -> None:
+        """T10: every past turn has empty level_states → None (scores empty)."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True, relevant_turn_threshold=0.7
+            ),
+        )
+        session.update(_mk_state(1.0), question_text="p1")
+        session.update(_mk_state(1.0), question_text="p2")
+        # Blank out the level_states of every *past* turn (leave current alone).
+        current = _mk_state(1.0)
+        session.update(current, question_text="current")
+        for past in session.turn_history[:-1]:
+            past.hierarchical_state = HierarchicalState(level_states=[])
+
+        assert session.find_relevant_past_turn(current) is None
+
+    def test_find_relevant_past_turn_all_non_finite_returns_none(self) -> None:
+        """T11: every past turn yields non-finite sim → None (fail-closed)."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True, relevant_turn_threshold=0.5
+            ),
+        )
+        session.update(self._mk_state_nan(), question_text="nan_a")
+        session.update(self._mk_state_nan(), question_text="nan_b")
+        current = _mk_state(1.0)
+        session.update(current, question_text="current")
+
+        assert session.find_relevant_past_turn(current) is None
+
 
 class TestSessionStateReset:
     """Issue #64 — reset_working_memory() preserves telemetry only."""


### PR DESCRIPTION
## 概要

`PhotonSessionState.find_relevant_past_turn()` を追加し、「現在の質問が過去のどのターンに意味的に戻っているか」をコサイン類似度で検出できるようにする。working memory に保持された `turn_history` を活用し、後続 Issue #57 の Safe RecGen フォールバック / `cited_chunk_ids` pin 処理の前提 API となる。

Closes #78

## 変更内容

### `photon_mlx/session.py` (+56 行)
- `PhotonSessionState.find_relevant_past_turn(current_state: HierarchicalState | None) -> TurnState | None` を追加
- 早期 return（fail-closed）: ``working_memory_cfg.enabled=False`` / ``len(turn_history) <= 1`` / ``current_state is None`` / 空 ``level_states``
- 類似度: 既存 ``cosine_distance`` を再利用（``1.0 - cosine_distance(...)``、DRY）
- 非有限類似度（NaN/Inf）のターンはランキングから除外、全滅時は ``None``
- 同点類似度は最新 ``turn_id`` 優先（`scores.sort(key=lambda x: (x[1], x[0].turn_id), reverse=True)`）
- 閾値比較は ``>=``（等号含む、設定値 ``session_memory.working_memory.relevant_turn_threshold`` 経由、デフォルト 0.7）

### `photon_mlx/tests/test_session.py` (+248 行)
- ``TestWorkingMemory`` クラスに T1–T11 の 11 件を追加（空履歴 / 単一ターン / 最善選定 / 閾値未満 / 閾値境界 / enabled=False / 非有限 skip / タイブレーカ / 空 level_states / 全空 / 全非有限）
- 既存 helper ``_mk_state`` に加え class-scoped ``_mk_state_vec`` / ``_mk_state_nan`` を追加（任意ベクトル / NaN 注入用）

## スコープ外（本 Issue で触らない）

- Pipeline 連携（`baseline_reporag/photon_pipeline.py` からの呼び出し、Safe RecGen wiring、`cited_chunk_ids` pin）は **Issue #57** に分離
- `configs/*.yaml` / `docs/*` / `README.md` / `photon_mlx/__init__.py` / `photon_mlx/inference.py` は変更なし
- `WorkingMemoryConfig.relevant_turn_threshold` のデフォルト / validation は Issue #64 Phase 1 で導入済み、本 PR で変更なし
- `B > 1` の batched state はサポート対象外（設計方針書 §4.3 で明示、runtime ガードは追加しない）

## テスト

- [x] `python -m pytest photon_mlx/tests/` → 244/244 pass（新規 11 件含む）
- [x] `python -m pytest photon_mlx/tests/test_session.py::TestWorkingMemory -v` → 16/16 pass（新規 11 + 既存 5）
- [x] `python -m pytest` → 489 pass / 2 pre-existing failure（`tests/test_generate_training_corpus.py`、CLAUDE.md 既知・本 PR と無関係）
- [x] `ruff check .` → warning 0
- [x] `ruff format --check .` → 差分なし

## レビュー履歴（事前）

- マルチステージ Issue レビュー（Claude opus × 2 + Codex × 2 回のクロスレビュー）
- マルチステージ設計レビュー（Claude opus 通常/整合性 + Codex 影響分析/セキュリティ）
- TDD 実装後の Codex コードレビュー: verdict **pass**（critical/high 0 件、low 1 件は本 PR で対応済み: 引数型を `HierarchicalState | None` に拡張）

## 関連 Issue

- 親: #64（Phase 1 で `turn_history` 構造を導入済み）
- 後続 consumer: #57（Safe RecGen fallback wiring / pipeline pin 処理で本 API を消費）
- 関連: #63（多層 drift）

🤖 Generated with [Claude Code](https://claude.com/claude-code)