### PR TITLE
feat(photon): dynamic aggregation mode for turn-position and drift adaptation

### DIFF
--- a/bench/run_all.py
+++ b/bench/run_all.py
@@ -3,6 +3,7 @@ run_all.py  –  Run all benchmark variants defined in eval.yaml.
 
 Usage:
     python bench/run_all.py --config configs/eval.yaml
+    python bench/run_all.py --config configs/eval.yaml --variants id1,id2
 """
 
 from __future__ import annotations
@@ -13,6 +14,89 @@ import time
 import uuid
 from pathlib import Path
 from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# --variants CSV helpers (Issue #92 T-0b)
+# ---------------------------------------------------------------------------
+
+
+def parse_variants_csv(raw: str | None) -> list[str]:
+    """Split a CSV string into a list of variant ids.
+
+    Pure-Python ``str.split(',')`` only — no shell / subprocess (DR4-002
+    security contract).
+
+    Codex CB-003 fail-closed (Issue #92 T-0b): there are three inputs we
+    must distinguish so malformed ``--variants`` cannot silently escalate
+    to "run all variants":
+
+    * ``raw is None``       → flag not passed → return ``[]`` (no filter).
+    * ``raw`` is non-empty and every comma-separated token is a non-empty
+      non-whitespace string → return the stripped token list.
+    * Otherwise (``raw == ""``, ``","``, ``"a,,b"``, ``" "``, ``",a"``,
+      ``"a,"``, ...) the CSV is malformed. Raise
+      :class:`argparse.ArgumentTypeError` WITHOUT embedding the raw value
+      (DR4-001 no-leak — the attacker-controlled string must not reach
+      logs / tracebacks).
+
+    The ``None`` vs. empty-CSV distinction is what keeps :func:`filter_variants`
+    from fail-OPEN-ing on a typo: previously ``--variants ','`` collapsed
+    to ``[]`` and then the ``if not selected`` branch in ``filter_variants``
+    treated it as "no filter → all variants run".
+    """
+    if raw is None:
+        return []
+    # Empty / whitespace-only CSV is a hard error (distinct from ``None``).
+    if not raw.strip():
+        raise argparse.ArgumentTypeError(
+            "--variants must be a non-empty comma-separated list of ids"
+        )
+    tokens = raw.split(",")
+    stripped = [tok.strip() for tok in tokens]
+    if any(not tok for tok in stripped):
+        # Any empty middle / leading / trailing token fails closed.
+        raise argparse.ArgumentTypeError(
+            "--variants must not contain empty or whitespace-only tokens"
+        )
+    return stripped
+
+
+def filter_variants(
+    variants: list[dict],
+    selected: list[str] | None,
+) -> list[dict]:
+    """Filter ``variants`` to those whose id is in ``selected`` (CSV-ordered).
+
+    ``selected`` semantics:
+
+    * ``None`` or ``[]`` → return ``variants`` unchanged (no filter applied).
+    * Otherwise: every id in ``selected`` MUST match a variant's ``id`` via
+      exact string equality. An unknown id raises
+      :class:`argparse.ArgumentError` with a fail-closed message that
+      intentionally excludes the raw invalid token (DR4-001 no-leak; only
+      the allowed-id count is surfaced).
+
+    Order in the returned list matches the CSV order so downstream reports
+    are deterministic when re-running a subset.
+    """
+    if not selected:
+        return list(variants)
+
+    by_id: dict[str, dict] = {v["id"]: v for v in variants}
+    result: list[dict] = []
+    for sid in selected:
+        if sid not in by_id:
+            # No-leak: the unknown id is attacker-controlled; surface only
+            # the count of allowed ids so operators can diagnose without
+            # seeing attacker payload. Raise via argparse so CLI entry
+            # point fails closed with a clean usage error.
+            raise argparse.ArgumentError(
+                None,
+                f"--variants contains an unknown id; allowed ids count = {len(by_id)}",
+            )
+        result.append(by_id[sid])
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -177,6 +261,14 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Run all benchmark variants")
     parser.add_argument("--config", default="configs/eval.yaml")
     parser.add_argument("--run-id", default="")
+    parser.add_argument(
+        "--variants",
+        default=None,
+        help=(
+            "Optional comma-separated list of variant ids to run. Unknown "
+            "ids fail closed (Issue #92 T-0b)."
+        ),
+    )
     args = parser.parse_args()
 
     import yaml
@@ -191,7 +283,21 @@ def main() -> None:
     print(f"run_id:     {run_id}")
     print(f"output_dir: {output_dir}\n")
 
-    for variant in cfg.get("variants", []):
+    # Codex CB-003: ``parse_variants_csv`` raises ``ArgumentTypeError`` on
+    # malformed CSV (empty tokens). Route it through ``parser.error`` so
+    # the CLI exits with a clean usage message (same treatment as the
+    # unknown-id case below). The raw value is already sanitized away
+    # inside ``parse_variants_csv``.
+    try:
+        selected_ids = parse_variants_csv(args.variants)
+    except argparse.ArgumentTypeError as exc:
+        parser.error(str(exc))
+    try:
+        variants_to_run = filter_variants(cfg.get("variants", []), selected_ids)
+    except argparse.ArgumentError as exc:
+        parser.error(str(exc))
+
+    for variant in variants_to_run:
         print(f"  variant: {variant['id']} ...")
         predictions = run_variant(variant, cfg)
         path = save_run_predictions(run_id, variant["id"], predictions, output_dir)

--- a/bench/tests/test_run_all.py
+++ b/bench/tests/test_run_all.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
+import argparse
 import json
 from dataclasses import dataclass
 from unittest.mock import MagicMock, patch
 
-from bench.run_all import run_variant, save_run_predictions
+import pytest
+
+from bench.run_all import (
+    filter_variants,
+    parse_variants_csv,
+    run_variant,
+    save_run_predictions,
+)
 
 
 # ------------------------------------------------------------------
@@ -206,3 +214,156 @@ class TestSaveRunPredictions:
         lines = path.read_text().strip().split("\n")
         assert len(lines) == 1
         assert json.loads(lines[0])["eval_id"] == "SE-001"
+
+
+# ------------------------------------------------------------------
+# Issue #92 T-0b: --variants CSV filter tests
+# ------------------------------------------------------------------
+
+
+class TestParseVariantsCsv:
+    """``parse_variants_csv`` splits on ``,``, strips whitespace, fail-closed on empties.
+
+    Codex CB-003 (Issue #92): empty / whitespace / empty-middle tokens
+    are REJECTED (fail-closed), not silently dropped. ``None`` (flag not
+    passed) is still distinct from an explicitly empty CSV.
+    """
+
+    def test_simple_csv_splits(self) -> None:
+        assert parse_variants_csv("a,b,c") == ["a", "b", "c"]
+
+    def test_strips_whitespace(self) -> None:
+        assert parse_variants_csv(" a , b ,c ") == ["a", "b", "c"]
+
+    def test_single_token_ok(self) -> None:
+        assert parse_variants_csv("a") == ["a"]
+        assert parse_variants_csv("a,b") == ["a", "b"]
+
+    def test_none_returns_empty_list(self) -> None:
+        # ``None`` means "flag not passed" — still the "no filter" signal.
+        assert parse_variants_csv(None) == []
+
+    # ---- Codex CB-003 fail-closed regression tests ----
+
+    def test_empty_string_rejected(self) -> None:
+        """``--variants ''`` must fail closed (was silently empty before)."""
+        with pytest.raises(argparse.ArgumentTypeError):
+            parse_variants_csv("")
+
+    def test_whitespace_only_rejected(self) -> None:
+        """``--variants ' '`` must fail closed."""
+        with pytest.raises(argparse.ArgumentTypeError):
+            parse_variants_csv(" ")
+        with pytest.raises(argparse.ArgumentTypeError):
+            parse_variants_csv("   \t  ")
+
+    def test_bare_comma_rejected(self) -> None:
+        """``--variants ','`` must fail closed (previously collapsed to ``[]``)."""
+        with pytest.raises(argparse.ArgumentTypeError):
+            parse_variants_csv(",")
+
+    def test_empty_middle_token_rejected(self) -> None:
+        """``--variants 'a,,b'`` must fail closed."""
+        with pytest.raises(argparse.ArgumentTypeError):
+            parse_variants_csv("a,,b")
+
+    def test_trailing_comma_rejected(self) -> None:
+        """``--variants 'a,'`` must fail closed."""
+        with pytest.raises(argparse.ArgumentTypeError):
+            parse_variants_csv("a,")
+
+    def test_leading_comma_rejected(self) -> None:
+        """``--variants ',a'`` must fail closed."""
+        with pytest.raises(argparse.ArgumentTypeError):
+            parse_variants_csv(",a")
+
+    def test_error_messages_do_not_leak_raw_value(self) -> None:
+        """DR4-001 no-leak: raw attacker-controlled value must not appear."""
+        SENSITIVE_WS = "<ATTACK-WHITESPACE-PAYLOAD>"
+        SENSITIVE_MIDDLE = "<ATTACK-MIDDLE-PAYLOAD>"
+        # Whitespace-only: attacker could pass e.g. "   <sentinel>   " but
+        # our reject message must not include it. Only a non-empty but
+        # all-whitespace value hits this path; use a pure-whitespace string
+        # to exercise the empty branch — and verify the attacker name used
+        # in test identification never leaks.
+        with pytest.raises(argparse.ArgumentTypeError) as excinfo:
+            parse_variants_csv("   ")
+        assert SENSITIVE_WS not in str(excinfo.value)
+        # Empty-middle branch: payload supplied as a token.
+        with pytest.raises(argparse.ArgumentTypeError) as excinfo:
+            parse_variants_csv(f"a,,{SENSITIVE_MIDDLE}")
+        assert SENSITIVE_MIDDLE not in str(excinfo.value)
+
+    def test_pure_python_split_no_shell(self) -> None:
+        """Security: parsing must not spawn subprocess / shell.
+
+        We patch ``subprocess`` and ``os.system`` and confirm neither is
+        consulted (DR4-002 no-shell guarantee).
+        """
+        with patch("subprocess.run") as mock_run, patch("os.system") as mock_sys:
+            parse_variants_csv("a,b,c")
+            assert not mock_run.called
+            assert not mock_sys.called
+
+
+class TestFilterVariants:
+    """``filter_variants`` selects variants by id; fail-closed on unknowns."""
+
+    def _mk_variants(self) -> list[dict]:
+        return [
+            {"id": "photon_rag_aggr_weighted"},
+            {"id": "photon_rag_aggr_attention"},
+            {"id": "photon_rag_aggr_last"},
+            {"id": "baseline_rag"},
+        ]
+
+    def test_valid_csv_filters_variants_in_order(self) -> None:
+        """Valid ids select a subset; result preserves the CSV order."""
+        variants = self._mk_variants()
+        selected = filter_variants(
+            variants,
+            ["photon_rag_aggr_attention", "photon_rag_aggr_weighted"],
+        )
+        assert [v["id"] for v in selected] == [
+            "photon_rag_aggr_attention",
+            "photon_rag_aggr_weighted",
+        ]
+
+    def test_none_selection_returns_all(self) -> None:
+        variants = self._mk_variants()
+        assert filter_variants(variants, None) == variants
+
+    def test_empty_selection_returns_all(self) -> None:
+        variants = self._mk_variants()
+        assert filter_variants(variants, []) == variants
+
+    def test_unknown_id_fails_closed(self) -> None:
+        """Unknown id raises ``argparse.ArgumentError`` (fail-closed)."""
+        variants = self._mk_variants()
+        with pytest.raises(argparse.ArgumentError):
+            filter_variants(variants, ["not_a_real_variant_id"])
+
+    def test_unknown_id_error_message_does_not_leak_raw_value(self) -> None:
+        """DR4-001 no-leak: raw invalid value must not appear in error text."""
+        variants = self._mk_variants()
+        SENSITIVE = "<ATTACK-PAYLOAD-VARIANT-SENTINEL>"
+        with pytest.raises(argparse.ArgumentError) as excinfo:
+            filter_variants(variants, [SENSITIVE])
+        assert SENSITIVE not in str(excinfo.value)
+
+    def test_partial_unknown_fails_closed(self) -> None:
+        """A single unknown id in a mostly-valid CSV still fails closed."""
+        variants = self._mk_variants()
+        with pytest.raises(argparse.ArgumentError):
+            filter_variants(
+                variants,
+                ["photon_rag_aggr_weighted", "unknown_x"],
+            )
+
+    def test_no_shell_calls_on_filter(self) -> None:
+        """Filtering must not call subprocess / os.system (DR4-002)."""
+        variants = self._mk_variants()
+        with patch("subprocess.run") as mock_run, patch("os.system") as mock_sys:
+            filter_variants(variants, ["baseline_rag"])
+            assert not mock_run.called
+            assert not mock_sys.called

--- a/configs/eval.yaml
+++ b/configs/eval.yaml
@@ -81,11 +81,17 @@ variants:
         photon_generation_enabled: true
         generation_fallback_policy: "qwen"
 
-  # Issue #80 — aggregation mode comparison variants (3 modes).
-  # Run with:
+  # Issue #80 — static aggregation mode comparison variants (3 modes).
+  # Issue #92 — dynamic aggregation variants added below (3 strategies).
+  # Run the full A/B/C with:
   #   python -m bench.run_all --config configs/eval.yaml \
-  #     --variants photon_rag_aggr_weighted,photon_rag_aggr_attention,photon_rag_aggr_last
-  # Each variant only toggles ``aggregation`` so results are A/B/C comparable.
+  #     --variants photon_rag_aggr_weighted,photon_rag_aggr_attention,photon_rag_aggr_last,\
+  #                photon_rag_aggr_dynamic_turn,photon_rag_aggr_dynamic_drift,photon_rag_aggr_dynamic_hybrid
+  # Re-run the dynamic 3 only with:
+  #   python -m bench.run_all --config configs/eval.yaml \
+  #     --variants photon_rag_aggr_dynamic_turn,photon_rag_aggr_dynamic_drift,photon_rag_aggr_dynamic_hybrid
+  # Each variant only toggles ``aggregation`` (and ``dynamic_strategy``) so
+  # results are A/B/C comparable.
   - id: "photon_rag_aggr_weighted"
     label: "PHOTON-RAG+Aggr(weighted)"
     kind: "photon"
@@ -127,6 +133,63 @@ variants:
         working_memory:
           enabled: true
           aggregation: last
+
+  # Issue #92 — dynamic aggregation: ターン位置ベース。
+  # weighted_until_turn までは weighted、それ以降は attention。
+  - id: "photon_rag_aggr_dynamic_turn"
+    label: "PHOTON-RAG+Aggr(dynamic,turn_position)"
+    kind: "photon"
+    config_path: "./configs/photon_small.yaml"
+    override:
+      inference:
+        safe_recgen_enabled: false
+      safe_recgen:
+        enabled: false
+      session_memory:
+        working_memory:
+          enabled: true
+          aggregation: dynamic
+          dynamic_strategy: turn_position
+          weighted_until_turn: 3
+
+  # Issue #92 — dynamic aggregation: drift ベース。
+  # latest_drift().latent_cosine_drift_top > threshold で attention。
+  - id: "photon_rag_aggr_dynamic_drift"
+    label: "PHOTON-RAG+Aggr(dynamic,drift_based)"
+    kind: "photon"
+    config_path: "./configs/photon_small.yaml"
+    override:
+      inference:
+        safe_recgen_enabled: false
+      safe_recgen:
+        enabled: false
+      session_memory:
+        working_memory:
+          enabled: true
+          aggregation: dynamic
+          dynamic_strategy: drift_based
+          attention_drift_threshold: 0.5
+
+  # Issue #92 — dynamic aggregation: ハイブリッド。
+  # alpha = clamp(base + per_turn * max(0, N - until), 0, 1) で
+  # (1-alpha)*weighted + alpha*attention を混合。
+  - id: "photon_rag_aggr_dynamic_hybrid"
+    label: "PHOTON-RAG+Aggr(dynamic,hybrid)"
+    kind: "photon"
+    config_path: "./configs/photon_small.yaml"
+    override:
+      inference:
+        safe_recgen_enabled: false
+      safe_recgen:
+        enabled: false
+      session_memory:
+        working_memory:
+          enabled: true
+          aggregation: dynamic
+          dynamic_strategy: hybrid
+          weighted_until_turn: 3
+          hybrid_alpha_base: 0.5
+          hybrid_alpha_per_turn: 0.1
 
 fairness:
   fix_repo_snapshot: true

--- a/configs/photon_600m_paper.yaml
+++ b/configs/photon_600m_paper.yaml
@@ -118,9 +118,11 @@ session_memory:
     decay_factor: 0.5
     relevant_turn_threshold: 0.7
     storage_mode: "top_level_only"
-    # Issue #80: session coarse state aggregation mode.
-    # One of {"weighted", "attention", "last"}. Default "weighted" keeps
-    # the pre-#80 decayed-mean behaviour.
+    # Issue #80 / #92: session coarse state aggregation mode.
+    # One of {"weighted", "attention", "last", "dynamic"}. Default
+    # "weighted" keeps the pre-#80 decayed-mean behaviour. "dynamic"
+    # (Issue #92) selects weighted/attention/hybrid at call time via
+    # ``dynamic_strategy`` ∈ {"turn_position","drift_based","hybrid"}.
     aggregation: weighted
 
 tokenizer:

--- a/configs/photon_long_context.yaml
+++ b/configs/photon_long_context.yaml
@@ -125,9 +125,11 @@ session_memory:
     decay_factor: 0.5
     relevant_turn_threshold: 0.7
     storage_mode: "top_level_only"
-    # Issue #80: session coarse state aggregation mode.
-    # One of {"weighted", "attention", "last"}. Default "weighted" keeps
-    # the pre-#80 decayed-mean behaviour.
+    # Issue #80 / #92: session coarse state aggregation mode.
+    # One of {"weighted", "attention", "last", "dynamic"}. Default
+    # "weighted" keeps the pre-#80 decayed-mean behaviour. "dynamic"
+    # (Issue #92) selects weighted/attention/hybrid at call time via
+    # ``dynamic_strategy`` ∈ {"turn_position","drift_based","hybrid"}.
     aggregation: weighted
 
 tokenizer:

--- a/configs/photon_small.yaml
+++ b/configs/photon_small.yaml
@@ -128,9 +128,13 @@ session_memory:
     decay_factor: 0.5
     relevant_turn_threshold: 0.7
     storage_mode: "full"
-    # Issue #80: session coarse state aggregation mode.
-    # One of {"weighted", "attention", "last"}. Default "weighted" keeps
-    # the pre-#80 decayed-mean behaviour.
+    # Issue #80 / #92: session coarse state aggregation mode.
+    # One of {"weighted", "attention", "last", "dynamic"}. Default
+    # "weighted" keeps the pre-#80 decayed-mean behaviour. "dynamic"
+    # (Issue #92) selects weighted/attention/hybrid at call time via
+    # ``dynamic_strategy`` ∈ {"turn_position","drift_based","hybrid"}
+    # along with the related knobs (weighted_until_turn,
+    # attention_drift_threshold, hybrid_alpha_base, hybrid_alpha_per_turn).
     aggregation: weighted
 
 tokenizer:

--- a/configs/photon_tiny.yaml
+++ b/configs/photon_tiny.yaml
@@ -117,9 +117,11 @@ session_memory:
     decay_factor: 0.5
     relevant_turn_threshold: 0.7
     storage_mode: "full"
-    # Issue #80: session coarse state aggregation mode.
-    # One of {"weighted", "attention", "last"}. Default "weighted" keeps
-    # the pre-#80 decayed-mean behaviour.
+    # Issue #80 / #92: session coarse state aggregation mode.
+    # One of {"weighted", "attention", "last", "dynamic"}. Default
+    # "weighted" keeps the pre-#80 decayed-mean behaviour. "dynamic"
+    # (Issue #92) selects weighted/attention/hybrid at call time via
+    # ``dynamic_strategy`` ∈ {"turn_position","drift_based","hybrid"}.
     aggregation: weighted
 
 tokenizer:

--- a/photon_mlx/session.py
+++ b/photon_mlx/session.py
@@ -11,6 +11,7 @@ import math
 import time
 import warnings
 from dataclasses import dataclass, field
+from typing import Callable, ClassVar
 
 import mlx.core as mx
 
@@ -131,6 +132,18 @@ class DriftMetrics:
     latent_cosine_drift_mid: float = 0.0  # drift of level_states[0] (≥2 levels)
     latent_cosine_drift_token: float = 0.0  # drift of token_proj
 
+    # Issue #92: per-turn dynamic aggregation telemetry (DR1-001 / DR2-002).
+    # Both fields default to ``None`` so pre-existing consumers see no
+    # behaviour change when aggregation is static. Populated by
+    # :meth:`PhotonSessionState._record_selected_mode` after
+    # :meth:`get_session_coarse_state` resolves the mode.
+    # * ``selected_aggregation_mode``: closed-enum ``{"weighted","attention",
+    #   "last","hybrid"}`` when set, ``None`` otherwise.
+    # * ``selected_aggregation_alpha``: finite float only when mode is
+    #   ``"hybrid"``, ``None`` for the three static modes.
+    selected_aggregation_mode: str | None = None
+    selected_aggregation_alpha: float | None = None
+
     @property
     def latent_cosine_drift(self) -> float:
         """Backward-compat alias: equals ``latent_cosine_drift_top`` (DR1-009).
@@ -141,17 +154,22 @@ class DriftMetrics:
         """
         return self.latent_cosine_drift_top
 
-    def as_dict(self) -> dict:
-        """Return a JSON-safe superset schema (Issue #63 + Issue #64).
+    def as_dict(self) -> dict[str, float | int | str | None]:
+        """Return a JSON-safe superset schema (Issue #63 + #64 + #92).
 
-        Includes the legacy ``latent_cosine_drift`` alias plus the three
-        per-level drift keys from Issue #63 (DR3-002). Non-finite values
-        (``NaN`` / ``+Inf`` / ``-Inf``) are replaced with ``0.0`` and a
-        ``warnings.warn`` is emitted — only the field name is included in
-        the warning text so raw latent vectors or question text are never
-        surfaced through this path (design §7).
+        Numeric drift fields (the Issue #63 per-level plus legacy alias)
+        are finite-checked and coerced to ``0.0`` on NaN/Inf with a
+        warning — only the field name is included so raw latent vectors
+        or question text are never surfaced (design §7).
+
+        Issue #92 adds ``selected_aggregation_mode`` (``str | None``) and
+        ``selected_aggregation_alpha`` (``float | None``) to the schema.
+        These two fields are passed through as-is without the finite
+        coercion since ``None`` is a legitimate value (DR1-001 structured
+        telemetry). The return type widens from ``dict[str, float | int]``
+        to ``dict[str, float | int | str | None]`` accordingly.
         """
-        safe: dict[str, float | int] = {"turn_id": self.turn_id}
+        safe: dict[str, float | int | str | None] = {"turn_id": self.turn_id}
         for name in (
             "latent_cosine_drift",
             "latent_cosine_drift_top",
@@ -170,6 +188,11 @@ class DriftMetrics:
                 )
                 raw = 0.0
             safe[name] = round(float(raw), 6)
+
+        # Issue #92: mode/alpha fields are passed through verbatim. ``None``
+        # is the expected default for static aggregation modes.
+        safe["selected_aggregation_mode"] = self.selected_aggregation_mode
+        safe["selected_aggregation_alpha"] = self.selected_aggregation_alpha
         return safe
 
 
@@ -233,6 +256,41 @@ class _WMFieldSentinel:
 _WM_FIELD_UNSET = _WMFieldSentinel()
 
 
+def _validate_finite_float(
+    name: str,
+    val: object,
+    *,
+    low: float | None = None,
+    high: float | None = None,
+) -> float:
+    """Validate ``val`` is a finite float in ``[low, high]`` (Issue #92 T-2).
+
+    Shared helper extracted from :meth:`WorkingMemoryConfig.__post_init__`
+    (DR1-005) so the existing ``decay_factor`` / ``relevant_turn_threshold``
+    checks and the new dynamic fields follow the same type / range /
+    finite-ness contract. Range check is skipped for the bounds that are
+    left as ``None``.
+
+    Error messages intentionally surface only the field name / type name
+    (DR4-001 no-leak) so attacker-controlled YAML cannot inject payload
+    into logs. Returns the ``float()`` coerced value for caller assignment.
+    """
+    if isinstance(val, bool) or not isinstance(val, (int, float)):
+        raise TypeError(f"{name} must be float, got {type(val).__name__}")
+    v = float(val)
+    # DR4-001 no-leak (Codex CB-004): numeric validator error messages
+    # must NOT embed the raw attacker-controlled value. Only the field
+    # name and the constraint (static constants from the caller) are
+    # surfaced so malformed YAML cannot inject payload into logs.
+    if not math.isfinite(v):
+        raise ValueError(f"{name} must be finite")
+    if low is not None and v < low:
+        raise ValueError(f"{name} must be >= {low}")
+    if high is not None and v > high:
+        raise ValueError(f"{name} must be <= {high}")
+    return v
+
+
 @dataclass
 class WorkingMemoryConfig:
     """Configuration for cross-turn hierarchical working memory (Issue #64).
@@ -265,10 +323,46 @@ class WorkingMemoryConfig:
         default_factory=lambda: _WM_FIELD_UNSET
     )
     # Issue #80: aggregation mode selector for ``get_session_coarse_state()``.
-    # ``Literal["weighted", "attention", "last"]`` — default ``weighted`` keeps
-    # the pre-#80 behaviour so YAML configs without this key are backward
-    # compatible.
+    # ``Literal["weighted", "attention", "last", "dynamic"]`` — default
+    # ``weighted`` keeps the pre-#80 behaviour so YAML configs without this
+    # key are backward compatible. Issue #92 adds ``"dynamic"`` so that
+    # ``dynamic_strategy`` selects the aggregation at call time.
     aggregation: str = "weighted"
+
+    # --- Issue #92: dynamic aggregation fields (parse-only unless
+    # ``aggregation == "dynamic"``, so existing YAMLs are unaffected). ---
+    dynamic_strategy: str = "turn_position"
+    """Closed-enum {'turn_position','drift_based','hybrid'}. Selects which
+    dynamic strategy ``get_session_coarse_state()`` uses when
+    ``aggregation == 'dynamic'``. Ignored otherwise (Issue #92 §4)."""
+
+    weighted_until_turn: int = 3
+    """Turn-count threshold for the turn_position / hybrid strategies.
+
+    * turn_position: use ``weighted`` while ``len(turn_history) <= value``,
+      otherwise ``attention``.
+    * hybrid: ``alpha`` begins to ramp up once ``turn_count`` exceeds this
+      value (``alpha = base + per_turn * max(0, turn_count - value)``).
+
+    Must be ``>= 0``. Values ``> max_turns`` only emit a warning rather
+    than raising, to let operators experiment without touching other
+    fields (Issue #92 §4)."""
+
+    attention_drift_threshold: float = 0.5
+    """Finite float in ``[0.0, 1.0]``. drift_based strategy flips to
+    ``attention`` when ``latest_drift().latent_cosine_drift_top`` exceeds
+    this threshold, otherwise stays on ``weighted`` (Issue #92 §4)."""
+
+    hybrid_alpha_base: float = 0.5
+    """Finite float. Starting value of hybrid's ``alpha`` before the
+    per-turn ramp kicks in. The dispatcher clamps the final alpha to
+    ``[0.0, 1.0]``, so out-of-range bases are tolerated here (Issue #92
+    §4)."""
+
+    hybrid_alpha_per_turn: float = 0.1
+    """Finite float. Hybrid alpha's linear slope once ``turn_count``
+    exceeds ``weighted_until_turn``. The dispatcher clamps to ``[0.0,
+    1.0]`` (Issue #92 §4)."""
 
     def __post_init__(self) -> None:
         if not isinstance(self.enabled, bool):
@@ -325,22 +419,19 @@ class WorkingMemoryConfig:
                 f"{WORKING_MEMORY_MAX_TURNS_HARD_CAP} (hard cap), got "
                 f"{self.max_turns}"
             )
-        for name in ("decay_factor", "relevant_turn_threshold"):
-            val = getattr(self, name)
-            if isinstance(val, bool) or not isinstance(val, (int, float)):
-                raise TypeError(f"{name} must be float, got {type(val).__name__}")
-            if not math.isfinite(float(val)):
-                raise ValueError(f"{name} must be finite, got {val}")
-        if not (0.0 <= float(self.decay_factor) <= 1.0):
-            raise ValueError(
-                f"decay_factor must be 0.0 <= float <= 1.0, got {self.decay_factor}"
-            )
-        if not (-1.0 <= float(self.relevant_turn_threshold) <= 1.0):
-            raise ValueError(
-                "relevant_turn_threshold must be -1.0 <= float <= 1.0, got "
-                f"{self.relevant_turn_threshold}"
-            )
-        # Issue #80: aggregation mode — fail-closed on malformed YAML.
+        # Existing Issue #64 fields — route through the shared helper
+        # (Issue #92 DR1-005) so all finite-float validation shares one
+        # code path.
+        self.decay_factor = _validate_finite_float(
+            "decay_factor", self.decay_factor, low=0.0, high=1.0
+        )
+        self.relevant_turn_threshold = _validate_finite_float(
+            "relevant_turn_threshold",
+            self.relevant_turn_threshold,
+            low=-1.0,
+            high=1.0,
+        )
+        # Issue #80 / #92: aggregation mode — fail-closed on malformed YAML.
         # Error messages intentionally exclude the raw value (log-poisoning /
         # PII mitigation, design §6 and DR4-001): only the literal set and the
         # type name are surfaced.
@@ -348,10 +439,59 @@ class WorkingMemoryConfig:
             raise TypeError(
                 f"aggregation must be str, got {type(self.aggregation).__name__}"
             )
-        if self.aggregation not in {"weighted", "attention", "last"}:
+        if self.aggregation not in {"weighted", "attention", "last", "dynamic"}:
             raise ValueError(
-                "aggregation must be one of {'weighted', 'attention', 'last'}"
+                "aggregation must be one of "
+                "{'weighted', 'attention', 'last', 'dynamic'}"
             )
+
+        # --- Issue #92: dynamic_strategy closed-enum validation. ---
+        if not isinstance(self.dynamic_strategy, str):
+            raise TypeError(
+                "dynamic_strategy must be str, got "
+                f"{type(self.dynamic_strategy).__name__}"
+            )
+        if self.dynamic_strategy not in {"turn_position", "drift_based", "hybrid"}:
+            # No-leak: raw value omitted (DR4-001).
+            raise ValueError(
+                "dynamic_strategy must be one of "
+                "{'turn_position', 'drift_based', 'hybrid'}"
+            )
+
+        # --- Issue #92: weighted_until_turn: non-negative int, warn if
+        # above max_turns. ---
+        if isinstance(self.weighted_until_turn, bool) or not isinstance(
+            self.weighted_until_turn, int
+        ):
+            raise TypeError(
+                "weighted_until_turn must be int, got "
+                f"{type(self.weighted_until_turn).__name__}"
+            )
+        if self.weighted_until_turn < 0:
+            raise ValueError(
+                f"weighted_until_turn must be >= 0, got {self.weighted_until_turn}"
+            )
+        if self.weighted_until_turn > self.max_turns:
+            warnings.warn(
+                "weighted_until_turn exceeds max_turns — the turn_position "
+                "strategy will stay on 'weighted' for every retained turn",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+
+        # --- Issue #92: finite-float fields. ---
+        self.attention_drift_threshold = _validate_finite_float(
+            "attention_drift_threshold",
+            self.attention_drift_threshold,
+            low=0.0,
+            high=1.0,
+        )
+        self.hybrid_alpha_base = _validate_finite_float(
+            "hybrid_alpha_base", self.hybrid_alpha_base
+        )
+        self.hybrid_alpha_per_turn = _validate_finite_float(
+            "hybrid_alpha_per_turn", self.hybrid_alpha_per_turn
+        )
 
         # DR1-004: emit DeprecationWarning only when the caller mixed the
         # deprecated ``compress_old_turns`` with a non-default ``storage_mode``.
@@ -887,6 +1027,208 @@ class PhotonSessionState:
         result = mx.sum(attn_weights[:, None] * stacked, axis=0)  # (D,)
         return result
 
+    def _aggregate(
+        self,
+        mode: str,
+        *,
+        vecs: list[mx.array],
+        turn_ids: list[int],
+        weights: list[float],
+        fallback_vec: mx.array,
+    ) -> mx.array:
+        """Run a single aggregation mode on pre-collected inputs (Issue #92 T-1).
+
+        Extracted from :meth:`get_session_coarse_state` so that the new
+        dynamic dispatcher (Issue #92) can reuse the weighted / attention /
+        last branches without duplicating the branch bodies. Behaviour is
+        bit-for-bit identical to the pre-refactor inline logic — existing
+        Issue #80 tests (``test_all_modes_*``) guard the invariants.
+
+        ``mode`` MUST be one of ``"weighted"``, ``"attention"``, ``"last"``;
+        unknown values raise :class:`ValueError` with the raw value
+        intentionally omitted (DR4-001 no-leak).
+        """
+        if mode == "last":
+            return fallback_vec
+        if mode == "weighted":
+            weight_sum = sum(weights)
+            if weight_sum <= 0.0:
+                # All weights were zero (e.g. decay=0 with history > 1).
+                return fallback_vec
+            stacked = mx.stack(vecs, axis=0)  # (N, D)
+            w_arr = mx.array(weights, dtype=mx.float32)[:, None]  # (N, 1)
+            return mx.sum(stacked * w_arr, axis=0) / float(weight_sum)
+        if mode == "attention":
+            # Need a valid current vec to score past turns against.
+            if self.current_state is None or not self.current_state.level_states:
+                return fallback_vec
+            curr_vec = mean_pool(self.current_state.level_states[-1])
+            attn = self._aggregate_attention(
+                vecs,
+                turn_ids,
+                curr_vec,
+                exclude_turn_id=self.current_state.turn_id,
+            )
+            return attn if attn is not None else fallback_vec
+        # Defensive fail-fast for post-__post_init__ corruption
+        # (Issue #80 §8 decision #1 safety net). The raw value is
+        # deliberately omitted from the message.
+        raise ValueError("Unknown aggregation mode")
+
+    # ------------------------------------------------------------------
+    # Issue #92: dynamic aggregation strategies + dispatcher helpers.
+    # ------------------------------------------------------------------
+
+    def _effective_turn_count(self) -> int:
+        """Return storage-mode-invariant effective turn count (Codex CB-001).
+
+        ``len(self.turn_history)`` alone under-counts when
+        ``storage_mode == "summary_only"``, because
+        :meth:`_append_summary_only` never appends to ``turn_history`` and
+        writes to ``compressed_history`` instead. In that mode the
+        turn-position / hybrid strategies would otherwise be stuck at
+        ``weighted`` forever (alpha never ramps).
+
+        Summing both lists gives the number of turns the session has
+        actually observed and that currently contribute to
+        :meth:`get_session_coarse_state`. The two lists are disjoint by
+        construction: ``_append_full`` only writes to ``turn_history`` (and
+        ``_compress_oldest_turn`` moves entries between them atomically),
+        while ``_append_summary_only`` only writes to
+        ``compressed_history`` — so no double-count is possible.
+        """
+        return len(self.turn_history) + len(self.compressed_history)
+
+    def _dynamic_turn_position(self) -> tuple[str, float | None]:
+        """Turn-position strategy: ``weighted`` early, ``attention`` later.
+
+        * ``effective_turn_count <= weighted_until_turn`` → ``("weighted", None)``
+        * otherwise                                      → ``("attention", None)``
+
+        Returns ``("weighted", None)`` when no turns exist yet (Turn 0) so
+        that dispatcher fallbacks always receive a valid mode. Uses
+        :meth:`_effective_turn_count` so the threshold fires correctly
+        under ``storage_mode="summary_only"`` where
+        ``turn_history`` stays empty (Codex CB-001).
+        """
+        cfg = self.working_memory_cfg
+        if self._effective_turn_count() <= cfg.weighted_until_turn:
+            return ("weighted", None)
+        return ("attention", None)
+
+    def _dynamic_drift_based(self) -> tuple[str, float | None]:
+        """Drift-based strategy: ``attention`` when drift spikes.
+
+        * ``drift_history == []``                        → ``("weighted", None)``
+        * ``drift.latent_cosine_drift_top > threshold``  → ``("attention", None)``
+        * otherwise                                      → ``("weighted", None)``
+
+        Off-by-one note (issue body §3.8): because prune_evidence runs
+        before session_forward, ``latest_drift()`` returns Turn N-1's drift
+        at the start of Turn N. Turn 1 has ``drift_history == []`` and
+        fails closed to ``weighted``.
+        """
+        cfg = self.working_memory_cfg
+        drift = self.latest_drift()
+        if drift is None:
+            return ("weighted", None)
+        if drift.latent_cosine_drift_top > cfg.attention_drift_threshold:
+            return ("attention", None)
+        return ("weighted", None)
+
+    def _dynamic_hybrid_select(self) -> tuple[str, float]:
+        """Hybrid strategy: compute alpha and defer mixing to dispatcher.
+
+        ``alpha = clamp(base + per_turn * max(0, turn_count - until), 0, 1)``
+
+        ``turn_count`` here is the :meth:`_effective_turn_count` so alpha
+        ramps up correctly under ``storage_mode="summary_only"`` where
+        ``turn_history`` stays empty (Codex CB-001).
+
+        The actual ``w*weighted + alpha*attention`` mixing happens in
+        :meth:`_aggregate_hybrid` — this helper only picks the mode tag
+        (``"hybrid"``) and the clamped alpha so the dispatcher can thread
+        the two through a uniform signature (DR1-002 tuple return).
+        """
+        cfg = self.working_memory_cfg
+        turn_count = self._effective_turn_count()
+        ramp_steps = max(0, turn_count - cfg.weighted_until_turn)
+        raw_alpha = cfg.hybrid_alpha_base + cfg.hybrid_alpha_per_turn * ramp_steps
+        alpha = max(0.0, min(1.0, float(raw_alpha)))
+        return ("hybrid", alpha)
+
+    def _aggregate_hybrid(
+        self,
+        *,
+        alpha: float,
+        vecs: list[mx.array],
+        turn_ids: list[int],
+        weights: list[float],
+        fallback_vec: mx.array,
+    ) -> mx.array:
+        """Mix weighted + attention aggregations by ``alpha`` (Issue #92 T-4).
+
+        The two branches reuse :meth:`_aggregate` so numerical behaviour
+        matches the static modes exactly. Both branches always return a
+        concrete vector (``fallback_vec`` when their own fallback path
+        fires), but we still guard with ``None`` checks to satisfy the
+        Issue #92 §3 contract should ``_aggregate`` evolve to return
+        ``None`` for new corner cases.
+
+        Output: ``(1 - alpha) * w_vec + alpha * a_vec``, clamped by the
+        caller-supplied ``alpha`` which the dispatcher has already held to
+        ``[0, 1]``.
+        """
+        w_vec = self._aggregate(
+            "weighted",
+            vecs=vecs,
+            turn_ids=turn_ids,
+            weights=weights,
+            fallback_vec=fallback_vec,
+        )
+        a_vec = self._aggregate(
+            "attention",
+            vecs=vecs,
+            turn_ids=turn_ids,
+            weights=weights,
+            fallback_vec=fallback_vec,
+        )
+        # Defensive ``None`` handling per Issue body L79-82. In practice
+        # ``_aggregate`` returns a concrete vec for weighted/attention
+        # because ``fallback_vec`` is always populated at this call site.
+        if a_vec is None:
+            return w_vec
+        if w_vec is None:
+            return a_vec
+        alpha_f = float(alpha)
+        return (1.0 - alpha_f) * w_vec + alpha_f * a_vec
+
+    # Class-level dict-based dispatch (design §3 judgement #3b). OCP:
+    # adding a new strategy only needs a single dict entry and a helper
+    # method — the dispatcher body stays untouched.
+    _DYNAMIC_STRATEGY_DISPATCH: ClassVar[
+        dict[str, Callable[["PhotonSessionState"], tuple[str, float | None]]]
+    ] = {
+        "turn_position": lambda self: self._dynamic_turn_position(),
+        "drift_based": lambda self: self._dynamic_drift_based(),
+        "hybrid": lambda self: self._dynamic_hybrid_select(),
+    }
+
+    def _record_selected_mode(self, mode: str, *, alpha: float | None) -> None:
+        """Write the selected mode/alpha onto the latest DriftMetrics.
+
+        No-op when ``drift_history`` is empty (Turn 0 / post-reset, per
+        DR2-005). When non-empty, both fields are written unconditionally
+        so the schema-level ``None`` default is replaced in a single
+        step. Downstream bench/report consumers read these through
+        :meth:`DriftMetrics.as_dict`.
+        """
+        if not self.drift_history:
+            return
+        latest = self.drift_history[-1]
+        latest.selected_aggregation_mode = mode
+        latest.selected_aggregation_alpha = alpha
+
     def get_session_coarse_state(self) -> mx.array | None:
         """Return a ``(D,)`` coarse session vector aggregated across turns.
 
@@ -951,40 +1293,58 @@ class PhotonSessionState:
             return None
 
         # DRY: the shared fallback is always the most-recent valid vec
-        # (DR1-004). Bound once and reused by last / weighted / attention.
+        # (DR1-004). Bound once and reused by last / weighted / attention
+        # / hybrid.
         fallback_vec = vecs[-1]
 
-        mode = self.working_memory_cfg.aggregation
-        if mode == "last":
-            result = fallback_vec
-        elif mode == "weighted":
-            weight_sum = sum(weights)
-            if weight_sum <= 0.0:
-                # All weights were zero (e.g. decay=0 with history > 1).
-                result = fallback_vec
-            else:
-                stacked = mx.stack(vecs, axis=0)  # (N, D)
-                w_arr = mx.array(weights, dtype=mx.float32)[:, None]  # (N, 1)
-                result = mx.sum(stacked * w_arr, axis=0) / float(weight_sum)
-        elif mode == "attention":
-            # Need a valid current vec to score past turns against.
-            if self.current_state is None or not self.current_state.level_states:
-                result = fallback_vec
-            else:
-                curr_vec = mean_pool(self.current_state.level_states[-1])
-                attn = self._aggregate_attention(
-                    vecs,
-                    turn_ids,
-                    curr_vec,
-                    exclude_turn_id=self.current_state.turn_id,
-                )
-                result = attn if attn is not None else fallback_vec
-        else:
-            # Defensive fail-fast for post-__post_init__ corruption
-            # (Issue #80 §8 decision #1 / judgement #1 safety net). The raw
-            # value is deliberately omitted from the message.
-            raise ValueError("Unknown aggregation mode")
+        agg = self.working_memory_cfg.aggregation
+        if agg != "dynamic":
+            # Static modes (Issue #80 behaviour). Record the chosen mode
+            # on the latest DriftMetrics so per-turn telemetry is
+            # consistent whether or not dynamic is in use.
+            result = self._aggregate(
+                agg,
+                vecs=vecs,
+                turn_ids=turn_ids,
+                weights=weights,
+                fallback_vec=fallback_vec,
+            )
+            self._record_selected_mode(agg, alpha=None)
+            mx.eval(result)
+            return result
 
+        # Issue #92 dynamic dispatch (DR1-003 dict-based, DR1-002 uniform
+        # tuple return signature). Codex CB-002: guard the dict lookup so
+        # post-__post_init__ corruption of ``dynamic_strategy`` raises a
+        # sanitized ``ValueError`` (matching the static path's
+        # "Unknown aggregation mode" style) rather than a raw
+        # ``KeyError('<payload>')`` that would leak the attacker-controlled
+        # value into logs / tracebacks (DR4-001 no-leak).
+        strategy = self.working_memory_cfg.dynamic_strategy
+        handler = self._DYNAMIC_STRATEGY_DISPATCH.get(strategy)
+        if handler is None:
+            raise ValueError("Unknown dynamic_strategy")
+        mode, alpha = handler(self)
+
+        if mode == "hybrid":
+            assert alpha is not None  # hybrid helper always returns a float
+            result = self._aggregate_hybrid(
+                alpha=alpha,
+                vecs=vecs,
+                turn_ids=turn_ids,
+                weights=weights,
+                fallback_vec=fallback_vec,
+            )
+        else:
+            result = self._aggregate(
+                mode,
+                vecs=vecs,
+                turn_ids=turn_ids,
+                weights=weights,
+                fallback_vec=fallback_vec,
+            )
+
+        self._record_selected_mode(mode, alpha=alpha)
         mx.eval(result)
         return result
 

--- a/photon_mlx/tests/test_session.py
+++ b/photon_mlx/tests/test_session.py
@@ -270,8 +270,17 @@ class TestSessionState:
         assert drift.topic_shift_score < 1e-5
 
     def test_drift_metrics_as_dict_superset(self) -> None:
-        """DriftMetrics.as_dict() superset contract (DR3-002): legacy keys
-        stay present, three new keys are added."""
+        """DriftMetrics.as_dict() superset contract (DR3-002 + Issue #92 T-3):
+
+        * Legacy keys stay present (numeric drift fields — finite-checked).
+        * Three per-level keys added in Issue #63 stay present.
+        * Two new Issue #92 keys are present with their default values
+          (``selected_aggregation_mode`` / ``selected_aggregation_alpha``).
+        * Finite-check for the numeric drift fields is separate from the
+          type check for the mode/alpha fields (Issue body (g)).
+        """
+        import math as _math
+
         session = PhotonSessionState("s1", "repo", "abc123")
         s1 = HierarchicalState(
             level_states=[mx.ones((1, 4, 64)), mx.ones((1, 1, 64))],
@@ -284,7 +293,7 @@ class TestSessionState:
         )
         drift = session.update(s2)
         d = drift.as_dict()
-        # Legacy keys preserved.
+        # Legacy numeric keys preserved — all must be finite.
         for key in (
             "turn_id",
             "latent_cosine_drift",
@@ -300,8 +309,49 @@ class TestSessionState:
             "latent_cosine_drift_token",
         ):
             assert key in d
+        # Finite-check (separated from mode/alpha in Issue #92 T-3).
+        numeric_keys = (
+            "latent_cosine_drift",
+            "latent_cosine_drift_top",
+            "latent_cosine_drift_mid",
+            "latent_cosine_drift_token",
+            "token_agreement",
+            "logit_kl",
+            "topic_shift_score",
+        )
+        for key in numeric_keys:
+            assert _math.isfinite(d[key]), f"{key} must be finite"
         # Alias still returns top.
         assert d["latent_cosine_drift"] == d["latent_cosine_drift_top"]
+
+        # Issue #92: new telemetry fields present by default as ``None``.
+        assert "selected_aggregation_mode" in d
+        assert "selected_aggregation_alpha" in d
+        assert d["selected_aggregation_mode"] is None
+        assert d["selected_aggregation_alpha"] is None
+
+    def test_drift_metrics_as_dict_mode_alpha_types(self) -> None:
+        """Issue #92 T-3 (g): mode/alpha fields carry correct types when set.
+
+        Separated from the legacy numeric ``as_dict`` test so that the
+        type-check for mode (str) and alpha (float) does NOT run through
+        the numeric finite-check path.
+        """
+        m = DriftMetrics(turn_id=2)
+        m.selected_aggregation_mode = "hybrid"
+        m.selected_aggregation_alpha = 0.375
+        d = m.as_dict()
+        assert d["selected_aggregation_mode"] == "hybrid"
+        assert isinstance(d["selected_aggregation_mode"], str)
+        assert d["selected_aggregation_alpha"] == pytest.approx(0.375)
+        assert isinstance(d["selected_aggregation_alpha"], float)
+
+        # When only mode is set (weighted/attention/last), alpha stays None.
+        m2 = DriftMetrics(turn_id=3)
+        m2.selected_aggregation_mode = "weighted"
+        d2 = m2.as_dict()
+        assert d2["selected_aggregation_mode"] == "weighted"
+        assert d2["selected_aggregation_alpha"] is None
 
     def test_custom_drift_level_weights(self) -> None:
         """Custom weights propagate into topic_shift_score."""
@@ -1276,9 +1326,21 @@ class TestWorkingMemorySecurityRegression:
         assert out["token_agreement"] == 0.0
         assert out["logit_kl"] == 0.0
         assert abs(out["topic_shift_score"] - 0.25) < 1e-9
-        # JSON-safety: no NaN / Inf tokens in the dict.
-        for v in out.values():
-            assert _math.isfinite(v)
+        # JSON-safety: no NaN / Inf tokens in the NUMERIC fields. Issue #92
+        # adds mode/alpha fields of types str | None and float | None so we
+        # finite-check only the drift numeric keys here.
+        numeric_keys = {
+            "turn_id",
+            "latent_cosine_drift",
+            "latent_cosine_drift_top",
+            "latent_cosine_drift_mid",
+            "latent_cosine_drift_token",
+            "token_agreement",
+            "logit_kl",
+            "topic_shift_score",
+        }
+        for key in numeric_keys:
+            assert _math.isfinite(out[key])
         # A warning was surfaced for each non-finite coercion. The alias
         # ``latent_cosine_drift`` and the authoritative ``_top`` field both
         # resolve to NaN, so at minimum the 4 coercions (drift + alias +
@@ -1416,8 +1478,12 @@ class TestWorkingMemoryConfigAggregation:
         assert cfg.aggregation == "weighted"
 
     def test_working_memory_config_aggregation_accepts_valid_values(self) -> None:
-        """All three documented modes must construct successfully."""
-        for mode in ("weighted", "attention", "last"):
+        """All four documented modes must construct successfully.
+
+        Issue #92 adds ``"dynamic"`` to the closed-enum. The three legacy
+        modes (weighted/attention/last) continue to construct unchanged.
+        """
+        for mode in ("weighted", "attention", "last", "dynamic"):
             cfg = WorkingMemoryConfig(aggregation=mode)
             assert cfg.aggregation == mode
 
@@ -1505,27 +1571,189 @@ class TestWorkingMemoryConfigAggregation:
             WorkingMemoryConfig(aggregation="")
 
 
+class TestDynamicStrategyConfigValidation:
+    """Issue #92 T-2: validation rules for the five new dynamic fields.
+
+    Closed-enum and finite-float invariants follow the existing DR4-001
+    no-leak pattern — raw attacker-controlled values must never surface in
+    the error messages.
+    """
+
+    # ---- dynamic_strategy (closed enum) ----
+    @pytest.mark.parametrize("strategy", ["turn_position", "drift_based", "hybrid"])
+    def test_dynamic_strategy_accepts_valid_values(self, strategy: str) -> None:
+        cfg = WorkingMemoryConfig(aggregation="dynamic", dynamic_strategy=strategy)
+        assert cfg.dynamic_strategy == strategy
+
+    def test_dynamic_strategy_default_is_turn_position(self) -> None:
+        cfg = WorkingMemoryConfig()
+        assert cfg.dynamic_strategy == "turn_position"
+
+    def test_dynamic_strategy_rejects_non_str(self) -> None:
+        for bad in (1, 1.5, ["hybrid"], None):
+            with pytest.raises(TypeError) as excinfo:
+                WorkingMemoryConfig(dynamic_strategy=bad)  # type: ignore[arg-type]
+            # Type name is surfaced; raw repr of the payload is not
+            # (except when ``None`` where ``repr(None)="None"`` is a
+            # substring of ``NoneType`` — we skip that assert for None).
+            assert type(bad).__name__ in str(excinfo.value)
+            if bad is not None:
+                assert repr(bad) not in str(excinfo.value)
+
+    def test_dynamic_strategy_rejects_unknown_value_no_leak(self) -> None:
+        SENSITIVE = "<ATTACK-DYN-STRATEGY-SENTINEL>"
+        with pytest.raises(ValueError) as excinfo:
+            WorkingMemoryConfig(dynamic_strategy=SENSITIVE)
+        assert SENSITIVE not in str(excinfo.value)
+
+        for bad in ("turnposition", "hybrid_plus", "TURN_POSITION"):
+            with pytest.raises(ValueError) as excinfo:
+                WorkingMemoryConfig(dynamic_strategy=bad)
+            assert bad not in str(excinfo.value)
+
+    # ---- weighted_until_turn ----
+    def test_weighted_until_turn_default_is_three(self) -> None:
+        cfg = WorkingMemoryConfig()
+        assert cfg.weighted_until_turn == 3
+
+    @pytest.mark.parametrize("value", [0, 1, 3, 8])
+    def test_weighted_until_turn_accepts_non_negative(self, value: int) -> None:
+        cfg = WorkingMemoryConfig(weighted_until_turn=value)
+        assert cfg.weighted_until_turn == value
+
+    def test_weighted_until_turn_rejects_negative(self) -> None:
+        with pytest.raises(ValueError, match="weighted_until_turn"):
+            WorkingMemoryConfig(weighted_until_turn=-1)
+
+    def test_weighted_until_turn_rejects_non_int(self) -> None:
+        for bad in (1.5, "3", True):
+            with pytest.raises(TypeError):
+                WorkingMemoryConfig(weighted_until_turn=bad)  # type: ignore[arg-type]
+
+    def test_weighted_until_turn_warns_when_above_max_turns(self) -> None:
+        import warnings as _warnings
+
+        with _warnings.catch_warnings(record=True) as captured:
+            _warnings.simplefilter("always")
+            cfg = WorkingMemoryConfig(max_turns=3, weighted_until_turn=10)
+        assert cfg.weighted_until_turn == 10  # stored even though above cap
+        assert any("weighted_until_turn" in str(w.message) for w in captured)
+
+    # ---- attention_drift_threshold (finite float in [0, 1]) ----
+    def test_attention_drift_threshold_default(self) -> None:
+        cfg = WorkingMemoryConfig()
+        assert cfg.attention_drift_threshold == 0.5
+
+    @pytest.mark.parametrize("value", [0.0, 0.25, 0.5, 0.75, 1.0])
+    def test_attention_drift_threshold_accepts_in_range(self, value: float) -> None:
+        cfg = WorkingMemoryConfig(attention_drift_threshold=value)
+        assert cfg.attention_drift_threshold == value
+
+    def test_attention_drift_threshold_rejects_out_of_range(self) -> None:
+        import math as _math
+
+        for bad in (-0.1, 1.1, 2.0, _math.nan, _math.inf, -_math.inf):
+            with pytest.raises(ValueError, match="attention_drift_threshold"):
+                WorkingMemoryConfig(attention_drift_threshold=bad)
+
+    def test_attention_drift_threshold_rejects_non_float(self) -> None:
+        for bad in ("0.5", [0.5], None, True):
+            with pytest.raises(TypeError):
+                WorkingMemoryConfig(attention_drift_threshold=bad)  # type: ignore[arg-type]
+
+    # ---- hybrid_alpha_base ----
+    def test_hybrid_alpha_base_default(self) -> None:
+        cfg = WorkingMemoryConfig()
+        assert cfg.hybrid_alpha_base == 0.5
+
+    @pytest.mark.parametrize("value", [-5.0, 0.0, 0.25, 1.0, 10.0])
+    def test_hybrid_alpha_base_accepts_finite(self, value: float) -> None:
+        # Finite floats are accepted; clamp happens at dispatch time.
+        cfg = WorkingMemoryConfig(hybrid_alpha_base=value)
+        assert cfg.hybrid_alpha_base == value
+
+    def test_hybrid_alpha_base_rejects_non_finite(self) -> None:
+        import math as _math
+
+        for bad in (_math.nan, _math.inf, -_math.inf):
+            with pytest.raises(ValueError, match="hybrid_alpha_base"):
+                WorkingMemoryConfig(hybrid_alpha_base=bad)
+
+    def test_hybrid_alpha_base_rejects_non_float(self) -> None:
+        for bad in ("0.5", [0.5], None, True):
+            with pytest.raises(TypeError):
+                WorkingMemoryConfig(hybrid_alpha_base=bad)  # type: ignore[arg-type]
+
+    # ---- hybrid_alpha_per_turn ----
+    def test_hybrid_alpha_per_turn_default(self) -> None:
+        cfg = WorkingMemoryConfig()
+        assert cfg.hybrid_alpha_per_turn == 0.1
+
+    @pytest.mark.parametrize("value", [-1.0, 0.0, 0.1, 5.0])
+    def test_hybrid_alpha_per_turn_accepts_finite(self, value: float) -> None:
+        cfg = WorkingMemoryConfig(hybrid_alpha_per_turn=value)
+        assert cfg.hybrid_alpha_per_turn == value
+
+    def test_hybrid_alpha_per_turn_rejects_non_finite(self) -> None:
+        import math as _math
+
+        for bad in (_math.nan, _math.inf, -_math.inf):
+            with pytest.raises(ValueError, match="hybrid_alpha_per_turn"):
+                WorkingMemoryConfig(hybrid_alpha_per_turn=bad)
+
+
+def _mk_mode_cfg(aggregation_param: str, **kwargs: object) -> WorkingMemoryConfig:
+    """Build a :class:`WorkingMemoryConfig` for parametrized mode tests.
+
+    Accepts either a static mode (``"weighted"``/``"attention"``/``"last"``)
+    or a ``"dynamic-<strategy>"`` tag (Issue #92 T-6). This collapses the
+    Issue #80 3-mode matrix and the Issue #92 3-strategy matrix into a
+    single 6-value parametrize for the (a) common-contract tests.
+    """
+    if aggregation_param.startswith("dynamic-"):
+        strategy = aggregation_param.split("-", 1)[1]
+        return WorkingMemoryConfig(
+            aggregation="dynamic",
+            dynamic_strategy=strategy,
+            **kwargs,  # type: ignore[arg-type]
+        )
+    return WorkingMemoryConfig(aggregation=aggregation_param, **kwargs)  # type: ignore[arg-type]
+
+
+# Parametrize ids used by TestGetSessionCoarseStateModes (a) common
+# contract: legacy 3 static + 3 dynamic strategies (Issue #92 T-6 (b)).
+_MODE_IDS_ALL: tuple[str, ...] = (
+    "weighted",
+    "attention",
+    "last",
+    "dynamic-turn_position",
+    "dynamic-drift_based",
+    "dynamic-hybrid",
+)
+
+
 class TestGetSessionCoarseStateModes:
-    """Issue #80: 3-mode dispatch for ``get_session_coarse_state()``.
+    """Issue #80 + #92: mode dispatch for ``get_session_coarse_state()``.
 
     Four categories (design §8 DR1-009):
     - (a) common contract across modes (shape, dtype, None)
     - (b) mode-specific edge cases
     - (c) validation / defensive raise
     - (d) prune parity (covered in TestPruneParityAcrossAggregationModes)
+
+    Issue #92 T-6 (b) extends the (a) common-contract parametrize to also
+    cover the 3 new dynamic strategies.
     """
 
     # ---- (a) common contract across modes ----
-    @pytest.mark.parametrize("aggregation", ["weighted", "attention", "last"])
+    @pytest.mark.parametrize("aggregation", list(_MODE_IDS_ALL))
     def test_all_modes_shape_dtype(self, aggregation: str) -> None:
-        """3 modes must return (D,) float32 vectors."""
+        """All modes (static 3 + dynamic 3) must return (D,) float32 vectors."""
         session = PhotonSessionState(
             "s1",
             "repo",
             "abc",
-            working_memory_cfg=WorkingMemoryConfig(
-                enabled=True, max_turns=4, aggregation=aggregation
-            ),
+            working_memory_cfg=_mk_mode_cfg(aggregation, max_turns=4),
         )
         session.update(_mk_state(1.0))
         session.update(_mk_state(2.0))
@@ -1535,46 +1763,40 @@ class TestGetSessionCoarseStateModes:
         assert coarse.shape == (4,)
         assert coarse.dtype == mx.float32
 
-    @pytest.mark.parametrize("aggregation", ["weighted", "attention", "last"])
+    @pytest.mark.parametrize("aggregation", list(_MODE_IDS_ALL))
     def test_all_modes_empty_turn_history_returns_none(self, aggregation: str) -> None:
-        """All 3 modes return None on empty turn_history."""
+        """All modes return None on empty turn_history."""
         session = PhotonSessionState(
             "s1",
             "repo",
             "abc",
-            working_memory_cfg=WorkingMemoryConfig(
-                enabled=True, aggregation=aggregation
-            ),
+            working_memory_cfg=_mk_mode_cfg(aggregation),
         )
         assert session.get_session_coarse_state() is None
 
-    @pytest.mark.parametrize("aggregation", ["weighted", "attention", "last"])
+    @pytest.mark.parametrize("aggregation", list(_MODE_IDS_ALL))
     def test_all_modes_disabled_returns_none(self, aggregation: str) -> None:
-        """All 3 modes return None when working memory is disabled."""
+        """All modes return None when working memory is disabled."""
         # Even if aggregation is set, enabled=False short-circuits.
         session = PhotonSessionState(
             "s1",
             "repo",
             "abc",
-            working_memory_cfg=WorkingMemoryConfig(
-                enabled=False, aggregation=aggregation
-            ),
+            working_memory_cfg=_mk_mode_cfg(aggregation, enabled=False),
         )
         session.update(_mk_state(1.0))
         assert session.get_session_coarse_state() is None
 
-    @pytest.mark.parametrize("aggregation", ["weighted", "attention", "last"])
+    @pytest.mark.parametrize("aggregation", list(_MODE_IDS_ALL))
     def test_all_modes_all_empty_level_states_returns_none(
         self, aggregation: str
     ) -> None:
-        """All 3 modes return None when every turn has empty level_states."""
+        """All modes return None when every turn has empty level_states."""
         session = PhotonSessionState(
             "s1",
             "repo",
             "abc",
-            working_memory_cfg=WorkingMemoryConfig(
-                enabled=True, aggregation=aggregation
-            ),
+            working_memory_cfg=_mk_mode_cfg(aggregation),
         )
         # Inject a turn whose hierarchical_state has empty level_states
         # (simulating the skip invariant).
@@ -1582,16 +1804,14 @@ class TestGetSessionCoarseStateModes:
         session.update(HierarchicalState(level_states=[]))
         assert session.get_session_coarse_state() is None
 
-    @pytest.mark.parametrize("aggregation", ["weighted", "attention", "last"])
+    @pytest.mark.parametrize("aggregation", list(_MODE_IDS_ALL))
     def test_all_modes_single_turn_equivalent(self, aggregation: str) -> None:
-        """Single-turn history: 3 modes must produce the same coarse vec."""
+        """Single-turn history: all modes must produce the same coarse vec."""
         session = PhotonSessionState(
             "s1",
             "repo",
             "abc",
-            working_memory_cfg=WorkingMemoryConfig(
-                enabled=True, aggregation=aggregation
-            ),
+            working_memory_cfg=_mk_mode_cfg(aggregation),
         )
         session.update(_mk_state(2.5))
         coarse = session.get_session_coarse_state()
@@ -1834,7 +2054,20 @@ class TestPruneParityAcrossAggregationModes:
     scores (ε=1e-5).
     """
 
-    @pytest.mark.parametrize("aggregation", ["weighted", "attention", "last"])
+    @pytest.mark.parametrize(
+        "aggregation",
+        [
+            "weighted",
+            "attention",
+            "last",
+            # Issue #92 T-6 (c): dynamic 3 strategies with storage_mode="full"
+            # — scope-bounded per plan (no 3x3 matrix, that lives in
+            # TestDynamicAggregationStorageModeMatrix).
+            "dynamic-turn_position",
+            "dynamic-drift_based",
+            "dynamic-hybrid",
+        ],
+    )
     def test_single_turn_prune_scores_match_across_modes(
         self, stub_tokenizer_for_cfg, aggregation: str
     ) -> None:
@@ -1846,9 +2079,7 @@ class TestPruneParityAcrossAggregationModes:
             model,
             cfg,
             tokenizer,
-            working_memory_cfg=WorkingMemoryConfig(
-                enabled=True, aggregation=aggregation
-            ),
+            working_memory_cfg=_mk_mode_cfg(aggregation, storage_mode="full"),
         )
         ids = mx.random.randint(0, 256, (1, 16))
         engine.session_forward(ids, "s1", "repo", "abc")
@@ -1906,6 +2137,430 @@ class TestPruneParityAcrossAggregationModes:
                     f"prune score mismatch at idx {i}: "
                     f"weighted={a} {mode}={b} delta={abs(a - b)}"
                 )
+
+
+class TestDynamicAggregation:
+    """Issue #92 T-4/T-5/T-7: dynamic aggregation strategies + dispatcher.
+
+    Exercises the three strategy helpers, the hybrid aggregator, and the
+    dispatcher in :meth:`PhotonSessionState.get_session_coarse_state`,
+    plus the per-turn mode recording on :class:`DriftMetrics`.
+    """
+
+    # ---------- (T-4) _dynamic_turn_position ----------
+    def test_turn_position_weighted_at_threshold(self) -> None:
+        """turn_count == weighted_until_turn → 'weighted' (inclusive)."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True,
+                max_turns=8,
+                aggregation="dynamic",
+                dynamic_strategy="turn_position",
+                weighted_until_turn=3,
+            ),
+        )
+        for i in range(3):
+            session.update(_mk_state(float(i + 1)))
+        mode, alpha = session._dynamic_turn_position()
+        assert mode == "weighted"
+        assert alpha is None
+
+    def test_turn_position_attention_above_threshold(self) -> None:
+        """turn_count > weighted_until_turn → 'attention'."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True,
+                max_turns=8,
+                aggregation="dynamic",
+                dynamic_strategy="turn_position",
+                weighted_until_turn=2,
+            ),
+        )
+        for i in range(4):
+            session.update(_mk_state(float(i + 1)))
+        mode, alpha = session._dynamic_turn_position()
+        assert mode == "attention"
+        assert alpha is None
+
+    def test_turn_position_weighted_zero_turns(self) -> None:
+        """turn_count == 0 → 'weighted' (no turns yet)."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True,
+                aggregation="dynamic",
+                dynamic_strategy="turn_position",
+                weighted_until_turn=3,
+            ),
+        )
+        mode, alpha = session._dynamic_turn_position()
+        assert mode == "weighted"
+        assert alpha is None
+
+    # ---------- (T-4) _dynamic_drift_based ----------
+    def test_drift_based_empty_drift_history_returns_weighted(self) -> None:
+        """drift_history empty (Turn 0 / reset) → ('weighted', None)."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True,
+                aggregation="dynamic",
+                dynamic_strategy="drift_based",
+                attention_drift_threshold=0.5,
+            ),
+        )
+        assert session.drift_history == []
+        mode, alpha = session._dynamic_drift_based()
+        assert mode == "weighted"
+        assert alpha is None
+
+    def test_drift_based_below_threshold_weighted(self) -> None:
+        """drift <= threshold → 'weighted'."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True,
+                aggregation="dynamic",
+                dynamic_strategy="drift_based",
+                attention_drift_threshold=0.5,
+            ),
+        )
+        session.update(_mk_state(1.0))
+        session.update(_mk_state(1.0))  # identical → drift ~ 0
+        mode, alpha = session._dynamic_drift_based()
+        assert mode == "weighted"
+        assert alpha is None
+
+    def test_drift_based_above_threshold_attention(self) -> None:
+        """drift > threshold → 'attention'."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True,
+                aggregation="dynamic",
+                dynamic_strategy="drift_based",
+                attention_drift_threshold=0.5,
+            ),
+        )
+        # Force a drift above threshold by mutating the latest DriftMetrics.
+        session.update(_mk_state(1.0))
+        session.update(_mk_state(1.0))
+        session.drift_history[-1].latent_cosine_drift_top = 0.9
+        mode, alpha = session._dynamic_drift_based()
+        assert mode == "attention"
+        assert alpha is None
+
+    def test_drift_based_at_threshold_boundary(self) -> None:
+        """drift == threshold → 'weighted' (strict '>' per design)."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True,
+                aggregation="dynamic",
+                dynamic_strategy="drift_based",
+                attention_drift_threshold=0.5,
+            ),
+        )
+        session.update(_mk_state(1.0))
+        session.update(_mk_state(1.0))
+        session.drift_history[-1].latent_cosine_drift_top = 0.5  # == threshold
+        mode, _alpha = session._dynamic_drift_based()
+        assert mode == "weighted"
+
+    # ---------- (T-4) _dynamic_hybrid_select ----------
+    def test_hybrid_select_alpha_before_ramp(self) -> None:
+        """turn_count <= weighted_until_turn → alpha = base (clamped)."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True,
+                max_turns=8,
+                aggregation="dynamic",
+                dynamic_strategy="hybrid",
+                weighted_until_turn=3,
+                hybrid_alpha_base=0.5,
+                hybrid_alpha_per_turn=0.1,
+            ),
+        )
+        for i in range(3):
+            session.update(_mk_state(float(i + 1)))
+        mode, alpha = session._dynamic_hybrid_select()
+        assert mode == "hybrid"
+        assert alpha == pytest.approx(0.5)
+
+    def test_hybrid_select_alpha_after_ramp(self) -> None:
+        """alpha = clamp(base + per_turn * (turn_count - until), 0, 1)."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True,
+                max_turns=8,
+                aggregation="dynamic",
+                dynamic_strategy="hybrid",
+                weighted_until_turn=3,
+                hybrid_alpha_base=0.5,
+                hybrid_alpha_per_turn=0.1,
+            ),
+        )
+        for i in range(5):  # turn_count = 5 → alpha = 0.5 + 0.1*2 = 0.7
+            session.update(_mk_state(float(i + 1)))
+        mode, alpha = session._dynamic_hybrid_select()
+        assert mode == "hybrid"
+        assert alpha == pytest.approx(0.7)
+
+    def test_hybrid_select_alpha_clamped_above_one(self) -> None:
+        """Huge ramp → alpha clamped to 1.0."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True,
+                max_turns=8,
+                aggregation="dynamic",
+                dynamic_strategy="hybrid",
+                weighted_until_turn=0,
+                hybrid_alpha_base=10.0,
+                hybrid_alpha_per_turn=5.0,
+            ),
+        )
+        session.update(_mk_state(1.0))
+        _mode, alpha = session._dynamic_hybrid_select()
+        assert alpha == pytest.approx(1.0)
+
+    def test_hybrid_select_alpha_clamped_below_zero(self) -> None:
+        """Negative base → alpha clamped to 0.0."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True,
+                max_turns=8,
+                aggregation="dynamic",
+                dynamic_strategy="hybrid",
+                weighted_until_turn=3,
+                hybrid_alpha_base=-5.0,
+                hybrid_alpha_per_turn=0.1,
+            ),
+        )
+        session.update(_mk_state(1.0))
+        _mode, alpha = session._dynamic_hybrid_select()
+        assert alpha == pytest.approx(0.0)
+
+    # ---------- (T-5) get_session_coarse_state dispatcher ----------
+    @pytest.mark.parametrize("strategy", ["turn_position", "drift_based", "hybrid"])
+    def test_dispatcher_returns_shape_d_dtype_float32(self, strategy: str) -> None:
+        """dynamic dispatcher: all 3 strategies produce (D,) float32 vec."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True,
+                max_turns=4,
+                aggregation="dynamic",
+                dynamic_strategy=strategy,
+            ),
+        )
+        session.update(_mk_state(1.0))
+        session.update(_mk_state(2.0))
+        coarse = session.get_session_coarse_state()
+        assert coarse is not None
+        assert coarse.shape == (4,)
+        assert coarse.dtype == mx.float32
+
+    @pytest.mark.parametrize("strategy", ["turn_position", "drift_based", "hybrid"])
+    def test_dispatcher_empty_turn_history_returns_none(self, strategy: str) -> None:
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True,
+                aggregation="dynamic",
+                dynamic_strategy=strategy,
+            ),
+        )
+        assert session.get_session_coarse_state() is None
+
+    def test_selected_mode_recorded_per_turn_weighted(self) -> None:
+        """static ``weighted`` mode is recorded on the latest DriftMetrics."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True, max_turns=4, aggregation="weighted"
+            ),
+        )
+        session.update(_mk_state(1.0))
+        session.update(_mk_state(2.0))
+        session.get_session_coarse_state()
+        assert session.drift_history[-1].selected_aggregation_mode == "weighted"
+        assert session.drift_history[-1].selected_aggregation_alpha is None
+
+    def test_selected_mode_recorded_per_turn_dynamic_hybrid(self) -> None:
+        """hybrid: mode='hybrid' AND alpha is a float on DriftMetrics."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True,
+                max_turns=4,
+                aggregation="dynamic",
+                dynamic_strategy="hybrid",
+                weighted_until_turn=0,
+                hybrid_alpha_base=0.5,
+                hybrid_alpha_per_turn=0.1,
+            ),
+        )
+        session.update(_mk_state(1.0))
+        session.update(_mk_state(2.0))
+        session.get_session_coarse_state()
+        last = session.drift_history[-1]
+        assert last.selected_aggregation_mode == "hybrid"
+        assert isinstance(last.selected_aggregation_alpha, float)
+
+    def test_selected_mode_recorded_per_turn_dynamic_turn_position(self) -> None:
+        """turn_position records 'weighted' or 'attention' with alpha=None."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True,
+                max_turns=8,
+                aggregation="dynamic",
+                dynamic_strategy="turn_position",
+                weighted_until_turn=1,
+            ),
+        )
+        # Turn 1 → mode=weighted (turn_count=1 <= until=1).
+        session.update(_mk_state(1.0))
+        session.get_session_coarse_state()
+        assert session.drift_history[-1].selected_aggregation_mode == "weighted"
+        assert session.drift_history[-1].selected_aggregation_alpha is None
+
+        # Turn 3 → mode=attention (turn_count=3 > until=1).
+        session.update(_mk_state(2.0))
+        session.update(_mk_state(3.0))
+        session.get_session_coarse_state()
+        assert session.drift_history[-1].selected_aggregation_mode == "attention"
+        assert session.drift_history[-1].selected_aggregation_alpha is None
+
+    def test_record_selected_mode_noop_when_drift_history_empty(self) -> None:
+        """Empty drift_history → _record_selected_mode is a no-op (no raise)."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True,
+                aggregation="dynamic",
+                dynamic_strategy="turn_position",
+            ),
+        )
+        # With no turn_history, get_session_coarse_state short-circuits to
+        # None. _record_selected_mode is not reached — but a direct call
+        # must also be a no-op.
+        session._record_selected_mode("weighted", alpha=None)
+        assert session.drift_history == []
+
+    def test_hybrid_aggregate_combines_weighted_and_attention(self) -> None:
+        """_aggregate_hybrid mixes weighted and attention results."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True,
+                max_turns=4,
+                aggregation="dynamic",
+                dynamic_strategy="hybrid",
+                weighted_until_turn=0,
+                hybrid_alpha_base=0.5,
+                hybrid_alpha_per_turn=0.0,  # keep alpha at 0.5
+            ),
+        )
+        session.update(_mk_state(1.0))
+        session.update(_mk_state(-1.0))
+        session.update(_mk_state(1.0))  # current similar to turn 1
+        coarse = session.get_session_coarse_state()
+        assert coarse is not None
+        mx.eval(coarse)
+        import math as _math
+
+        for v in coarse.tolist():
+            assert _math.isfinite(v)
+
+
+class TestDynamicAggregationStorageModeMatrix:
+    """Issue #92 T-7 (f): storage_mode × dynamic_strategy 3×3 = 9 combos."""
+
+    @pytest.mark.parametrize("storage_mode", ["full", "top_level_only", "summary_only"])
+    @pytest.mark.parametrize("strategy", ["turn_position", "drift_based", "hybrid"])
+    def test_shape_dtype_across_storage_modes(
+        self, storage_mode: str, strategy: str
+    ) -> None:
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True,
+                max_turns=3,
+                storage_mode=storage_mode,
+                aggregation="dynamic",
+                dynamic_strategy=strategy,
+            ),
+        )
+        for v in (1.0, 2.0):
+            session.update(_mk_state(v))
+        coarse = session.get_session_coarse_state()
+        assert coarse is not None
+        assert coarse.shape == (4,)
+        assert coarse.dtype == mx.float32
+
+    @pytest.mark.parametrize("storage_mode", ["full", "top_level_only", "summary_only"])
+    @pytest.mark.parametrize("strategy", ["turn_position", "drift_based", "hybrid"])
+    def test_empty_returns_none_across_storage_modes(
+        self, storage_mode: str, strategy: str
+    ) -> None:
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True,
+                max_turns=3,
+                storage_mode=storage_mode,
+                aggregation="dynamic",
+                dynamic_strategy=strategy,
+            ),
+        )
+        assert session.get_session_coarse_state() is None
 
 
 class TestCodexCB004WorkingMemoryMaxTurnsHardCap:


### PR DESCRIPTION
## Summary

Issue #92 を実装。Wave 5 で判明した「aggregation mode のトレードオフ」（weighted は Turn 2-3 で優位、attention は Turn 4-6 で優位）を解決するため、**dynamic mode** を追加し、ターン位置・drift に応じて weighted/attention を動的に切替可能にする。

## 変更内容

- `photon_mlx/session.py`: `aggregation: dynamic` + 3 つの `dynamic_strategy`（turn_position / drift_based / hybrid）
- 全 configs に `dynamic_strategy` 設定追加
- 単体テスト追加
- `reports/issue_92_dynamic_aggregation.md`: 測定プロトコル記載

## Test Plan

- [x] `ruff check .` / `ruff format --check .` 全パス
- [x] `pytest` - 432 passed
- [ ] Post-merge で MT eval (6 variant A/B) を実行、最良モードを default 化

Closes #92

🤖 Generated with Claude Code