### PR TITLE
feat(retrieval): in-process grid-search harness for retrieval tuning

### DIFF
--- a/scripts/_grid_search_core.py
+++ b/scripts/_grid_search_core.py
@@ -1,0 +1,504 @@
+"""Pure-function core of the retrieval grid-search tool (Issue #88).
+
+This module is deliberately MLX-free so it can be imported from unit
+tests on a CI runner that has no MLX installed. It provides:
+
+- ``ConfigParams`` / ``ConfigResult`` dataclasses
+- ``generate_phase1_grid`` / ``generate_phase2_grid`` (grid construction)
+- ``is_invalid_combo`` (4-condition filter per design §5)
+- ``aggregate_metrics`` (pinned against ``ci_eval_check.check_static``)
+- ``validate_override`` (fail-fast key typo guard)
+- ``atomic_write_json`` / ``write_markdown_report`` (IO helpers)
+
+The CLI-facing ``scripts/retrieval_grid_search.py`` is the only place
+that imports MLX-backed pipeline code.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+import statistics
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from baseline_reporag.config import Config
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ConfigParams:
+    """Sweep-target parameters. Immutable + hashable."""
+
+    lexical_top_k: int
+    embedding_top_k: int
+    fused_top_k: int
+    rerank_top_k: int
+    weights_lexical: float
+    weights_embedding: float
+
+    def to_override_dict(self) -> dict[str, Any]:
+        return {
+            "lexical_top_k": self.lexical_top_k,
+            "embedding_top_k": self.embedding_top_k,
+            "fused_top_k": self.fused_top_k,
+            "rerank_top_k": self.rerank_top_k,
+            "weights": {
+                "lexical": self.weights_lexical,
+                "embedding": self.weights_embedding,
+            },
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> ConfigParams:
+        weights = d.get("weights", {})
+        return cls(
+            lexical_top_k=int(d["lexical_top_k"]),
+            embedding_top_k=int(d["embedding_top_k"]),
+            fused_top_k=int(d["fused_top_k"]),
+            rerank_top_k=int(d["rerank_top_k"]),
+            weights_lexical=float(
+                weights.get("lexical", d.get("weights_lexical", 0.0))
+            ),
+            weights_embedding=float(
+                weights.get("embedding", d.get("weights_embedding", 0.0))
+            ),
+        )
+
+
+@dataclass
+class ConfigResult:
+    """Per-config aggregated result. Serialized to JSON with _ms suffix."""
+
+    config_idx: int
+    params: ConfigParams
+    raw_no_citation_rate: float
+    true_nc_rate: float
+    wrong_citation_count: int
+    latency_p50_ms: float
+    latency_p95_ms: float
+    n_questions: int
+    n_no_citation: int
+    duration_seconds: float
+    started_at: str
+    completed_at: str
+    memory_peak_mb: float | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def to_json(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "config_idx": self.config_idx,
+            "params": self.params.to_override_dict(),
+            "raw_no_citation_rate": self.raw_no_citation_rate,
+            "true_nc_rate": self.true_nc_rate,
+            "wrong_citation_count": self.wrong_citation_count,
+            "latency_p50_ms": self.latency_p50_ms,
+            "latency_p95_ms": self.latency_p95_ms,
+            "n_questions": self.n_questions,
+            "n_no_citation": self.n_no_citation,
+            "duration_seconds": self.duration_seconds,
+            "started_at": self.started_at,
+            "completed_at": self.completed_at,
+        }
+        if self.memory_peak_mb is not None:
+            out["memory_peak_mb"] = self.memory_peak_mb
+        if self.extra:
+            out["extra"] = self.extra
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Invalid combo filter (design §5)
+# ---------------------------------------------------------------------------
+
+
+_WEIGHTS_SUM_MAX = 0.90
+_WEIGHTS_SUM_EPS = 1e-9
+
+
+def is_invalid_combo(p: ConfigParams) -> bool:
+    """Return True when ``p`` violates at least one of the 4 sanity rules.
+
+    See design §5 for the full rationale of each condition.
+    """
+    if p.rerank_top_k > p.fused_top_k:
+        return True
+    if p.lexical_top_k <= 0 or p.embedding_top_k <= 0 or p.fused_top_k <= 0:
+        return True
+    if (p.weights_lexical + p.weights_embedding) > _WEIGHTS_SUM_MAX + _WEIGHTS_SUM_EPS:
+        return True
+    if p.lexical_top_k <= 15 and p.embedding_top_k <= 15 and p.fused_top_k >= 20:
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Grid generators
+# ---------------------------------------------------------------------------
+
+
+_PHASE1_LEX_EMB: tuple[tuple[int, int], ...] = ((15, 15), (20, 20), (25, 25))
+_PHASE1_FUSED_RERANK: tuple[tuple[int, int], ...] = ((10, 8), (16, 12), (20, 16))
+_PHASE1_WEIGHTS: tuple[tuple[float, float], ...] = (
+    (0.55, 0.35),
+    (0.45, 0.45),
+    (0.35, 0.55),
+)
+
+
+def generate_phase1_grid() -> list[ConfigParams]:
+    """Return the 24 valid Phase 1 configs (27 candidates minus 3 invalid)."""
+    valid: list[ConfigParams] = []
+    for lex, emb in _PHASE1_LEX_EMB:
+        for fused, rerank in _PHASE1_FUSED_RERANK:
+            for w_lex, w_emb in _PHASE1_WEIGHTS:
+                params = ConfigParams(
+                    lexical_top_k=lex,
+                    embedding_top_k=emb,
+                    fused_top_k=fused,
+                    rerank_top_k=rerank,
+                    weights_lexical=w_lex,
+                    weights_embedding=w_emb,
+                )
+                if is_invalid_combo(params):
+                    continue
+                valid.append(params)
+    return valid
+
+
+def _key(params: ConfigParams) -> str:
+    return json.dumps(params.to_override_dict(), sort_keys=True)
+
+
+def generate_phase2_grid(
+    seeds: list[ConfigParams],
+    *,
+    topk_delta: int = 5,
+    topk_step: int = 5,
+    weight_delta: float = 0.05,
+    weight_step: float = 0.05,
+) -> list[ConfigParams]:
+    """Generate Phase 2 neighborhood around each seed.
+
+    For every seed we walk ``top_k ± topk_delta`` in ``topk_step`` increments
+    on each of the four ``*_top_k`` axes, and ``weights ± weight_delta`` in
+    ``weight_step`` increments on the two weight axes. Invalid combos are
+    filtered out and duplicates (including the seed itself) are dropped.
+    """
+    if not seeds:
+        return []
+
+    seed_keys = {_key(s) for s in seeds}
+    seen: set[str] = set(seed_keys)
+    result: list[ConfigParams] = []
+
+    topk_offsets = _range_int(-topk_delta, topk_delta, topk_step)
+    weight_offsets = _range_float(-weight_delta, weight_delta, weight_step)
+
+    for seed in seeds:
+        for d_lex in topk_offsets:
+            for d_emb in topk_offsets:
+                for d_fused in topk_offsets:
+                    for d_rerank in topk_offsets:
+                        for d_wl in weight_offsets:
+                            for d_we in weight_offsets:
+                                cand = ConfigParams(
+                                    lexical_top_k=seed.lexical_top_k + d_lex,
+                                    embedding_top_k=seed.embedding_top_k + d_emb,
+                                    fused_top_k=seed.fused_top_k + d_fused,
+                                    rerank_top_k=seed.rerank_top_k + d_rerank,
+                                    weights_lexical=round(
+                                        seed.weights_lexical + d_wl, 4
+                                    ),
+                                    weights_embedding=round(
+                                        seed.weights_embedding + d_we, 4
+                                    ),
+                                )
+                                if is_invalid_combo(cand):
+                                    continue
+                                k = _key(cand)
+                                if k in seen:
+                                    continue
+                                seen.add(k)
+                                result.append(cand)
+    return result
+
+
+def _range_int(lo: int, hi: int, step: int) -> list[int]:
+    if step <= 0:
+        return [0]
+    out: list[int] = []
+    n = lo
+    while n <= hi + 0:
+        out.append(n)
+        n += step
+    return out
+
+
+def _range_float(lo: float, hi: float, step: float) -> list[float]:
+    if step <= 0:
+        return [0.0]
+    out: list[float] = []
+    # Use integer math to avoid floating-point drift.
+    n_steps = int(round((hi - lo) / step))
+    for i in range(n_steps + 1):
+        out.append(round(lo + i * step, 6))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# aggregate_metrics (pinned against ci_eval_check.check_static)
+# ---------------------------------------------------------------------------
+
+
+def aggregate_metrics(
+    records: list[dict[str, Any]],
+    unanswerable_ids: set[str],
+) -> dict[str, Any]:
+    """Compute the same metrics as ``ci_eval_check.check_static``.
+
+    Returned keys match that function's dict (no ``_ms`` suffix on latency).
+    ``true_nc_rate`` is only present when ``unanswerable_ids`` is non-empty,
+    matching the reference implementation.
+    """
+    total = len(records)
+    if total == 0:
+        return {"total": 0, "error": "no records found"}
+
+    no_cite = sum(1 for r in records if r.get("no_citation"))
+    wrong_cite = sum(1 for r in records if r.get("wrong_citation_indices"))
+    latencies = [lat for r in records if (lat := _extract_latency(r)) is not None]
+
+    answerable_records = [r for r in records if _eval_id(r) not in unanswerable_ids]
+    answerable_total = len(answerable_records)
+    answerable_no_cite = sum(1 for r in answerable_records if r.get("no_citation"))
+    correct_abstains = sum(
+        1 for r in records if _eval_id(r) in unanswerable_ids and r.get("no_citation")
+    )
+
+    result: dict[str, Any] = {
+        "total": total,
+        "no_citation_rate": no_cite / total,
+        "wrong_citation_count": wrong_cite,
+        "latency_p50": statistics.median(latencies) if latencies else 0,
+        "latency_p95": _percentile(latencies, 0.95) if latencies else 0,
+        "n_questions": total,
+        "n_no_citation": no_cite,
+    }
+
+    if unanswerable_ids:
+        result["unanswerable_count"] = len(unanswerable_ids)
+        result["correct_abstains"] = correct_abstains
+        result["answerable_total"] = answerable_total
+        result["answerable_no_cite"] = answerable_no_cite
+        result["true_nc_rate"] = (
+            answerable_no_cite / answerable_total if answerable_total else 0
+        )
+
+    return result
+
+
+def _extract_latency(record: dict[str, Any]) -> float | None:
+    if "latency" in record and isinstance(record["latency"], dict):
+        return record["latency"].get("total_ms")
+    return record.get("latency_ms")
+
+
+def _eval_id(record: dict[str, Any]) -> str:
+    qid = record.get("eval_id", "") or record.get("id", "")
+    if not qid:
+        sid = record.get("session_id", "")
+        qid = sid.replace("eval-", "", 1) if sid.startswith("eval-") else sid
+    return qid
+
+
+def _percentile(values: list[float], q: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    # nearest-rank method: ceil(q * N) - 1, clipped to [0, N-1].
+    idx = max(0, min(len(ordered) - 1, math.ceil(q * len(ordered)) - 1))
+    return ordered[idx]
+
+
+# ---------------------------------------------------------------------------
+# validate_override (O8: fail-fast before 16h run)
+# ---------------------------------------------------------------------------
+
+
+def validate_override(base_cfg: Config, params: ConfigParams) -> None:
+    """Raise ValueError if ``params`` contains a key absent from ``base_cfg.retrieval``.
+
+    Catches typos (e.g. ``lexcial_top_k``) before they silently collapse to
+    the base config value during a 16h sweep.
+    """
+    retrieval_cfg = getattr(base_cfg, "retrieval", None)
+    if retrieval_cfg is None:
+        raise ValueError("base_cfg has no .retrieval section")
+
+    base_keys = set(_cfg_to_dict(retrieval_cfg).keys())
+    override = params.to_override_dict()
+    for key, value in override.items():
+        if key not in base_keys:
+            raise ValueError(
+                f"Unknown retrieval key: {key!r} (not in base_cfg.retrieval)"
+            )
+        if key == "weights" and isinstance(value, dict):
+            weights_base = _cfg_to_dict(getattr(retrieval_cfg, "weights", {}))
+            for wk in value:
+                if wk not in weights_base:
+                    raise ValueError(f"Unknown retrieval key: weights.{wk}")
+
+
+def _cfg_to_dict(cfg_or_dict: Any) -> dict[str, Any]:
+    if hasattr(cfg_or_dict, "to_dict"):
+        return cfg_or_dict.to_dict()
+    if isinstance(cfg_or_dict, dict):
+        return cfg_or_dict
+    return dict(vars(cfg_or_dict))
+
+
+# ---------------------------------------------------------------------------
+# Atomic JSON write
+# ---------------------------------------------------------------------------
+
+
+def atomic_write_json(path: str | Path, payload: dict[str, Any]) -> None:
+    """Atomically replace ``path`` with a JSON dump of ``payload``.
+
+    The tmp file is created in the same directory (same filesystem) so
+    ``os.replace`` is atomic on POSIX. Permissions are restricted to the
+    owner and ``fsync`` is called before the rename so a power loss after
+    rename still yields a durable, valid file.
+    """
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    tmp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=target.parent,
+            prefix=target.stem + ".",
+            suffix=".tmp",
+            delete=False,
+        ) as tmp:
+            tmp_path = Path(tmp.name)
+            os.chmod(tmp.name, 0o600)
+            json.dump(payload, tmp, indent=2, ensure_ascii=False)
+            tmp.flush()
+            os.fsync(tmp.fileno())
+        tmp_path.replace(target)
+        tmp_path = None
+    finally:
+        if tmp_path is not None and tmp_path.exists():
+            try:
+                tmp_path.unlink()
+            except OSError:
+                logger.warning("Failed to clean up tmp file %s", tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Markdown report
+# ---------------------------------------------------------------------------
+
+
+def write_markdown_report(
+    state: dict[str, Any],
+    best: ConfigResult,
+    out_path: str | Path,
+) -> None:
+    """Render a Markdown summary of all configs with best highlighted."""
+    target = Path(out_path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    lines: list[str] = []
+    lines.append("# Retrieval Grid Search Report")
+    lines.append("")
+    lines.append(f"- Base config: `{state.get('base_config_path', '')}`")
+    lines.append(f"- Phase: `{state.get('phase', '')}`")
+    lines.append(
+        f"- Max questions per config: {state.get('max_questions_per_config', '')}"
+    )
+    lines.append(f"- Started at: {state.get('started_at', '')}")
+    lines.append(f"- Completed at: {state.get('completed_at', '')}")
+    lines.append(f"- Total configs: {len(state.get('configs', []))}")
+    lines.append("")
+
+    lines.append("## Best Config")
+    lines.append("")
+    lines.append(
+        f"- **config_idx**: {best.config_idx}  "
+        f"(lexical_top_k={best.params.lexical_top_k}, "
+        f"embedding_top_k={best.params.embedding_top_k}, "
+        f"fused_top_k={best.params.fused_top_k}, "
+        f"rerank_top_k={best.params.rerank_top_k}, "
+        f"weights_lexical={best.params.weights_lexical}, "
+        f"weights_embedding={best.params.weights_embedding})"
+    )
+    lines.append(
+        f"- **raw no_citation_rate**: {best.raw_no_citation_rate:.2%} "
+        f"({best.n_no_citation}/{best.n_questions})"
+    )
+    lines.append(f"- **true_nc_rate**: {best.true_nc_rate:.2%}")
+    lines.append(f"- **wrong_citation_count**: {best.wrong_citation_count}")
+    lines.append(f"- **latency_p50_ms**: {best.latency_p50_ms:.0f}")
+    lines.append(f"- **latency_p95_ms**: {best.latency_p95_ms:.0f}")
+    lines.append(f"- **duration_seconds**: {best.duration_seconds:.1f}")
+    lines.append("")
+
+    lines.append("## All Configs")
+    lines.append("")
+    lines.append(
+        "| idx | lex | emb | fused | rerank | w_lex | w_emb | "
+        "raw NC | true NC | p50 ms | p95 ms | wrong |"
+    )
+    lines.append(
+        "|-----|-----|-----|-------|--------|-------|-------|"
+        "--------|---------|--------|--------|-------|"
+    )
+    for entry in state.get("configs", []):
+        params = entry.get("params", {})
+        weights = params.get("weights", {})
+        lines.append(
+            "| {idx} | {lex} | {emb} | {fused} | {rerank} | "
+            "{wl:.2f} | {we:.2f} | {raw:.2%} | {true_nc} | "
+            "{p50:.0f} | {p95:.0f} | {wrong} |".format(
+                idx=entry.get("config_idx", ""),
+                lex=params.get("lexical_top_k", ""),
+                emb=params.get("embedding_top_k", ""),
+                fused=params.get("fused_top_k", ""),
+                rerank=params.get("rerank_top_k", ""),
+                wl=float(weights.get("lexical", 0.0)),
+                we=float(weights.get("embedding", 0.0)),
+                raw=entry.get("raw_no_citation_rate", 0.0),
+                true_nc=_format_pct_or_dash(entry.get("true_nc_rate")),
+                p50=entry.get("latency_p50_ms", 0.0),
+                p95=entry.get("latency_p95_ms", 0.0),
+                wrong=entry.get("wrong_citation_count", 0),
+            )
+        )
+
+    lines.append("")
+    target.write_text("\n".join(lines), encoding="utf-8")
+
+
+def _format_pct_or_dash(value: Any) -> str:
+    if value is None:
+        return "-"
+    try:
+        return f"{float(value):.2%}"
+    except (TypeError, ValueError):
+        return "-"

--- a/scripts/retrieval_grid_search.py
+++ b/scripts/retrieval_grid_search.py
@@ -1,0 +1,523 @@
+"""Retrieval parameter grid-search driver (Issue #88).
+
+Sweeps ``configs/baseline.yaml`` ``retrieval.*`` parameters in a single
+process, reusing one loaded pipeline across all configs. Writes per-config
+progress to ``reports/retrieval_grid_search.json`` atomically and renders
+``reports/retrieval_grid_search.md`` at the end.
+
+See ``workspace/design/issue-88-retrieval-grid-search-design-policy.md``
+for the full design rationale. The pure-function helpers live in
+``scripts/_grid_search_core`` and are unit-tested without MLX.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import signal
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from types import FrameType
+from typing import TYPE_CHECKING, Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts._grid_search_core import (  # noqa: E402
+    ConfigParams,
+    ConfigResult,
+    aggregate_metrics,
+    atomic_write_json,
+    generate_phase1_grid,
+    generate_phase2_grid,
+    validate_override,
+    write_markdown_report,
+)
+
+if TYPE_CHECKING:
+    from baseline_reporag.config import Config
+    from baseline_reporag.pipeline import RepoRAGPipeline
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# CLI parsing + path validation
+# ---------------------------------------------------------------------------
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Retrieval parameter grid search (Issue #88)."
+    )
+    parser.add_argument("--config", default="configs/baseline.yaml")
+    parser.add_argument("--eval-set", default="data/eval_sets/static_eval.jsonl")
+    parser.add_argument("--phase", choices=["1", "2", "both"], default="both")
+    parser.add_argument("--max-questions", type=int, default=40)
+    parser.add_argument("--output-dir", default="reports")
+    parser.add_argument("--logs-dir", default="logs")
+    parser.add_argument("--resume", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--top-n-for-phase2", type=int, default=5)
+    parser.add_argument("--phase2-topk-delta", type=int, default=5)
+    parser.add_argument("--phase2-weight-delta", type=float, default=0.05)
+    return parser.parse_args(argv)
+
+
+def _repo_relative(p: str | Path) -> Path:
+    """Resolve ``p`` and assert it stays under ``REPO_ROOT``.
+
+    Rejects absolute paths, ``..`` traversal, and symlink escapes. The
+    grid-search tool is trusted-operator-only; this guard exists to keep
+    an accidental ``--config /etc/shadow`` from reaching ``pickle.load``.
+    """
+    raw = Path(p)
+    if raw.is_absolute():
+        raise SystemExit(f"error: path must be repo-relative, got absolute: {p!r}")
+    resolved = (REPO_ROOT / raw).resolve()
+    try:
+        resolved.relative_to(REPO_ROOT.resolve())
+    except ValueError as exc:
+        raise SystemExit(f"error: path escapes repo root: {p!r}") from exc
+    return resolved
+
+
+def _validate_paths(args: argparse.Namespace) -> None:
+    _repo_relative(args.config)
+    _repo_relative(args.eval_set)
+    _repo_relative(args.output_dir)
+    _repo_relative(args.logs_dir)
+
+
+# ---------------------------------------------------------------------------
+# Pipeline build + eval helpers
+# ---------------------------------------------------------------------------
+
+
+def build_pipeline_for_sweep(
+    base_cfg: Config,
+    scratch_log_root: Path,
+) -> "RepoRAGPipeline":
+    """Load a single pipeline instance, pointing scratch logs to *scratch_log_root*."""
+    from baseline_reporag.pipeline_factory import build_pipeline
+
+    scratch_log_root.mkdir(parents=True, exist_ok=True)
+    sweep_cfg = base_cfg.merge_override({"paths": {"log_root": str(scratch_log_root)}})
+    return build_pipeline(sweep_cfg)  # type: ignore[return-value]
+
+
+def load_questions(path: Path, max_questions: int) -> list[dict[str, Any]]:
+    questions: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            questions.append(json.loads(line))
+    if max_questions > 0:
+        questions = questions[:max_questions]
+    return questions
+
+
+def unanswerable_ids_from(questions: list[dict[str, Any]]) -> set[str]:
+    return {q["id"] for q in questions if q.get("answerable") is False}
+
+
+def run_eval_inproc(
+    pipeline: "RepoRAGPipeline",
+    questions: list[dict[str, Any]],
+    *,
+    config_idx: int,
+    repo_id: str,
+) -> list[dict[str, Any]]:
+    """Run ``pipeline.query`` once per question, collect citation records.
+
+    Each question uses ``session_id = f"grid-{config_idx}-{q['id']}"`` to
+    keep session history from leaking across configs.
+    """
+    records: list[dict[str, Any]] = []
+    for q in questions:
+        result = pipeline.query(
+            question=q["question"],
+            session_id=f"grid-{config_idx}-{q['id']}",
+            repo_id=repo_id,
+        )
+        latency_ms = float(getattr(result.latency, "total_ms", 0.0))
+        memory_peak = float(getattr(result.memory, "peak_mb", 0.0))
+        records.append(
+            {
+                "eval_id": q["id"],
+                "no_citation": bool(result.no_citation),
+                "wrong_citation_indices": list(result.wrong_citation_indices or []),
+                "latency_ms": latency_ms,
+                "memory_peak_mb": memory_peak,
+            }
+        )
+    return records
+
+
+# ---------------------------------------------------------------------------
+# Sweep loop + resume + atomic write
+# ---------------------------------------------------------------------------
+
+
+def _params_key(params: ConfigParams) -> str:
+    return json.dumps(params.to_override_dict(), sort_keys=True)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).astimezone().isoformat()
+
+
+def _load_state(state_path: Path) -> dict[str, Any] | None:
+    if not state_path.exists():
+        return None
+    try:
+        return json.loads(state_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        logger.warning("Could not read existing state at %s", state_path)
+        return None
+
+
+def _build_config_result(
+    config_idx: int,
+    params: ConfigParams,
+    records: list[dict[str, Any]],
+    metrics: dict[str, Any],
+    started_at: str,
+    completed_at: str,
+    duration_seconds: float,
+) -> ConfigResult:
+    memory_peaks = [
+        r.get("memory_peak_mb", 0.0)
+        for r in records
+        if r.get("memory_peak_mb") is not None
+    ]
+    peak = max(memory_peaks) if memory_peaks else None
+    return ConfigResult(
+        config_idx=config_idx,
+        params=params,
+        raw_no_citation_rate=float(metrics.get("no_citation_rate", 0.0)),
+        true_nc_rate=float(metrics.get("true_nc_rate", 0.0) or 0.0),
+        wrong_citation_count=int(metrics.get("wrong_citation_count", 0)),
+        latency_p50_ms=float(metrics.get("latency_p50", 0.0)),
+        latency_p95_ms=float(metrics.get("latency_p95", 0.0)),
+        n_questions=int(metrics.get("n_questions", len(records))),
+        n_no_citation=int(metrics.get("n_no_citation", 0)),
+        duration_seconds=duration_seconds,
+        started_at=started_at,
+        completed_at=completed_at,
+        memory_peak_mb=peak,
+    )
+
+
+class _InterruptedError(BaseException):
+    """Raised when a signal handler requests graceful shutdown."""
+
+
+def _install_signal_handlers(flag: dict[str, bool]) -> None:
+    def _handler(signum: int, _frame: FrameType | None) -> None:
+        logger.warning("Received signal %s, flushing and exiting.", signum)
+        flag["stop"] = True
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        try:
+            signal.signal(sig, _handler)
+        except (ValueError, OSError):
+            # SIGTERM not available on every platform / thread context.
+            pass
+
+
+def run_phase(
+    base_cfg: Config,
+    grid: list[ConfigParams],
+    *,
+    questions: list[dict[str, Any]],
+    unanswerable_ids: set[str],
+    pipeline: "RepoRAGPipeline",
+    state_path: Path,
+    resume: bool,
+    phase_name: str,
+    repo_id: str,
+    stop_flag: dict[str, bool],
+) -> list[ConfigResult]:
+    """Execute one phase of the sweep, atomically persisting per-config state."""
+    state: dict[str, Any]
+    existing = _load_state(state_path) if resume else None
+    if existing and resume:
+        state = existing
+    else:
+        state = {
+            "phase": phase_name,
+            "base_config_path": getattr(base_cfg, "_config_path", ""),
+            "max_questions_per_config": len(questions),
+            "started_at": _now_iso(),
+            "completed_at": "",
+            "configs": [],
+            "status": "running",
+        }
+
+    done_keys = {
+        json.dumps(c.get("params", {}), sort_keys=True)
+        for c in state.get("configs", [])
+    }
+
+    results: list[ConfigResult] = []
+    total = len(grid)
+    sweep_start = time.perf_counter()
+
+    for idx, params in enumerate(grid):
+        if stop_flag.get("stop"):
+            state["status"] = "interrupted"
+            state["interrupted_at"] = _now_iso()
+            atomic_write_json(state_path, state)
+            raise _InterruptedError("interrupted by signal")
+
+        key = _params_key(params)
+        if resume and key in done_keys:
+            logger.info(
+                "[%s] skipping already-completed config %d/%d",
+                phase_name,
+                idx + 1,
+                total,
+            )
+            continue
+
+        started_at = _now_iso()
+        t0 = time.perf_counter()
+        logger.info(
+            "[%s] [Config %d/%d] starting params=%s",
+            phase_name,
+            idx + 1,
+            total,
+            params.to_override_dict(),
+        )
+
+        cfg2 = base_cfg.merge_override({"retrieval": params.to_override_dict()})
+        pipeline.cfg = cfg2  # type: ignore[attr-defined]
+
+        try:
+            records = run_eval_inproc(
+                pipeline, questions, config_idx=idx, repo_id=repo_id
+            )
+        except KeyboardInterrupt:
+            state["status"] = "interrupted"
+            state["interrupted_at"] = _now_iso()
+            atomic_write_json(state_path, state)
+            raise
+
+        metrics = aggregate_metrics(records, unanswerable_ids)
+        duration = time.perf_counter() - t0
+        completed_at = _now_iso()
+        result = _build_config_result(
+            idx, params, records, metrics, started_at, completed_at, duration
+        )
+        results.append(result)
+
+        state["configs"].append(result.to_json())
+        state["completed_at"] = completed_at
+        done_keys.add(key)
+        atomic_write_json(state_path, state)
+
+        elapsed = time.perf_counter() - sweep_start
+        logger.info(
+            "[%s] [Config %d/%d] NC=%.1f%% (%d/%d) p50=%.0fms elapsed=%.1fs",
+            phase_name,
+            idx + 1,
+            total,
+            100.0 * result.raw_no_citation_rate,
+            result.n_no_citation,
+            result.n_questions,
+            result.latency_p50_ms,
+            elapsed,
+        )
+
+    state["status"] = f"{phase_name}_complete"
+    state["completed_at"] = _now_iso()
+    atomic_write_json(state_path, state)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Best config selection + phase 2 gating
+# ---------------------------------------------------------------------------
+
+
+def pick_best(results: list[ConfigResult]) -> ConfigResult | None:
+    if not results:
+        return None
+    return min(
+        results,
+        key=lambda r: (r.raw_no_citation_rate, r.latency_p50_ms),
+    )
+
+
+def top_n(results: list[ConfigResult], n: int) -> list[ConfigResult]:
+    return sorted(results, key=lambda r: (r.raw_no_citation_rate, r.latency_p50_ms))[:n]
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    args = _parse_args(argv)
+    _validate_paths(args)
+
+    config_path = _repo_relative(args.config)
+    eval_set_path = _repo_relative(args.eval_set)
+    output_dir = _repo_relative(args.output_dir)
+    logs_dir = _repo_relative(args.logs_dir)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    logs_dir.mkdir(parents=True, exist_ok=True)
+
+    from baseline_reporag.config import load_config
+
+    base_cfg = load_config(config_path)
+    repo_id = base_cfg.repo.repo_id
+
+    phase1_grid = generate_phase1_grid()
+    for params in phase1_grid:
+        validate_override(base_cfg, params)
+
+    logger.info("Phase 1 grid: %d configs", len(phase1_grid))
+
+    if args.dry_run:
+        _print_dry_run(phase1_grid)
+        return 0
+
+    questions = load_questions(eval_set_path, args.max_questions)
+    unanswerable = unanswerable_ids_from(questions)
+    logger.info(
+        "Loaded %d questions (unanswerable: %d)", len(questions), len(unanswerable)
+    )
+
+    scratch_root = logs_dir / "grid_search_scratch"
+    pipeline = build_pipeline_for_sweep(base_cfg, scratch_root)
+
+    state_path = output_dir / "retrieval_grid_search.json"
+    report_path = output_dir / "retrieval_grid_search.md"
+
+    stop_flag: dict[str, bool] = {"stop": False}
+    _install_signal_handlers(stop_flag)
+
+    all_results: list[ConfigResult] = []
+
+    try:
+        if args.phase in ("1", "both"):
+            phase1_results = run_phase(
+                base_cfg,
+                phase1_grid,
+                questions=questions,
+                unanswerable_ids=unanswerable,
+                pipeline=pipeline,
+                state_path=state_path,
+                resume=args.resume,
+                phase_name="phase1",
+                repo_id=repo_id,
+                stop_flag=stop_flag,
+            )
+            all_results.extend(phase1_results)
+
+        if args.phase in ("2", "both"):
+            seeds_source = all_results or _reload_results_from_state(state_path)
+            seeds = [r.params for r in top_n(seeds_source, args.top_n_for_phase2)]
+            if not seeds:
+                logger.warning("No Phase 1 seeds available; skipping Phase 2.")
+            else:
+                best_so_far = pick_best(seeds_source)
+                if (
+                    args.phase == "both"
+                    and best_so_far is not None
+                    and best_so_far.raw_no_citation_rate > 0.18
+                ):
+                    logger.warning(
+                        "Phase 1 best NC=%.1f%% > 18%%; skipping Phase 2.",
+                        100.0 * best_so_far.raw_no_citation_rate,
+                    )
+                else:
+                    phase2_grid = generate_phase2_grid(
+                        seeds,
+                        topk_delta=args.phase2_topk_delta,
+                        weight_delta=args.phase2_weight_delta,
+                    )
+                    logger.info(
+                        "Phase 2 grid: %d configs around top-%d seeds",
+                        len(phase2_grid),
+                        len(seeds),
+                    )
+                    phase2_results = run_phase(
+                        base_cfg,
+                        phase2_grid,
+                        questions=questions,
+                        unanswerable_ids=unanswerable,
+                        pipeline=pipeline,
+                        state_path=state_path,
+                        resume=args.resume,
+                        phase_name="phase2",
+                        repo_id=repo_id,
+                        stop_flag=stop_flag,
+                    )
+                    all_results.extend(phase2_results)
+    except _InterruptedError:
+        logger.warning("Sweep interrupted; partial state preserved in %s", state_path)
+        return 130
+
+    final_state = _load_state(state_path) or {}
+    all_config_results = _reload_results_from_state(state_path)
+    best = pick_best(all_config_results)
+    if best is not None:
+        write_markdown_report(final_state, best, report_path)
+        logger.info(
+            "Best config: idx=%d raw_nc=%.2f%% p50=%.0fms",
+            best.config_idx,
+            100.0 * best.raw_no_citation_rate,
+            best.latency_p50_ms,
+        )
+    else:
+        logger.warning("No results available; Markdown report not written.")
+    return 0
+
+
+def _reload_results_from_state(state_path: Path) -> list[ConfigResult]:
+    state = _load_state(state_path)
+    if not state:
+        return []
+    out: list[ConfigResult] = []
+    for entry in state.get("configs", []):
+        params = ConfigParams.from_dict(entry.get("params", {}))
+        out.append(
+            ConfigResult(
+                config_idx=int(entry.get("config_idx", 0)),
+                params=params,
+                raw_no_citation_rate=float(entry.get("raw_no_citation_rate", 0.0)),
+                true_nc_rate=float(entry.get("true_nc_rate", 0.0) or 0.0),
+                wrong_citation_count=int(entry.get("wrong_citation_count", 0)),
+                latency_p50_ms=float(entry.get("latency_p50_ms", 0.0)),
+                latency_p95_ms=float(entry.get("latency_p95_ms", 0.0)),
+                n_questions=int(entry.get("n_questions", 0)),
+                n_no_citation=int(entry.get("n_no_citation", 0)),
+                duration_seconds=float(entry.get("duration_seconds", 0.0)),
+                started_at=str(entry.get("started_at", "")),
+                completed_at=str(entry.get("completed_at", "")),
+                memory_peak_mb=entry.get("memory_peak_mb"),
+            )
+        )
+    return out
+
+
+def _print_dry_run(grid: list[ConfigParams]) -> None:
+    print(f"Phase 1 grid contains {len(grid)} configs:")
+    for idx, params in enumerate(grid):
+        print(f"  [{idx:2d}] {json.dumps(params.to_override_dict(), sort_keys=True)}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_retrieval_grid_search.py
+++ b/tests/test_retrieval_grid_search.py
@@ -1,0 +1,523 @@
+"""Unit tests for scripts/_grid_search_core (Issue #88).
+
+Covers the pure-function grid search core module per design §7.1:
+ConfigParams / ConfigResult, grid generation, invalid-combo filtering,
+metric aggregation pinned against ci_eval_check.check_static, and
+override validation.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts._grid_search_core import (  # noqa: E402
+    ConfigParams,
+    ConfigResult,
+    aggregate_metrics,
+    atomic_write_json,
+    generate_phase1_grid,
+    generate_phase2_grid,
+    is_invalid_combo,
+    validate_override,
+    write_markdown_report,
+)
+
+
+# ---------------------------------------------------------------------------
+# ConfigParams / ConfigResult
+# ---------------------------------------------------------------------------
+
+
+def _sample_params(**overrides: object) -> ConfigParams:
+    base = dict(
+        lexical_top_k=20,
+        embedding_top_k=20,
+        fused_top_k=16,
+        rerank_top_k=12,
+        weights_lexical=0.45,
+        weights_embedding=0.45,
+    )
+    base.update(overrides)
+    return ConfigParams(**base)  # type: ignore[arg-type]
+
+
+def test_config_params_to_override_dict() -> None:
+    params = _sample_params()
+    override = params.to_override_dict()
+
+    assert override["lexical_top_k"] == 20
+    assert override["embedding_top_k"] == 20
+    assert override["fused_top_k"] == 16
+    assert override["rerank_top_k"] == 12
+    assert override["weights"] == {"lexical": 0.45, "embedding": 0.45}
+
+
+def test_config_params_roundtrip() -> None:
+    original = _sample_params(weights_lexical=0.55, weights_embedding=0.35)
+    restored = ConfigParams.from_dict(original.to_override_dict())
+    assert restored == original
+
+
+def test_config_result_to_json_uses_ms_suffix() -> None:
+    params = _sample_params()
+    result = ConfigResult(
+        config_idx=3,
+        params=params,
+        raw_no_citation_rate=0.175,
+        true_nc_rate=0.16,
+        wrong_citation_count=1,
+        latency_p50_ms=19500.0,
+        latency_p95_ms=28000.0,
+        n_questions=40,
+        n_no_citation=7,
+        duration_seconds=780.5,
+        started_at="2026-04-22T10:01:00+09:00",
+        completed_at="2026-04-22T10:14:00+09:00",
+    )
+    j = result.to_json()
+    assert j["config_idx"] == 3
+    assert j["latency_p50_ms"] == 19500.0
+    assert j["latency_p95_ms"] == 28000.0
+    assert j["params"] == params.to_override_dict()
+
+
+# ---------------------------------------------------------------------------
+# is_invalid_combo
+# ---------------------------------------------------------------------------
+
+
+def test_is_invalid_combo_rerank_exceeds_fused() -> None:
+    p = _sample_params(fused_top_k=16, rerank_top_k=20)
+    assert is_invalid_combo(p) is True
+
+
+def test_is_invalid_combo_non_positive_topk() -> None:
+    p = _sample_params(lexical_top_k=0)
+    assert is_invalid_combo(p) is True
+
+
+def test_is_invalid_combo_weights_sum_overflow() -> None:
+    p = _sample_params(weights_lexical=0.55, weights_embedding=0.55)
+    assert is_invalid_combo(p) is True
+
+
+def test_is_invalid_combo_known_cases() -> None:
+    assert (
+        is_invalid_combo(
+            _sample_params(
+                lexical_top_k=15,
+                embedding_top_k=15,
+                fused_top_k=20,
+                rerank_top_k=16,
+            )
+        )
+        is True
+    )
+    assert is_invalid_combo(_sample_params()) is False
+
+
+def test_is_invalid_combo_weights_sum_exactly_0_90_is_valid() -> None:
+    p = _sample_params(weights_lexical=0.55, weights_embedding=0.35)
+    assert is_invalid_combo(p) is False
+
+
+# ---------------------------------------------------------------------------
+# generate_phase1_grid
+# ---------------------------------------------------------------------------
+
+
+def test_generate_phase1_grid_count() -> None:
+    grid = generate_phase1_grid()
+    assert len(grid) == 24
+
+
+def test_phase1_grid_no_invalid_combos() -> None:
+    for params in generate_phase1_grid():
+        assert not is_invalid_combo(params), params
+
+
+def test_phase1_grid_unique_configs() -> None:
+    grid = generate_phase1_grid()
+    seen = {json.dumps(p.to_override_dict(), sort_keys=True) for p in grid}
+    assert len(seen) == len(grid)
+
+
+# ---------------------------------------------------------------------------
+# generate_phase2_grid
+# ---------------------------------------------------------------------------
+
+
+def test_phase2_neighborhood_dedup() -> None:
+    seeds = [
+        _sample_params(),
+        _sample_params(),
+    ]
+    grid = generate_phase2_grid(seeds)
+    seen = {json.dumps(p.to_override_dict(), sort_keys=True) for p in grid}
+    assert len(seen) == len(grid)
+
+
+def test_phase2_no_invalid_combos() -> None:
+    seeds = [_sample_params()]
+    for p in generate_phase2_grid(seeds):
+        assert not is_invalid_combo(p), p
+
+
+def test_phase2_excludes_seed_itself() -> None:
+    seed = _sample_params()
+    grid = generate_phase2_grid([seed])
+    seed_key = json.dumps(seed.to_override_dict(), sort_keys=True)
+    keys = {json.dumps(p.to_override_dict(), sort_keys=True) for p in grid}
+    assert seed_key not in keys
+
+
+# ---------------------------------------------------------------------------
+# aggregate_metrics (pin against scripts.ci_eval_check.check_static)
+# ---------------------------------------------------------------------------
+
+
+def _sample_records() -> list[dict]:
+    return [
+        {
+            "eval_id": "SE-001",
+            "no_citation": False,
+            "wrong_citation_indices": [],
+            "latency_ms": 10_000.0,
+        },
+        {
+            "eval_id": "SE-002",
+            "no_citation": True,
+            "wrong_citation_indices": [],
+            "latency_ms": 20_000.0,
+        },
+        {
+            "eval_id": "SE-003",
+            "no_citation": False,
+            "wrong_citation_indices": [2],
+            "latency_ms": 30_000.0,
+        },
+        {
+            "eval_id": "SE-UA-001",
+            "no_citation": True,
+            "wrong_citation_indices": [],
+            "latency_ms": 5_000.0,
+        },
+    ]
+
+
+def test_aggregate_metrics_matches_ci_eval_check(tmp_path: Path) -> None:
+    from scripts.ci_eval_check import check_static
+
+    records = _sample_records()
+    unanswerable_ids = {"SE-UA-001"}
+
+    metrics = aggregate_metrics(records, unanswerable_ids)
+
+    log_path = tmp_path / "fake.jsonl"
+    with open(log_path, "w", encoding="utf-8") as f:
+        for r in records:
+            f.write(json.dumps(r) + "\n")
+    ref = check_static(str(log_path), unanswerable_ids=unanswerable_ids)
+
+    assert metrics["no_citation_rate"] == pytest.approx(ref["no_citation_rate"])
+    assert metrics["wrong_citation_count"] == ref["wrong_citation_count"]
+    assert metrics["latency_p50"] == pytest.approx(ref["latency_p50"])
+    assert metrics["true_nc_rate"] == pytest.approx(ref["true_nc_rate"])
+
+
+def test_aggregate_metrics_p50_calculation() -> None:
+    records = _sample_records()
+    metrics = aggregate_metrics(records, unanswerable_ids=set())
+    expected_p50 = statistics.median([r["latency_ms"] for r in records])
+    assert metrics["latency_p50"] == pytest.approx(expected_p50)
+
+
+def test_aggregate_metrics_no_true_nc_when_empty_unanswerable() -> None:
+    records = _sample_records()
+    metrics = aggregate_metrics(records, unanswerable_ids=set())
+    assert "true_nc_rate" not in metrics
+
+
+def test_aggregate_metrics_counts_wrong_citation_records() -> None:
+    records = _sample_records()
+    metrics = aggregate_metrics(records, unanswerable_ids=set())
+    # ci_eval_check counts records with non-empty wrong_citation_indices.
+    assert metrics["wrong_citation_count"] == 1
+
+
+def test_aggregate_metrics_latency_p95() -> None:
+    records = _sample_records()
+    metrics = aggregate_metrics(records, unanswerable_ids=set())
+    # p95 of 4 points = index min(len-1, ceil(.95 * len) - 1) = 3
+    assert metrics["latency_p95"] == pytest.approx(30_000.0)
+
+
+# ---------------------------------------------------------------------------
+# validate_override
+# ---------------------------------------------------------------------------
+
+
+def _load_base_cfg():  # type: ignore[no-untyped-def]
+    from baseline_reporag.config import load_config
+
+    return load_config(REPO_ROOT / "configs" / "baseline.yaml")
+
+
+def test_validate_override_rejects_unknown_key() -> None:
+    base_cfg = _load_base_cfg()
+    bad = _sample_params()
+    # Patch override dict to include a typo'd key by wrapping in a subclass
+    # that returns a custom dict. validate_override must inspect the dict.
+
+    class _BadParams(ConfigParams):
+        def to_override_dict(self) -> dict:  # type: ignore[override]
+            d = super().to_override_dict()
+            d["lexcial_top_k"] = 20  # intentional typo
+            return d
+
+    bad_typed = _BadParams(
+        lexical_top_k=bad.lexical_top_k,
+        embedding_top_k=bad.embedding_top_k,
+        fused_top_k=bad.fused_top_k,
+        rerank_top_k=bad.rerank_top_k,
+        weights_lexical=bad.weights_lexical,
+        weights_embedding=bad.weights_embedding,
+    )
+    with pytest.raises(ValueError, match="Unknown retrieval key"):
+        validate_override(base_cfg, bad_typed)
+
+
+def test_validate_override_passes_valid_params() -> None:
+    base_cfg = _load_base_cfg()
+    params = _sample_params()
+    validate_override(base_cfg, params)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# merge_override preserves sibling keys (D2-a / D3 pin)
+# ---------------------------------------------------------------------------
+
+
+def test_merge_override_preserves_reranker() -> None:
+    base_cfg = _load_base_cfg()
+    params = _sample_params()
+    cfg2 = base_cfg.merge_override({"retrieval": params.to_override_dict()})
+    assert cfg2.retrieval.reranker.enabled is True
+
+
+def test_merge_override_preserves_graph_weight() -> None:
+    base_cfg = _load_base_cfg()
+    params = _sample_params()
+    cfg2 = base_cfg.merge_override({"retrieval": params.to_override_dict()})
+    assert cfg2.retrieval.weights.graph == pytest.approx(0.10)
+
+
+# ---------------------------------------------------------------------------
+# atomic_write_json
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_json_writes_content(tmp_path: Path) -> None:
+    target = tmp_path / "state.json"
+    payload = {"configs": [{"config_idx": 0}], "phase": "phase1"}
+    atomic_write_json(target, payload)
+    assert target.exists()
+    assert json.loads(target.read_text(encoding="utf-8")) == payload
+
+
+def test_atomic_write_json_replaces_existing(tmp_path: Path) -> None:
+    target = tmp_path / "state.json"
+    target.write_text('{"stale": true}', encoding="utf-8")
+    payload = {"fresh": True}
+    atomic_write_json(target, payload)
+    assert json.loads(target.read_text(encoding="utf-8")) == payload
+
+
+def test_atomic_write_json_no_tmp_leftover(tmp_path: Path) -> None:
+    target = tmp_path / "state.json"
+    atomic_write_json(target, {"ok": True})
+    leftovers = [p for p in tmp_path.iterdir() if p.name.endswith(".tmp")]
+    assert leftovers == []
+
+
+def test_atomic_write_json_chmod_owner_only(tmp_path: Path) -> None:
+    target = tmp_path / "state.json"
+    atomic_write_json(target, {"ok": True})
+    mode = target.stat().st_mode & 0o777
+    # Owner-only permissions: no group / world access.
+    assert mode & 0o077 == 0
+
+
+# ---------------------------------------------------------------------------
+# write_markdown_report
+# ---------------------------------------------------------------------------
+
+
+def test_write_markdown_report_renders_best_config(tmp_path: Path) -> None:
+    params = _sample_params()
+    best = ConfigResult(
+        config_idx=0,
+        params=params,
+        raw_no_citation_rate=0.125,
+        true_nc_rate=0.10,
+        wrong_citation_count=0,
+        latency_p50_ms=19000.0,
+        latency_p95_ms=27000.0,
+        n_questions=40,
+        n_no_citation=5,
+        duration_seconds=780.0,
+        started_at="2026-04-22T10:00:00+09:00",
+        completed_at="2026-04-22T10:13:00+09:00",
+    )
+    state = {
+        "phase": "both",
+        "base_config_path": "configs/baseline.yaml",
+        "max_questions_per_config": 40,
+        "started_at": "2026-04-22T10:00:00+09:00",
+        "completed_at": "2026-04-22T10:13:00+09:00",
+        "configs": [best.to_json()],
+    }
+    out = tmp_path / "report.md"
+    write_markdown_report(state, best, out)
+
+    text = out.read_text(encoding="utf-8")
+    assert "# Retrieval Grid Search" in text
+    assert "12.50%" in text  # raw NC as %
+    assert "lexical_top_k=20" in text or "lexical_top_k: 20" in text
+
+
+# ---------------------------------------------------------------------------
+# resume skip (state helper used by run_phase)
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_json_survives_partial_write(tmp_path: Path) -> None:
+    # Write once, verify, then overwrite and verify again. The tmp+replace
+    # pattern guarantees the reader either sees the old or the new file,
+    # never a truncated one. We can't simulate a real crash inside a unit
+    # test, but we can assert the contract's key property: after a
+    # successful call the file is always valid JSON.
+    target = tmp_path / "state.json"
+    atomic_write_json(target, {"n": 1})
+    assert json.loads(target.read_text(encoding="utf-8")) == {"n": 1}
+    atomic_write_json(target, {"n": 2, "nested": {"x": "y"}})
+    assert json.loads(target.read_text(encoding="utf-8")) == {
+        "n": 2,
+        "nested": {"x": "y"},
+    }
+    # No leftover temp files in the directory.
+    assert [p.name for p in tmp_path.iterdir()] == ["state.json"]
+
+
+# ---------------------------------------------------------------------------
+# Misc: atomic_write_json dir must exist
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_json_creates_parent(tmp_path: Path) -> None:
+    target = tmp_path / "sub" / "nested" / "state.json"
+    atomic_write_json(target, {"ok": True})
+    assert target.exists()
+
+
+# ---------------------------------------------------------------------------
+# Sanity: is_invalid_combo boundary fused_top_k == 15
+# ---------------------------------------------------------------------------
+
+
+def test_is_invalid_combo_fused_19_below_threshold() -> None:
+    # (15,15,19,?) is NOT filtered by condition (4); only fused>=20 triggers.
+    p = _sample_params(
+        lexical_top_k=15,
+        embedding_top_k=15,
+        fused_top_k=19,
+        rerank_top_k=12,
+    )
+    assert is_invalid_combo(p) is False
+
+
+# ---------------------------------------------------------------------------
+# Ensure tempfile clean-up survives a filesystem where dir is read-only.
+# (Guard: we only check non-hostile case; hostile case tested via exception.)
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_json_fsync_called(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[int] = []
+    real_fsync = os.fsync
+
+    def _fake_fsync(fd: int) -> None:
+        calls.append(fd)
+        real_fsync(fd)
+
+    monkeypatch.setattr(os, "fsync", _fake_fsync)
+    atomic_write_json(tmp_path / "x.json", {"ok": True})
+    assert calls, "os.fsync must be invoked before rename"
+
+
+# ---------------------------------------------------------------------------
+# Misc: atomic_write_json with pathlib.Path and str both accepted.
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_json_accepts_str_path(tmp_path: Path) -> None:
+    target = tmp_path / "x.json"
+    atomic_write_json(str(target), {"ok": True})  # type: ignore[arg-type]
+    assert json.loads(target.read_text(encoding="utf-8")) == {"ok": True}
+
+
+# ---------------------------------------------------------------------------
+# Regression: ConfigParams is hashable (used as dict key / set).
+# ---------------------------------------------------------------------------
+
+
+def test_config_params_is_hashable() -> None:
+    s = {_sample_params(), _sample_params(lexical_top_k=25)}
+    assert len(s) == 2
+
+
+# ---------------------------------------------------------------------------
+# Smoke: Phase 2 without any seeds returns empty grid.
+# ---------------------------------------------------------------------------
+
+
+def test_phase2_empty_seeds_returns_empty() -> None:
+    assert generate_phase2_grid([]) == []
+
+
+# ---------------------------------------------------------------------------
+# Smoke: tempfile is placed in target dir, not /tmp.
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_json_tmp_in_same_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    tmp_paths: list[str] = []
+
+    real_ntf = tempfile.NamedTemporaryFile
+
+    def _fake_ntf(*args: object, **kwargs: object):  # type: ignore[no-untyped-def]
+        f = real_ntf(*args, **kwargs)
+        tmp_paths.append(f.name)
+        return f
+
+    monkeypatch.setattr(tempfile, "NamedTemporaryFile", _fake_ntf)
+
+    target = tmp_path / "x.json"
+    atomic_write_json(target, {"ok": True})
+    assert tmp_paths, "atomic_write_json must use NamedTemporaryFile"
+    assert Path(tmp_paths[0]).parent == target.parent

--- a/tests/test_retrieval_grid_search_smoke.py
+++ b/tests/test_retrieval_grid_search_smoke.py
@@ -1,0 +1,367 @@
+"""Smoke integration test for scripts/retrieval_grid_search (Issue #88).
+
+Patches ``build_pipeline`` with a ``MagicMock`` so the sweep loop runs
+without loading MLX / Qwen / sentence-transformers. Verifies:
+
+- ``run_eval_inproc`` feeds ``session_id = grid-<idx>-<qid>`` correctly
+- ``run_phase`` writes per-config results atomically
+- ``--resume`` skips already-completed configs
+- ``--dry-run`` prints the 24 Phase 1 configs and exits clean
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts._grid_search_core import (  # noqa: E402
+    ConfigParams,
+    aggregate_metrics,
+)
+from scripts.retrieval_grid_search import (  # noqa: E402
+    _params_key,
+    main,
+    run_eval_inproc,
+    run_phase,
+)
+
+
+# ---------------------------------------------------------------------------
+# Minimal fakes mirroring the bits of QueryResult the loop reads.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeLatency:
+    total_ms: float = 12_000.0
+
+
+@dataclass
+class _FakeMemory:
+    peak_mb: float = 4200.0
+
+
+@dataclass
+class _FakeQueryResult:
+    answer: str
+    no_citation: bool
+    wrong_citation_indices: list[int]
+    latency: _FakeLatency
+    memory: _FakeMemory
+
+
+def _mk_result(
+    *, no_citation: bool, wrong: list[int] | None = None, latency: float = 12_000.0
+) -> _FakeQueryResult:
+    return _FakeQueryResult(
+        answer="dummy",
+        no_citation=no_citation,
+        wrong_citation_indices=wrong or [],
+        latency=_FakeLatency(total_ms=latency),
+        memory=_FakeMemory(),
+    )
+
+
+def _load_base_cfg():  # type: ignore[no-untyped-def]
+    from baseline_reporag.config import load_config
+
+    return load_config(REPO_ROOT / "configs" / "baseline.yaml")
+
+
+# ---------------------------------------------------------------------------
+# run_eval_inproc
+# ---------------------------------------------------------------------------
+
+
+def test_smoke_run_eval_inproc_uses_session_id_scope() -> None:
+    mock_pipeline = MagicMock()
+    mock_pipeline.query.side_effect = [
+        _mk_result(no_citation=False, latency=10_000.0),
+        _mk_result(no_citation=True, latency=20_000.0),
+        _mk_result(no_citation=False, wrong=[2], latency=30_000.0),
+    ]
+    questions = [
+        {"id": "q1", "question": "Q1"},
+        {"id": "q2", "question": "Q2"},
+        {"id": "q3", "question": "Q3"},
+    ]
+    records = run_eval_inproc(
+        mock_pipeline, questions, config_idx=7, repo_id="fastapi_fastapi"
+    )
+    assert len(records) == 3
+    assert records[0]["eval_id"] == "q1"
+    assert records[1]["no_citation"] is True
+    assert records[2]["wrong_citation_indices"] == [2]
+
+    calls = mock_pipeline.query.call_args_list
+    assert calls[0].kwargs["session_id"] == "grid-7-q1"
+    assert calls[1].kwargs["session_id"] == "grid-7-q2"
+    assert calls[2].kwargs["session_id"] == "grid-7-q3"
+
+    metrics = aggregate_metrics(records, unanswerable_ids=set())
+    assert metrics["no_citation_rate"] == pytest.approx(1 / 3)
+
+
+# ---------------------------------------------------------------------------
+# run_phase writes JSON state atomically and supports resume.
+# ---------------------------------------------------------------------------
+
+
+def _params(
+    lex: int = 20, emb: int = 20, fused: int = 16, rerank: int = 12
+) -> ConfigParams:
+    return ConfigParams(
+        lexical_top_k=lex,
+        embedding_top_k=emb,
+        fused_top_k=fused,
+        rerank_top_k=rerank,
+        weights_lexical=0.45,
+        weights_embedding=0.45,
+    )
+
+
+def test_run_phase_writes_state_per_config(tmp_path: Path) -> None:
+    base_cfg = _load_base_cfg()
+    mock_pipeline = MagicMock()
+    mock_pipeline.cfg = base_cfg
+    mock_pipeline.query.side_effect = [
+        _mk_result(no_citation=False),
+        _mk_result(no_citation=True),
+    ]
+    questions: list[dict[str, Any]] = [
+        {"id": "q1", "question": "?"},
+        {"id": "q2", "question": "?"},
+    ]
+    state_path = tmp_path / "state.json"
+
+    grid = [_params(lex=20)]
+    results = run_phase(
+        base_cfg,
+        grid,
+        questions=questions,
+        unanswerable_ids=set(),
+        pipeline=mock_pipeline,
+        state_path=state_path,
+        resume=False,
+        phase_name="phase1",
+        repo_id="fastapi_fastapi",
+        stop_flag={"stop": False},
+    )
+
+    assert len(results) == 1
+    assert state_path.exists()
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert state["status"] == "phase1_complete"
+    assert len(state["configs"]) == 1
+    assert state["configs"][0]["params"]["lexical_top_k"] == 20
+
+
+def test_run_phase_resume_skips_completed_configs(tmp_path: Path) -> None:
+    base_cfg = _load_base_cfg()
+    mock_pipeline = MagicMock()
+    mock_pipeline.cfg = base_cfg
+    state_path = tmp_path / "state.json"
+
+    grid = [_params(lex=20), _params(lex=25)]
+
+    # Run once with both configs...
+    mock_pipeline.query.side_effect = [
+        _mk_result(no_citation=False)
+        for _ in range(2)  # q1 for config1
+    ] + [
+        _mk_result(no_citation=True)
+        for _ in range(2)  # q1 for config2
+    ]
+    questions = [{"id": "q1", "question": "?"}]
+    # But actually we only pass 1 question per config so side_effect length = 2.
+    mock_pipeline.query.side_effect = [
+        _mk_result(no_citation=False),
+        _mk_result(no_citation=True),
+    ]
+    run_phase(
+        base_cfg,
+        grid,
+        questions=questions,
+        unanswerable_ids=set(),
+        pipeline=mock_pipeline,
+        state_path=state_path,
+        resume=False,
+        phase_name="phase1",
+        repo_id="fastapi_fastapi",
+        stop_flag={"stop": False},
+    )
+
+    # Now re-run with --resume; both configs are already in state so pipeline
+    # must not be invoked again.
+    call_count_before = mock_pipeline.query.call_count
+    run_phase(
+        base_cfg,
+        grid,
+        questions=questions,
+        unanswerable_ids=set(),
+        pipeline=mock_pipeline,
+        state_path=state_path,
+        resume=True,
+        phase_name="phase1",
+        repo_id="fastapi_fastapi",
+        stop_flag={"stop": False},
+    )
+    assert mock_pipeline.query.call_count == call_count_before
+
+
+def test_run_phase_resume_completes_missing_configs(tmp_path: Path) -> None:
+    base_cfg = _load_base_cfg()
+    mock_pipeline = MagicMock()
+    mock_pipeline.cfg = base_cfg
+    state_path = tmp_path / "state.json"
+
+    # Pre-populate state with config A only.
+    grid = [_params(lex=20), _params(lex=25)]
+    key_done = _params_key(grid[0])
+    state = {
+        "phase": "phase1",
+        "configs": [
+            {
+                "config_idx": 0,
+                "params": json.loads(key_done),
+                "raw_no_citation_rate": 0.1,
+                "true_nc_rate": 0.1,
+                "wrong_citation_count": 0,
+                "latency_p50_ms": 12_000.0,
+                "latency_p95_ms": 12_000.0,
+                "n_questions": 1,
+                "n_no_citation": 0,
+                "duration_seconds": 1.0,
+                "started_at": "x",
+                "completed_at": "y",
+            }
+        ],
+        "status": "running",
+    }
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    mock_pipeline.query.side_effect = [_mk_result(no_citation=True)]
+    questions = [{"id": "q1", "question": "?"}]
+    results = run_phase(
+        base_cfg,
+        grid,
+        questions=questions,
+        unanswerable_ids=set(),
+        pipeline=mock_pipeline,
+        state_path=state_path,
+        resume=True,
+        phase_name="phase1",
+        repo_id="fastapi_fastapi",
+        stop_flag={"stop": False},
+    )
+    # Only config B ran (config A skipped on resume).
+    assert mock_pipeline.query.call_count == 1
+    assert len(results) == 1
+    assert results[0].params.lexical_top_k == 25
+
+
+# ---------------------------------------------------------------------------
+# main --dry-run prints the 24 Phase 1 configs and exits clean.
+# ---------------------------------------------------------------------------
+
+
+def test_main_dry_run_prints_grid(capsys: pytest.CaptureFixture[str]) -> None:
+    with patch("scripts.retrieval_grid_search.build_pipeline_for_sweep") as mock_build:
+        exit_code = main(
+            [
+                "--config",
+                "configs/baseline.yaml",
+                "--dry-run",
+            ]
+        )
+    # Dry-run must NOT build a pipeline.
+    mock_build.assert_not_called()
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "Phase 1 grid contains 24 configs" in out
+
+
+def test_main_rejects_absolute_config_path() -> None:
+    with pytest.raises(SystemExit):
+        main(["--config", "/etc/passwd", "--dry-run"])
+
+
+def test_main_rejects_parent_traversal() -> None:
+    with pytest.raises(SystemExit):
+        main(["--config", "../../../etc/passwd", "--dry-run"])
+
+
+# ---------------------------------------------------------------------------
+# Sanity: pipeline.cfg is mutated in-place between configs.
+# ---------------------------------------------------------------------------
+
+
+def test_run_phase_mutates_pipeline_cfg_each_iteration(tmp_path: Path) -> None:
+    base_cfg = _load_base_cfg()
+    mock_pipeline = MagicMock()
+    mock_pipeline.cfg = base_cfg
+
+    seen_lex: list[int] = []
+
+    def _capture_cfg(**_kwargs: Any) -> _FakeQueryResult:
+        seen_lex.append(mock_pipeline.cfg.retrieval.lexical_top_k)
+        return _mk_result(no_citation=False)
+
+    mock_pipeline.query.side_effect = _capture_cfg
+    questions = [{"id": "q1", "question": "?"}]
+    grid = [_params(lex=20), _params(lex=25)]
+
+    run_phase(
+        base_cfg,
+        grid,
+        questions=questions,
+        unanswerable_ids=set(),
+        pipeline=mock_pipeline,
+        state_path=tmp_path / "state.json",
+        resume=False,
+        phase_name="phase1",
+        repo_id="fastapi_fastapi",
+        stop_flag={"stop": False},
+    )
+    assert seen_lex == [20, 25]
+
+
+# ---------------------------------------------------------------------------
+# Sanity: stop_flag aborts before running the next config.
+# ---------------------------------------------------------------------------
+
+
+def test_run_phase_honors_stop_flag(tmp_path: Path) -> None:
+    from scripts.retrieval_grid_search import _InterruptedError
+
+    base_cfg = _load_base_cfg()
+    mock_pipeline = MagicMock()
+    mock_pipeline.cfg = base_cfg
+    stop_flag = {"stop": True}
+    grid = [_params(lex=20), _params(lex=25)]
+
+    with pytest.raises(_InterruptedError):
+        run_phase(
+            base_cfg,
+            grid,
+            questions=[{"id": "q1", "question": "?"}],
+            unanswerable_ids=set(),
+            pipeline=mock_pipeline,
+            state_path=tmp_path / "state.json",
+            resume=False,
+            phase_name="phase1",
+            repo_id="fastapi_fastapi",
+            stop_flag=stop_flag,
+        )
+    state = json.loads((tmp_path / "state.json").read_text(encoding="utf-8"))
+    assert state["status"] == "interrupted"


### PR DESCRIPTION
## Summary

Issue #88 を実装。Retrieval パラメータ（lexical/embedding/fused/rerank top_k + fusion weights）の grid search を **in-process** で実行する harness を追加。subprocess 毎の cold-start +40 分オーバーヘッドを回避。

## 変更内容

- `scripts/retrieval_grid_search.py`: メイン harness
- `scripts/_grid_search_core.py`: in-process sweep core
- `tests/test_retrieval_grid_search{,_smoke}.py`: smoke + unit

## 重要な発見（本 Issue レビュー中に surfaced）

- NC ベースライン値の重大な不整合（16.7% / 21.7% / 25.8% / 54.17%）→ 着手前の再計測必須化
- `weights.graph` は dead config（pipeline 未使用）→ grid 対象から除外
- `lexical.pkl` の pickle trust boundary リスク → CLI で repo-local YAML に拘束
- #89/#90/#91 との merge 順序を明文化（#88 → #89 → #90 → #91 → 再 grid）

## Test Plan

- [x] `ruff check .` / `ruff format --check .` / `pytest` 全パス（175 passed）
- [ ] Post-merge で bench を実行し `configs/baseline_optimized.yaml` を生成

Closes #88

🤖 Generated with Claude Code