### PR TITLE
feat(retrieval): weighted symbol-graph expansion and adaptive neighborhood

### DIFF
--- a/baseline_reporag/indexing/symbol_graph.py
+++ b/baseline_reporag/indexing/symbol_graph.py
@@ -3,30 +3,49 @@ from __future__ import annotations
 import ast
 import json
 from collections import defaultdict
+from enum import Enum
 from pathlib import Path
 
 from ..ingestion.store import ChunkStore
 
 
+class EdgeKind(str, Enum):
+    """Kind of edge in the symbol graph."""
+
+    CALL = "call"
+    INHERIT = "inherit"
+    IMPORT = "import"
+
+
+# Default BFS edge weights. Hop decay (0.5 per hop) is applied on top of this.
+_DEFAULT_HOP_DECAY = 0.5
+
+
 class SymbolGraph:
-    """Maps Python symbols to chunk IDs and tracks call-level edges."""
+    """Maps Python symbols to chunk IDs and tracks typed edges (call / inherit / import)."""
 
     def __init__(self) -> None:
         # symbol_name -> [chunk_ids where it is defined]
         self._definitions: dict[str, list[str]] = defaultdict(list)
-        # chunk_id -> [chunk_ids it references]
-        self._edges: dict[str, list[str]] = defaultdict(list)
+        # chunk_id -> [(neighbor_id, edge_kind), ...]
+        self._edges: dict[str, list[tuple[str, EdgeKind]]] = defaultdict(list)
+
+    # ------------------------------------------------------------------
+    # Build
+    # ------------------------------------------------------------------
 
     def build(self, store: ChunkStore, repo_id: str, repo_commit: str) -> None:
         self._definitions = defaultdict(list)
         self._edges = defaultdict(list)
 
-        # Pass 1: collect symbol definitions
+        # Pass 1: collect symbol definitions and record (chunk_id -> rel_path)
+        chunk_rel_paths: dict[str, str] = {}
         for chunk in store.iter_repo(repo_id, repo_commit):
+            chunk_rel_paths[chunk.chunk_id] = chunk.rel_path
             for sym in chunk.symbols:
                 self._definitions[sym].append(chunk.chunk_id)
 
-        # Pass 2: find call edges in Python chunks
+        # Pass 2: walk AST for call / inherit / import edges (Python only)
         for chunk in store.iter_repo(repo_id, repo_commit):
             if chunk.language != "python":
                 continue
@@ -34,40 +53,199 @@ class SymbolGraph:
                 tree = ast.parse(chunk.content)
             except SyntaxError:
                 continue
+
+            edges_with_kind: list[tuple[str, EdgeKind]] = []
+            seen_pair: set[tuple[str, EdgeKind]] = set()
+
+            def _add(target: str, kind: EdgeKind) -> None:
+                if target == chunk.chunk_id:
+                    return
+                pair = (target, kind)
+                if pair in seen_pair:
+                    return
+                seen_pair.add(pair)
+                edges_with_kind.append(pair)
+
+            # CALL edges: ast.Call -> func.id / func.attr
             called: set[str] = set()
+            # INHERIT edges: ClassDef.bases
+            inherited: set[str] = set()
+            # IMPORT edges: Import / ImportFrom
+            imported: list[str] = []
+
             for node in ast.walk(tree):
                 if isinstance(node, ast.Call):
                     if isinstance(node.func, ast.Name):
                         called.add(node.func.id)
                     elif isinstance(node.func, ast.Attribute):
                         called.add(node.func.attr)
+                elif isinstance(node, ast.ClassDef):
+                    for base in node.bases:
+                        if isinstance(base, ast.Name):
+                            inherited.add(base.id)
+                        elif isinstance(base, ast.Attribute):
+                            inherited.add(base.attr)
+                elif isinstance(node, ast.Import):
+                    for alias in node.names:
+                        # "import foo.bar" -> try qualified name first, then the tail.
+                        imported.append(alias.name)
+                        tail = alias.name.rsplit(".", 1)[-1]
+                        if tail != alias.name:
+                            imported.append(tail)
+                elif isinstance(node, ast.ImportFrom):
+                    for alias in node.names:
+                        imported.append(alias.name)
+
             for sym in called:
                 for target_id in self._definitions.get(sym, []):
-                    if target_id != chunk.chunk_id:
-                        self._edges[chunk.chunk_id].append(target_id)
+                    _add(target_id, EdgeKind.CALL)
 
-    def get_related_chunks(self, chunk_id: str, max_hops: int = 1) -> list[str]:
+            for sym in inherited:
+                for target_id in self._definitions.get(sym, []):
+                    _add(target_id, EdgeKind.INHERIT)
+
+            for sym in imported:
+                candidates = self._definitions.get(sym, [])
+                if not candidates:
+                    continue
+                resolved = self._resolve_import_target(
+                    candidates,
+                    importing_chunk_id=chunk.chunk_id,
+                    importing_rel_path=chunk.rel_path,
+                    chunk_rel_paths=chunk_rel_paths,
+                )
+                if resolved is not None:
+                    _add(resolved, EdgeKind.IMPORT)
+
+            if edges_with_kind:
+                self._edges[chunk.chunk_id].extend(edges_with_kind)
+
+    @staticmethod
+    def _resolve_import_target(
+        candidates: list[str],
+        *,
+        importing_chunk_id: str,
+        importing_rel_path: str,
+        chunk_rel_paths: dict[str, str],
+    ) -> str | None:
+        """Pick a single best target for an import symbol (DR4-002).
+
+        Priority: intra-file -> same directory/package -> first candidate.
+        Self-chunk is skipped at the caller via ``_add``.
+        """
+        intra_file = [
+            c
+            for c in candidates
+            if chunk_rel_paths.get(c) == importing_rel_path and c != importing_chunk_id
+        ]
+        if intra_file:
+            return intra_file[0]
+
+        importing_dir = (
+            importing_rel_path.rsplit("/", 1)[0] if "/" in importing_rel_path else ""
+        )
+        same_dir = [
+            c
+            for c in candidates
+            if c != importing_chunk_id
+            and (
+                (
+                    chunk_rel_paths.get(c, "").rsplit("/", 1)[0]
+                    if "/" in chunk_rel_paths.get(c, "")
+                    else ""
+                )
+                == importing_dir
+            )
+        ]
+        if same_dir:
+            return same_dir[0]
+
+        for c in candidates:
+            if c != importing_chunk_id:
+                return c
+        return None
+
+    # ------------------------------------------------------------------
+    # Query
+    # ------------------------------------------------------------------
+
+    def get_related_chunks(
+        self,
+        chunk_id: str,
+        max_hops: int = 1,
+        weights: dict[EdgeKind, float] | None = None,
+    ) -> list[str]:
+        """Return neighbors up to ``max_hops`` away.
+
+        - ``weights=None`` preserves the original insertion-order semantics.
+        - When ``weights`` is provided, BFS accumulates ``edge_weight * hop_decay**hop``
+          per reachable neighbor and the result is sorted by score descending.
+        """
+        if weights is None:
+            return self._get_related_unweighted(chunk_id, max_hops)
+        return self._get_related_weighted(chunk_id, max_hops, weights)
+
+    def _get_related_unweighted(self, chunk_id: str, max_hops: int) -> list[str]:
         visited: set[str] = set()
+        ordered: list[str] = []
         frontier = {chunk_id}
         for _ in range(max_hops):
             next_frontier: set[str] = set()
             for cid in frontier:
-                for neighbor in self._edges.get(cid, []):
-                    if neighbor not in visited:
+                for neighbor, _kind in self._edges.get(cid, []):
+                    if neighbor not in visited and neighbor != chunk_id:
+                        if neighbor not in ordered:
+                            ordered.append(neighbor)
                         next_frontier.add(neighbor)
             visited |= frontier
             frontier = next_frontier - visited
-        visited.discard(chunk_id)
-        return list(visited)
+        return ordered
+
+    def _get_related_weighted(
+        self,
+        chunk_id: str,
+        max_hops: int,
+        weights: dict[EdgeKind, float],
+    ) -> list[str]:
+        scores: dict[str, float] = {}
+        # BFS: track best score discovered per neighbor at each hop.
+        current: dict[str, float] = {chunk_id: 1.0}
+        for hop in range(max_hops):
+            nxt: dict[str, float] = {}
+            decay = _DEFAULT_HOP_DECAY**hop
+            for cid, base in current.items():
+                for neighbor, kind in self._edges.get(cid, []):
+                    if neighbor == chunk_id:
+                        continue
+                    w = weights.get(kind, 0.0)
+                    inc = base * w * decay
+                    if inc <= 0:
+                        continue
+                    scores[neighbor] = scores.get(neighbor, 0.0) + inc
+                    # Propagate the current cumulative score for the next hop.
+                    nxt[neighbor] = max(nxt.get(neighbor, 0.0), scores[neighbor])
+            current = nxt
+        return [
+            cid for cid, _ in sorted(scores.items(), key=lambda kv: (-kv[1], kv[0]))
+        ]
+
+    # ------------------------------------------------------------------
+    # Persistence
+    # ------------------------------------------------------------------
 
     def save(self, path: str | Path) -> None:
         path = Path(path)
         path.parent.mkdir(parents=True, exist_ok=True)
+        serialized_edges: dict[str, list[dict[str, str]]] = {
+            cid: [{"to": t, "kind": k.value} for (t, k) in edges]
+            for cid, edges in self._edges.items()
+        }
         path.write_text(
             json.dumps(
                 {
+                    "version": 2,
                     "definitions": dict(self._definitions),
-                    "edges": dict(self._edges),
+                    "edges": serialized_edges,
                 }
             ),
             encoding="utf-8",
@@ -77,6 +255,35 @@ class SymbolGraph:
     def load(cls, path: str | Path) -> SymbolGraph:
         data = json.loads(Path(path).read_text(encoding="utf-8"))
         g = cls()
-        g._definitions = defaultdict(list, data["definitions"])
-        g._edges = defaultdict(list, data["edges"])
+        g._definitions = defaultdict(list, data.get("definitions", {}))
+
+        raw_edges = data.get("edges", {}) or {}
+        version = data.get("version")
+        is_v2 = version == 2 or _looks_like_v2_edges(raw_edges)
+
+        parsed: dict[str, list[tuple[str, EdgeKind]]] = defaultdict(list)
+        if is_v2:
+            for cid, edges in raw_edges.items():
+                for e in edges:
+                    if isinstance(e, dict):
+                        parsed[cid].append(
+                            (e["to"], EdgeKind(e.get("kind", EdgeKind.CALL.value)))
+                        )
+                    else:
+                        # Mixed or legacy-looking entry: fall back to CALL.
+                        parsed[cid].append((e, EdgeKind.CALL))
+        else:
+            # v1: edges are list[str]; treat all as CALL.
+            for cid, neighbors in raw_edges.items():
+                for n in neighbors:
+                    parsed[cid].append((n, EdgeKind.CALL))
+        g._edges = parsed
         return g
+
+
+def _looks_like_v2_edges(raw_edges: dict) -> bool:
+    """True iff any edge value is a dict (v2 schema marker)."""
+    for edges in raw_edges.values():
+        for e in edges:
+            return isinstance(e, dict)
+    return False

--- a/baseline_reporag/photon_pipeline.py
+++ b/baseline_reporag/photon_pipeline.py
@@ -687,16 +687,24 @@ class PhotonRAGPipeline:
 
         # --- Graph expansion ---
         with prof.phase("graph_expansion"):
+            graph_cfg = cfg.retrieval.graph_expansion
+            nbh_cfg = cfg.retrieval.neighborhood_expansion
+            edge_weights = getattr(graph_cfg, "edge_weights", None)
+            adaptive = getattr(nbh_cfg, "adaptive", False)
+            by_kind = getattr(nbh_cfg, "by_kind", None)
             expanded_ids = expand_with_graph(
                 results=raw,
                 store=bl.store,
                 graph=bl.graph,
                 repo_id=repo_id,
                 repo_commit=cfg.repo.repo_commit,
-                max_hops=cfg.retrieval.graph_expansion.max_hops,
-                max_nodes=cfg.retrieval.graph_expansion.max_nodes,
-                neighborhood_before=cfg.retrieval.neighborhood_expansion.before,
-                neighborhood_after=cfg.retrieval.neighborhood_expansion.after,
+                max_hops=graph_cfg.max_hops,
+                max_nodes=graph_cfg.max_nodes,
+                neighborhood_before=nbh_cfg.before,
+                neighborhood_after=nbh_cfg.after,
+                edge_weights=edge_weights,
+                adaptive_neighborhood=bool(adaptive),
+                neighborhood_by_kind=by_kind,
             )
 
         # --- Evidence pruning (PHOTON-guided) and Pass 1 scoring (Issue #56) ---

--- a/baseline_reporag/pipeline.py
+++ b/baseline_reporag/pipeline.py
@@ -168,16 +168,24 @@ class RepoRAGPipeline:
 
         # --- Graph expansion ---
         with prof.phase("graph_expansion"):
+            graph_cfg = cfg.retrieval.graph_expansion
+            nbh_cfg = cfg.retrieval.neighborhood_expansion
+            edge_weights = getattr(graph_cfg, "edge_weights", None)
+            adaptive = getattr(nbh_cfg, "adaptive", False)
+            by_kind = getattr(nbh_cfg, "by_kind", None)
             expanded_ids = expand_with_graph(
                 results=raw,
                 store=self.store,
                 graph=self.graph,
                 repo_id=repo_id,
                 repo_commit=cfg.repo.repo_commit,
-                max_hops=cfg.retrieval.graph_expansion.max_hops,
-                max_nodes=cfg.retrieval.graph_expansion.max_nodes,
-                neighborhood_before=cfg.retrieval.neighborhood_expansion.before,
-                neighborhood_after=cfg.retrieval.neighborhood_expansion.after,
+                max_hops=graph_cfg.max_hops,
+                max_nodes=graph_cfg.max_nodes,
+                neighborhood_before=nbh_cfg.before,
+                neighborhood_after=nbh_cfg.after,
+                edge_weights=edge_weights,
+                adaptive_neighborhood=bool(adaptive),
+                neighborhood_by_kind=by_kind,
             )
 
         # --- Evidence pack ---

--- a/baseline_reporag/retrieval/graph_expansion.py
+++ b/baseline_reporag/retrieval/graph_expansion.py
@@ -1,8 +1,75 @@
 from __future__ import annotations
 
+from typing import Any, Literal
+
+from ..indexing.symbol_graph import EdgeKind, SymbolGraph
+from ..ingestion.chunker import Chunk
 from ..ingestion.store import ChunkStore
-from ..indexing.symbol_graph import SymbolGraph
 from .hybrid import RetrievalResult
+
+
+def _chunk_kind(chunk: Chunk) -> Literal["class", "function", "module"]:
+    """Classify a chunk for adaptive neighborhood expansion (Issue #91).
+
+    - Non-python chunks always fall back to ``"function"`` (safe default).
+    - ``"module"`` when we have no symbol anchor (module preamble / top-level).
+    - ``"class"`` when the first symbol's leading char is uppercase.
+    - ``"function"`` otherwise.
+    """
+    if chunk.language != "python":
+        return "function"
+    if not chunk.symbols or not chunk.section_header:
+        return "module"
+    first = chunk.symbols[0]
+    if first and first[0].isupper():
+        return "class"
+    return "function"
+
+
+def _normalize_edge_weights(
+    edge_weights: Any,
+) -> dict[EdgeKind, float] | None:
+    """Convert an ``edge_weights`` value (None / dict / Config-like) to the
+    ``dict[EdgeKind, float]`` shape ``SymbolGraph`` expects, or None.
+    """
+    if edge_weights is None:
+        return None
+    if hasattr(edge_weights, "to_dict"):
+        edge_weights = edge_weights.to_dict()
+    if not isinstance(edge_weights, dict):
+        return None
+
+    out: dict[EdgeKind, float] = {}
+    for k, v in edge_weights.items():
+        try:
+            kind = EdgeKind(k) if not isinstance(k, EdgeKind) else k
+        except ValueError:
+            continue
+        try:
+            out[kind] = float(v)
+        except (TypeError, ValueError):
+            continue
+    return out or None
+
+
+def _normalize_by_kind(
+    neighborhood_by_kind: Any,
+) -> dict[str, tuple[int, int]] | None:
+    if neighborhood_by_kind is None:
+        return None
+    if hasattr(neighborhood_by_kind, "to_dict"):
+        neighborhood_by_kind = neighborhood_by_kind.to_dict()
+    if not isinstance(neighborhood_by_kind, dict):
+        return None
+
+    out: dict[str, tuple[int, int]] = {}
+    for k, v in neighborhood_by_kind.items():
+        if isinstance(v, (list, tuple)) and len(v) == 2:
+            try:
+                out[str(k)] = (int(v[0]), int(v[1]))
+            except (TypeError, ValueError):
+                continue
+    return out or None
 
 
 def expand_with_graph(
@@ -15,6 +82,10 @@ def expand_with_graph(
     max_nodes: int = 24,
     neighborhood_before: int = 1,
     neighborhood_after: int = 1,
+    *,
+    edge_weights: Any = None,
+    adaptive_neighborhood: bool = False,
+    neighborhood_by_kind: Any = None,
 ) -> list[str]:
     """Return deduplicated chunk IDs: original + graph neighbors + file neighbors."""
     seen: set[str] = set()
@@ -28,11 +99,20 @@ def expand_with_graph(
     for r in results:
         add(r.chunk_id)
 
+    weights = _normalize_edge_weights(edge_weights)
+    by_kind = _normalize_by_kind(neighborhood_by_kind)
+
     # Graph-based neighbors
     for r in results:
         if len(ordered) >= max_nodes:
             break
-        for neighbor_id in graph.get_related_chunks(r.chunk_id, max_hops=max_hops):
+        if weights is not None:
+            neighbors = graph.get_related_chunks(
+                r.chunk_id, max_hops=max_hops, weights=weights
+            )
+        else:
+            neighbors = graph.get_related_chunks(r.chunk_id, max_hops=max_hops)
+        for neighbor_id in neighbors:
             if len(ordered) >= max_nodes:
                 break
             add(neighbor_id)
@@ -42,9 +122,11 @@ def expand_with_graph(
     for chunk in primary_chunks:
         if len(ordered) >= max_nodes:
             break
-        for neighbor in store.get_neighbors(
-            chunk, before=neighborhood_before, after=neighborhood_after
-        ):
+        before, after = neighborhood_before, neighborhood_after
+        if adaptive_neighborhood and by_kind is not None:
+            kind = _chunk_kind(chunk)
+            before, after = by_kind.get(kind, (before, after))
+        for neighbor in store.get_neighbors(chunk, before=before, after=after):
             if len(ordered) >= max_nodes:
                 break
             add(neighbor.chunk_id)

--- a/baseline_reporag/tests/test_graph_expansion.py
+++ b/baseline_reporag/tests/test_graph_expansion.py
@@ -1,0 +1,215 @@
+"""Unit tests for expand_with_graph edge-weight / adaptive-neighborhood extensions (Issue #91)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from baseline_reporag.indexing.symbol_graph import EdgeKind, SymbolGraph
+from baseline_reporag.ingestion.chunker import Chunk
+from baseline_reporag.retrieval.graph_expansion import (
+    _chunk_kind,
+    expand_with_graph,
+)
+from baseline_reporag.retrieval.hybrid import RetrievalResult
+
+
+def _mk_chunk(
+    *,
+    chunk_id: str,
+    rel_path: str = "pkg/a.py",
+    symbols: list[str] | None = None,
+    section_header: str = "",
+    language: str = "python",
+) -> Chunk:
+    return Chunk(
+        chunk_id=chunk_id,
+        repo_id="r",
+        repo_commit="c",
+        rel_path=rel_path,
+        language=language,
+        start_line=1,
+        end_line=10,
+        content="",
+        symbols=symbols if symbols is not None else [],
+        section_header=section_header,
+        file_header="",
+    )
+
+
+def _mk_retrieval(chunk_id: str) -> RetrievalResult:
+    return RetrievalResult(
+        chunk_id=chunk_id, score=1.0, lexical_score=0.5, embedding_score=0.5
+    )
+
+
+def test_default_behavior_unchanged() -> None:
+    """Without new kwargs, output must match the pre-change path."""
+    # Primary result: chunk "a"; graph neighbor "b"; store returns no file neighbors.
+    results = [_mk_retrieval("a")]
+    graph = MagicMock(spec=SymbolGraph)
+    graph.get_related_chunks.return_value = ["b"]
+
+    store = MagicMock()
+    store.get_many.return_value = [_mk_chunk(chunk_id="a")]
+    store.get_neighbors.return_value = []
+
+    ids = expand_with_graph(
+        results=results,
+        store=store,
+        graph=graph,
+        repo_id="r",
+        repo_commit="c",
+        max_hops=1,
+        max_nodes=24,
+        neighborhood_before=1,
+        neighborhood_after=1,
+    )
+    assert ids == ["a", "b"]
+    # weights not passed when kwargs omitted
+    kwargs = graph.get_related_chunks.call_args.kwargs
+    assert "weights" not in kwargs or kwargs["weights"] is None
+
+
+def test_edge_weights_reorder() -> None:
+    """edge_weights kwarg must be forwarded and change neighbor order."""
+    # Real graph: a -> [(b, IMPORT), (c, CALL), (d, INHERIT)]
+    graph = SymbolGraph()
+    graph._edges["a"] = [
+        ("b", EdgeKind.IMPORT),
+        ("c", EdgeKind.CALL),
+        ("d", EdgeKind.INHERIT),
+    ]
+    store = MagicMock()
+    store.get_many.return_value = [_mk_chunk(chunk_id="a")]
+    store.get_neighbors.return_value = []
+
+    ids = expand_with_graph(
+        results=[_mk_retrieval("a")],
+        store=store,
+        graph=graph,
+        repo_id="r",
+        repo_commit="c",
+        max_hops=1,
+        max_nodes=24,
+        neighborhood_before=0,
+        neighborhood_after=0,
+        edge_weights={"call": 1.0, "inherit": 0.8, "import": 0.5},
+    )
+    # "a" first (primary), then graph neighbors by score: c > d > b
+    assert ids == ["a", "c", "d", "b"]
+
+
+def test_adaptive_neighborhood_class_vs_function() -> None:
+    """class chunks use (2,2), function chunks use (1,1) when adaptive=True."""
+    graph = MagicMock(spec=SymbolGraph)
+    graph.get_related_chunks.return_value = []
+
+    # chunk "cls" is a class, chunk "fn" is a function
+    cls_chunk = _mk_chunk(chunk_id="cls", symbols=["MyClass"], section_header="MyClass")
+    fn_chunk = _mk_chunk(chunk_id="fn", symbols=["do_it"], section_header="do_it")
+
+    store = MagicMock()
+    store.get_many.return_value = [cls_chunk, fn_chunk]
+    store.get_neighbors.return_value = []
+
+    expand_with_graph(
+        results=[_mk_retrieval("cls"), _mk_retrieval("fn")],
+        store=store,
+        graph=graph,
+        repo_id="r",
+        repo_commit="c",
+        neighborhood_before=1,
+        neighborhood_after=1,
+        adaptive_neighborhood=True,
+        neighborhood_by_kind={
+            "class": (2, 2),
+            "function": (1, 1),
+            "module": (0, 0),
+        },
+    )
+    calls = store.get_neighbors.call_args_list
+    assert len(calls) == 2
+    # First call: cls_chunk, (2, 2)
+    assert calls[0].kwargs["before"] == 2
+    assert calls[0].kwargs["after"] == 2
+    # Second call: fn_chunk, (1, 1)
+    assert calls[1].kwargs["before"] == 1
+    assert calls[1].kwargs["after"] == 1
+
+
+def test_adaptive_neighborhood_fallback_non_python() -> None:
+    """Non-python chunks are treated as function (safe fallback)."""
+    graph = MagicMock(spec=SymbolGraph)
+    graph.get_related_chunks.return_value = []
+
+    rust_chunk = _mk_chunk(
+        chunk_id="r1",
+        language="rust",
+        symbols=["SomeStruct"],
+        section_header="SomeStruct",
+    )
+    store = MagicMock()
+    store.get_many.return_value = [rust_chunk]
+    store.get_neighbors.return_value = []
+
+    expand_with_graph(
+        results=[_mk_retrieval("r1")],
+        store=store,
+        graph=graph,
+        repo_id="r",
+        repo_commit="c",
+        neighborhood_before=1,
+        neighborhood_after=1,
+        adaptive_neighborhood=True,
+        neighborhood_by_kind={"class": (3, 3), "function": (1, 1), "module": (0, 0)},
+    )
+    call = store.get_neighbors.call_args_list[0]
+    assert call.kwargs["before"] == 1
+    assert call.kwargs["after"] == 1
+
+
+def test_max_nodes_cap_still_enforced() -> None:
+    """max_nodes cap must hold even with new kwargs active."""
+    graph = SymbolGraph()
+    graph._edges["a"] = [(f"n{i}", EdgeKind.CALL) for i in range(50)]
+    store = MagicMock()
+    store.get_many.return_value = [_mk_chunk(chunk_id="a")]
+    store.get_neighbors.return_value = []
+
+    ids = expand_with_graph(
+        results=[_mk_retrieval("a")],
+        store=store,
+        graph=graph,
+        repo_id="r",
+        repo_commit="c",
+        max_hops=1,
+        max_nodes=5,
+        edge_weights={"call": 1.0, "inherit": 0.8, "import": 0.5},
+    )
+    assert len(ids) == 5
+
+
+def test_chunk_kind_module_when_no_symbols() -> None:
+    c = _mk_chunk(chunk_id="c", symbols=[], section_header="")
+    assert _chunk_kind(c) == "module"
+
+
+def test_chunk_kind_class_when_capitalized() -> None:
+    c = _mk_chunk(chunk_id="c", symbols=["Foo"], section_header="Foo")
+    assert _chunk_kind(c) == "class"
+
+
+def test_chunk_kind_function_when_lowercase() -> None:
+    c = _mk_chunk(chunk_id="c", symbols=["foo"], section_header="foo")
+    assert _chunk_kind(c) == "function"
+
+
+def test_chunk_kind_non_python_fallback() -> None:
+    c = _mk_chunk(chunk_id="c", symbols=["Foo"], section_header="Foo", language="rust")
+    assert _chunk_kind(c) == "function"
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/baseline_reporag/tests/test_symbol_graph_weights.py
+++ b/baseline_reporag/tests/test_symbol_graph_weights.py
@@ -1,0 +1,211 @@
+"""Tests for SymbolGraph edge-kind / weight extensions (Issue #91)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from baseline_reporag.indexing.symbol_graph import EdgeKind, SymbolGraph
+from baseline_reporag.ingestion.chunker import Chunk
+
+
+class _FakeStore:
+    def __init__(self, chunks: list[Chunk]) -> None:
+        self._chunks = chunks
+
+    def iter_repo(self, repo_id: str, repo_commit: str):
+        for c in self._chunks:
+            if c.repo_id == repo_id and c.repo_commit == repo_commit:
+                yield c
+
+
+def _make_chunk(
+    *,
+    chunk_id: str,
+    rel_path: str,
+    content: str,
+    symbols: list[str],
+    repo_id: str = "r",
+    repo_commit: str = "c",
+    language: str = "python",
+    section_header: str = "",
+) -> Chunk:
+    return Chunk(
+        chunk_id=chunk_id,
+        repo_id=repo_id,
+        repo_commit=repo_commit,
+        rel_path=rel_path,
+        language=language,
+        start_line=1,
+        end_line=10,
+        content=content,
+        symbols=symbols,
+        section_header=section_header,
+        file_header="",
+    )
+
+
+def _edge_kinds_from(
+    edges: list,
+) -> set[EdgeKind]:
+    return {kind for (_, kind) in edges}
+
+
+def _targets(edges: list) -> list[str]:
+    return [t for (t, _) in edges]
+
+
+def test_edge_kinds_collected() -> None:
+    """build() should collect CALL, INHERIT, IMPORT edges on a synthetic repo."""
+    chunk_a = _make_chunk(
+        chunk_id="a",
+        rel_path="pkg/a.py",
+        content="class Base:\n    def hello(self):\n        pass\n",
+        symbols=["Base", "hello"],
+        section_header="Base",
+    )
+    chunk_b = _make_chunk(
+        chunk_id="b",
+        rel_path="pkg/b.py",
+        content=(
+            "from pkg.a import Base\n\n"
+            "class Child(Base):\n"
+            "    def greet(self):\n"
+            "        return hello()\n"
+        ),
+        symbols=["Child", "greet"],
+        section_header="Child",
+    )
+    store = _FakeStore([chunk_a, chunk_b])
+
+    g = SymbolGraph()
+    g.build(store, "r", "c")
+
+    edges = g._edges.get("b", [])
+    kinds = _edge_kinds_from(edges)
+    # INHERIT Base, IMPORT Base, CALL hello
+    assert EdgeKind.INHERIT in kinds
+    assert EdgeKind.IMPORT in kinds
+    assert EdgeKind.CALL in kinds
+
+    # INHERIT edge should point to the chunk that defines Base
+    inherit_targets = [t for (t, k) in edges if k is EdgeKind.INHERIT]
+    assert inherit_targets == ["a"]
+
+
+def test_get_related_chunks_weighted() -> None:
+    """weights should reorder neighbors by cumulative score (descending)."""
+    g = SymbolGraph()
+    # hand-wire edges: chunk x -> [y (IMPORT), z (CALL), w (INHERIT)]
+    g._edges["x"] = [
+        ("y", EdgeKind.IMPORT),
+        ("z", EdgeKind.CALL),
+        ("w", EdgeKind.INHERIT),
+    ]
+
+    related = g.get_related_chunks(
+        "x",
+        max_hops=1,
+        weights={
+            EdgeKind.CALL: 1.0,
+            EdgeKind.INHERIT: 0.8,
+            EdgeKind.IMPORT: 0.5,
+        },
+    )
+    # Expected order: CALL (1.0) > INHERIT (0.8) > IMPORT (0.5)
+    assert related == ["z", "w", "y"]
+
+
+def test_get_related_chunks_unweighted_back_compat() -> None:
+    """weights=None preserves old behavior (insertion order, dedup)."""
+    g = SymbolGraph()
+    g._edges["x"] = [
+        ("y", EdgeKind.IMPORT),
+        ("z", EdgeKind.CALL),
+        ("w", EdgeKind.INHERIT),
+    ]
+    related = g.get_related_chunks("x", max_hops=1)
+    # must contain exactly {y, z, w}; order insertion-based is acceptable
+    assert set(related) == {"y", "z", "w"}
+
+
+def test_save_load_v2_roundtrip(tmp_path: Path) -> None:
+    g = SymbolGraph()
+    g._definitions["foo"] = ["chunk_foo"]
+    g._edges["x"] = [("y", EdgeKind.CALL), ("z", EdgeKind.INHERIT)]
+    path = tmp_path / "graph.json"
+    g.save(path)
+
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["version"] == 2
+    # edges must be list of {"to": ..., "kind": ...} dicts
+    edges_x = data["edges"]["x"]
+    assert edges_x[0] == {"to": "y", "kind": "call"}
+    assert edges_x[1] == {"to": "z", "kind": "inherit"}
+
+    g2 = SymbolGraph.load(path)
+    assert g2._definitions["foo"] == ["chunk_foo"]
+    assert g2._edges["x"] == [
+        ("y", EdgeKind.CALL),
+        ("z", EdgeKind.INHERIT),
+    ]
+
+
+def test_load_v1_back_compat(tmp_path: Path) -> None:
+    """v1 JSON (edges are list[str], no version key) loads as all-CALL edges."""
+    v1 = {
+        "definitions": {"foo": ["chunk_foo"]},
+        "edges": {"x": ["y", "z"]},
+    }
+    path = tmp_path / "v1.json"
+    path.write_text(json.dumps(v1), encoding="utf-8")
+
+    g = SymbolGraph.load(path)
+    assert g._definitions["foo"] == ["chunk_foo"]
+    assert g._edges["x"] == [
+        ("y", EdgeKind.CALL),
+        ("z", EdgeKind.CALL),
+    ]
+
+
+def test_import_resolution_intra_file_priority() -> None:
+    """When multiple chunks define a symbol with the same name, intra-file wins."""
+    # Two chunks define `util`: one in the importing file (intra-file),
+    # one elsewhere. Expect intra-file to be chosen for the IMPORT edge.
+    chunk_caller = _make_chunk(
+        chunk_id="caller",
+        rel_path="pkg/caller.py",
+        content="import util\n\ndef use():\n    return util.do()\n",
+        symbols=["use"],
+        section_header="use",
+    )
+    chunk_util_same_file = _make_chunk(
+        chunk_id="caller_util",
+        rel_path="pkg/caller.py",
+        content="def util():\n    pass\n",
+        symbols=["util"],
+        section_header="util",
+    )
+    chunk_util_other = _make_chunk(
+        chunk_id="other_util",
+        rel_path="pkg_other/util.py",
+        content="def util():\n    pass\n",
+        symbols=["util"],
+        section_header="util",
+    )
+    store = _FakeStore([chunk_caller, chunk_util_same_file, chunk_util_other])
+    g = SymbolGraph()
+    g.build(store, "r", "c")
+
+    import_targets = [
+        t for (t, k) in g._edges.get("caller", []) if k is EdgeKind.IMPORT
+    ]
+    # The IMPORT edge must point to the intra-file candidate only
+    assert "caller_util" in import_targets
+    assert "other_util" not in import_targets
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/configs/baseline.yaml
+++ b/configs/baseline.yaml
@@ -137,11 +137,20 @@ retrieval:
     enabled: true
     before: 1
     after: 1
+    adaptive: false                  # Issue #91: chunk-kind-aware neighborhood
+    by_kind:
+      class: [2, 2]
+      function: [1, 1]
+      module: [0, 0]
 
   graph_expansion:
     enabled: true
     max_hops: 1
     max_nodes: 24
+    edge_weights:                    # Issue #91: edge-kind priorities (call/inherit/import)
+      call: 1.0
+      inherit: 0.8
+      import: 0.5
 
   file_type_boost: 0.0             # disabled: v6 eval showed +2.5pp regression at 0.15
 

--- a/configs/photon_600m_paper.yaml
+++ b/configs/photon_600m_paper.yaml
@@ -76,11 +76,20 @@ retrieval:
     enabled: true
     before: 1
     after: 1
+    adaptive: false                  # Issue #91
+    by_kind:
+      class: [2, 2]
+      function: [1, 1]
+      module: [0, 0]
 
   graph_expansion:
     enabled: true
     max_hops: 1
     max_nodes: 24
+    edge_weights:                    # Issue #91
+      call: 1.0
+      inherit: 0.8
+      import: 0.5
 
   two_pass_search:
     enabled: false       # Issue #56: enable to add Pass 1 PHOTON scoring on Turn 1

--- a/configs/photon_long_context.yaml
+++ b/configs/photon_long_context.yaml
@@ -87,11 +87,20 @@ retrieval:
     enabled: true
     before: 1
     after: 1
+    adaptive: false                  # Issue #91
+    by_kind:
+      class: [2, 2]
+      function: [1, 1]
+      module: [0, 0]
 
   graph_expansion:
     enabled: true
     max_hops: 1
     max_nodes: 24
+    edge_weights:                    # Issue #91
+      call: 1.0
+      inherit: 0.8
+      import: 0.5
 
 evidence_pack:
   max_chunks: 16

--- a/configs/photon_small.yaml
+++ b/configs/photon_small.yaml
@@ -87,11 +87,20 @@ retrieval:
     enabled: true
     before: 1
     after: 1
+    adaptive: false                  # Issue #91
+    by_kind:
+      class: [2, 2]
+      function: [1, 1]
+      module: [0, 0]
 
   graph_expansion:
     enabled: true
     max_hops: 1
     max_nodes: 24
+    edge_weights:                    # Issue #91
+      call: 1.0
+      inherit: 0.8
+      import: 0.5
 
   two_pass_search:
     enabled: false       # Issue #56: enable to add Pass 1 PHOTON scoring on Turn 1

--- a/configs/photon_tiny.yaml
+++ b/configs/photon_tiny.yaml
@@ -76,11 +76,20 @@ retrieval:
     enabled: true
     before: 1
     after: 1
+    adaptive: false                  # Issue #91
+    by_kind:
+      class: [2, 2]
+      function: [1, 1]
+      module: [0, 0]
 
   graph_expansion:
     enabled: true
     max_hops: 1
     max_nodes: 24
+    edge_weights:                    # Issue #91
+      call: 1.0
+      inherit: 0.8
+      import: 0.5
 
   two_pass_search:
     enabled: false       # Issue #56: enable to add Pass 1 PHOTON scoring on Turn 1

--- a/configs/photon_tiny_recgen.yaml
+++ b/configs/photon_tiny_recgen.yaml
@@ -81,11 +81,20 @@ retrieval:
     enabled: true
     before: 1
     after: 1
+    adaptive: false                  # Issue #91
+    by_kind:
+      class: [2, 2]
+      function: [1, 1]
+      module: [0, 0]
 
   graph_expansion:
     enabled: true
     max_hops: 1
     max_nodes: 24
+    edge_weights:                    # Issue #91
+      call: 1.0
+      inherit: 0.8
+      import: 0.5
 
   two_pass_search:
     enabled: false

--- a/scripts/_graph_bench_core.py
+++ b/scripts/_graph_bench_core.py
@@ -1,0 +1,173 @@
+"""Pure-function core for the graph-expansion grid search (Issue #91).
+
+MLX-free so unit tests can run on a minimal CI runner. Provides:
+
+- ``GraphBenchParams`` frozen dataclass (hashable, ``to_override_dict``)
+- ``is_invalid_graph_combo`` (design §4.3 sanity rules)
+- ``generate_graph_bench_grid`` (phase 1 broad grid)
+- ``generate_graph_bench_phase2`` (narrow neighborhood around seeds)
+- ``atomic_write_json`` is re-exported from ``scripts._grid_search_core``
+  so callers do not need to import both modules.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from scripts._grid_search_core import atomic_write_json  # noqa: F401  (re-export)
+
+
+# ---------------------------------------------------------------------------
+# Dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class GraphBenchParams:
+    """Immutable + hashable sweep target for graph/neighborhood axes."""
+
+    max_hops: int
+    max_nodes: int
+    neighborhood_before: int
+    neighborhood_after: int
+    edge_weights_call: float
+    edge_weights_inherit: float
+    edge_weights_import: float
+    adaptive_neighborhood: bool
+
+    def to_override_dict(self) -> dict[str, Any]:
+        return {
+            "graph_expansion": {
+                "max_hops": self.max_hops,
+                "max_nodes": self.max_nodes,
+                "edge_weights": {
+                    "call": self.edge_weights_call,
+                    "inherit": self.edge_weights_inherit,
+                    "import": self.edge_weights_import,
+                },
+            },
+            "neighborhood_expansion": {
+                "before": self.neighborhood_before,
+                "after": self.neighborhood_after,
+                "adaptive": self.adaptive_neighborhood,
+            },
+        }
+
+
+# ---------------------------------------------------------------------------
+# Invalid combo filter
+# ---------------------------------------------------------------------------
+
+
+def is_invalid_graph_combo(p: GraphBenchParams) -> bool:
+    """Return True when ``p`` violates a sanity rule (design §4.3)."""
+    if p.max_nodes < p.max_hops * 8:
+        return True
+    if p.neighborhood_before == 0 and p.neighborhood_after == 0 and p.max_hops == 0:
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Grid generators
+# ---------------------------------------------------------------------------
+
+
+_PHASE1_MAX_HOPS: tuple[int, ...] = (1, 2)
+_PHASE1_MAX_NODES: tuple[int, ...] = (24, 32, 48)
+_PHASE1_NBH: tuple[tuple[int, int], ...] = ((1, 1), (2, 2), (3, 3))
+_PHASE1_EDGE_WEIGHTS: tuple[tuple[float, float, float], ...] = (
+    (1.0, 1.0, 1.0),  # equal
+    (1.0, 0.8, 0.5),  # weighted (default)
+    (1.0, 0.0, 0.0),  # call-only
+)
+_PHASE1_ADAPTIVE: tuple[bool, ...] = (False, True)
+
+
+def generate_graph_bench_grid() -> list[GraphBenchParams]:
+    """Return the phase-1 grid after dropping invalid combos + duplicates."""
+    seen: set[str] = set()
+    out: list[GraphBenchParams] = []
+    for max_hops in _PHASE1_MAX_HOPS:
+        for max_nodes in _PHASE1_MAX_NODES:
+            for before, after in _PHASE1_NBH:
+                for w_call, w_inh, w_imp in _PHASE1_EDGE_WEIGHTS:
+                    for adaptive in _PHASE1_ADAPTIVE:
+                        params = GraphBenchParams(
+                            max_hops=max_hops,
+                            max_nodes=max_nodes,
+                            neighborhood_before=before,
+                            neighborhood_after=after,
+                            edge_weights_call=w_call,
+                            edge_weights_inherit=w_inh,
+                            edge_weights_import=w_imp,
+                            adaptive_neighborhood=adaptive,
+                        )
+                        if is_invalid_graph_combo(params):
+                            continue
+                        key = _key(params)
+                        if key in seen:
+                            continue
+                        seen.add(key)
+                        out.append(params)
+    return out
+
+
+def _key(params: GraphBenchParams) -> str:
+    return json.dumps(params.to_override_dict(), sort_keys=True)
+
+
+def generate_graph_bench_phase2(
+    seeds: list[GraphBenchParams],
+    *,
+    hops_delta: int = 1,
+    nodes_step: int = 8,
+    nodes_delta: int = 8,
+    nbh_delta: int = 1,
+) -> list[GraphBenchParams]:
+    """Generate phase-2 near-seed neighborhoods, de-duped across seeds.
+
+    The seeds themselves are excluded from the output; ``is_invalid_graph_combo``
+    is applied to each candidate and adaptive / edge-weight axes are inherited
+    from the seed unchanged (narrow phase 2 keeps the categorical knobs fixed).
+    """
+    if not seeds:
+        return []
+
+    seed_keys = {_key(s) for s in seeds}
+    seen: set[str] = set(seed_keys)
+    out: list[GraphBenchParams] = []
+
+    hops_offsets = range(-hops_delta, hops_delta + 1)
+    node_offsets = [d for d in range(-nodes_delta, nodes_delta + 1, nodes_step) if True]
+    nbh_offsets = range(-nbh_delta, nbh_delta + 1)
+
+    for seed in seeds:
+        for d_hops in hops_offsets:
+            for d_nodes in node_offsets:
+                for d_before in nbh_offsets:
+                    for d_after in nbh_offsets:
+                        cand = GraphBenchParams(
+                            max_hops=max(0, seed.max_hops + d_hops),
+                            max_nodes=max(1, seed.max_nodes + d_nodes),
+                            neighborhood_before=max(
+                                0, seed.neighborhood_before + d_before
+                            ),
+                            neighborhood_after=max(
+                                0, seed.neighborhood_after + d_after
+                            ),
+                            edge_weights_call=seed.edge_weights_call,
+                            edge_weights_inherit=seed.edge_weights_inherit,
+                            edge_weights_import=seed.edge_weights_import,
+                            adaptive_neighborhood=seed.adaptive_neighborhood,
+                        )
+                        if is_invalid_graph_combo(cand):
+                            continue
+                        k = _key(cand)
+                        if k in seen:
+                            continue
+                        seen.add(k)
+                        out.append(cand)
+    return out

--- a/scripts/graph_expansion_bench.py
+++ b/scripts/graph_expansion_bench.py
@@ -1,0 +1,443 @@
+"""Graph-expansion / neighborhood-expansion grid search driver (Issue #91).
+
+Mirrors ``scripts/retrieval_grid_search.py``: single loaded pipeline,
+per-config override via ``Config.merge_override``, atomic per-config JSON,
+and SIGTERM resume.
+
+See ``workspace/design/issue-91-graph-neighborhood-design-policy.md`` for
+the full design.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import signal
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from types import FrameType
+from typing import TYPE_CHECKING, Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts._graph_bench_core import (  # noqa: E402
+    GraphBenchParams,
+    atomic_write_json,
+    generate_graph_bench_grid,
+    generate_graph_bench_phase2,
+)
+from scripts._grid_search_core import aggregate_metrics  # noqa: E402
+
+if TYPE_CHECKING:
+    from baseline_reporag.config import Config
+    from baseline_reporag.pipeline import RepoRAGPipeline
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# CLI parsing
+# ---------------------------------------------------------------------------
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Graph/Neighborhood expansion grid search (Issue #91)."
+    )
+    parser.add_argument("--config", default="configs/baseline.yaml")
+    parser.add_argument("--eval-set", default="data/eval_sets/static_v1.jsonl")
+    parser.add_argument(
+        "--output",
+        default="reports/graph_expansion_bench.json",
+        help="Atomic per-config JSON state path.",
+    )
+    parser.add_argument("--phase", choices=["1", "2"], default="1")
+    parser.add_argument("--resume", action="store_true")
+    parser.add_argument(
+        "--smoke",
+        action="store_true",
+        help="Run only the first 2 phase-1 configs (for CI / local sanity).",
+    )
+    parser.add_argument("--max-questions", type=int, default=40)
+    parser.add_argument("--logs-dir", default="logs")
+    parser.add_argument(
+        "--seed-json",
+        default=None,
+        help="Phase 2 only: path to a phase-1 JSON whose top configs will seed phase 2.",
+    )
+    parser.add_argument("--top-n-for-phase2", type=int, default=3)
+    return parser.parse_args(argv)
+
+
+# ---------------------------------------------------------------------------
+# Pipeline build + eval helpers
+# ---------------------------------------------------------------------------
+
+
+def build_pipeline_for_sweep(
+    base_cfg: "Config",
+    scratch_log_root: Path,
+) -> "RepoRAGPipeline":
+    from baseline_reporag.pipeline_factory import build_pipeline
+
+    scratch_log_root.mkdir(parents=True, exist_ok=True)
+    sweep_cfg = base_cfg.merge_override({"paths": {"log_root": str(scratch_log_root)}})
+    return build_pipeline(sweep_cfg)  # type: ignore[return-value]
+
+
+def load_questions(path: Path, max_questions: int) -> list[dict[str, Any]]:
+    questions: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            questions.append(json.loads(line))
+    if max_questions > 0:
+        questions = questions[:max_questions]
+    return questions
+
+
+def unanswerable_ids_from(questions: list[dict[str, Any]]) -> set[str]:
+    return {q["id"] for q in questions if q.get("answerable") is False}
+
+
+def run_eval_inproc(
+    pipeline: "RepoRAGPipeline",
+    questions: list[dict[str, Any]],
+    *,
+    config_idx: int,
+    repo_id: str,
+) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for q in questions:
+        result = pipeline.query(
+            question=q["question"],
+            session_id=f"graphbench-{config_idx}-{q['id']}",
+            repo_id=repo_id,
+        )
+        latency_ms = float(getattr(result.latency, "total_ms", 0.0))
+        memory_peak = float(getattr(result.memory, "peak_mb", 0.0))
+        records.append(
+            {
+                "eval_id": q["id"],
+                "no_citation": bool(result.no_citation),
+                "wrong_citation_indices": list(result.wrong_citation_indices or []),
+                "latency_ms": latency_ms,
+                "memory_peak_mb": memory_peak,
+            }
+        )
+    return records
+
+
+# ---------------------------------------------------------------------------
+# State + sweep loop
+# ---------------------------------------------------------------------------
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).astimezone().isoformat()
+
+
+def _params_key(params: GraphBenchParams) -> str:
+    return json.dumps(params.to_override_dict(), sort_keys=True)
+
+
+def _build_config_entry(
+    config_idx: int,
+    params: GraphBenchParams,
+    records: list[dict[str, Any]],
+    metrics: dict[str, Any],
+    *,
+    started_at: str,
+    completed_at: str,
+    duration_seconds: float,
+) -> dict[str, Any]:
+    memory_peaks = [
+        r.get("memory_peak_mb", 0.0)
+        for r in records
+        if r.get("memory_peak_mb") is not None
+    ]
+    peak = max(memory_peaks) if memory_peaks else None
+    entry: dict[str, Any] = {
+        "config_idx": config_idx,
+        "params": params.to_override_dict(),
+        "raw_no_citation_rate": float(metrics.get("no_citation_rate", 0.0)),
+        "true_nc_rate": float(metrics.get("true_nc_rate", 0.0) or 0.0),
+        "wrong_citation_count": int(metrics.get("wrong_citation_count", 0)),
+        "latency_p50_ms": float(metrics.get("latency_p50", 0.0)),
+        "latency_p95_ms": float(metrics.get("latency_p95", 0.0)),
+        "n_questions": int(metrics.get("n_questions", len(records))),
+        "n_no_citation": int(metrics.get("n_no_citation", 0)),
+        "duration_seconds": duration_seconds,
+        "started_at": started_at,
+        "completed_at": completed_at,
+    }
+    if peak is not None:
+        entry["memory_peak_mb"] = peak
+    return entry
+
+
+class _InterruptedError(BaseException):
+    pass
+
+
+def _install_signal_handlers(flag: dict[str, bool]) -> None:
+    def _handler(signum: int, _frame: FrameType | None) -> None:
+        logger.warning("Received signal %s, flushing and exiting.", signum)
+        flag["stop"] = True
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        try:
+            signal.signal(sig, _handler)
+        except (ValueError, OSError):
+            pass
+
+
+def _load_state(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def run_grid(
+    base_cfg: "Config",
+    grid: list[GraphBenchParams],
+    *,
+    pipeline: "RepoRAGPipeline",
+    questions: list[dict[str, Any]],
+    unanswerable_ids: set[str],
+    output_path: Path,
+    repo_id: str,
+    resume: bool,
+    phase_name: str,
+    stop_flag: dict[str, bool],
+) -> dict[str, Any]:
+    existing = _load_state(output_path) if resume else None
+    if existing and resume:
+        state = existing
+    else:
+        state = {
+            "phase": phase_name,
+            "base_config_path": getattr(base_cfg, "_config_path", ""),
+            "max_questions_per_config": len(questions),
+            "started_at": _now_iso(),
+            "completed_at": "",
+            "configs": [],
+            "status": "running",
+        }
+
+    done_keys = {
+        json.dumps(c.get("params", {}), sort_keys=True)
+        for c in state.get("configs", [])
+    }
+
+    sweep_start = time.perf_counter()
+    total = len(grid)
+    for idx, params in enumerate(grid):
+        if stop_flag.get("stop"):
+            state["status"] = "interrupted"
+            state["interrupted_at"] = _now_iso()
+            atomic_write_json(output_path, state)
+            raise _InterruptedError("interrupted by signal")
+
+        key = _params_key(params)
+        if resume and key in done_keys:
+            logger.info(
+                "[%s] skipping already-completed config %d/%d",
+                phase_name,
+                idx + 1,
+                total,
+            )
+            continue
+
+        started_at = _now_iso()
+        t0 = time.perf_counter()
+        logger.info(
+            "[%s] [Config %d/%d] starting params=%s",
+            phase_name,
+            idx + 1,
+            total,
+            params.to_override_dict(),
+        )
+
+        cfg2 = base_cfg.merge_override({"retrieval": params.to_override_dict()})
+        pipeline.cfg = cfg2  # type: ignore[attr-defined]
+
+        try:
+            records = run_eval_inproc(
+                pipeline, questions, config_idx=idx, repo_id=repo_id
+            )
+        except KeyboardInterrupt:
+            state["status"] = "interrupted"
+            state["interrupted_at"] = _now_iso()
+            atomic_write_json(output_path, state)
+            raise
+
+        metrics = aggregate_metrics(records, unanswerable_ids)
+        duration = time.perf_counter() - t0
+        completed_at = _now_iso()
+        entry = _build_config_entry(
+            idx,
+            params,
+            records,
+            metrics,
+            started_at=started_at,
+            completed_at=completed_at,
+            duration_seconds=duration,
+        )
+        state["configs"].append(entry)
+        state["completed_at"] = completed_at
+        done_keys.add(key)
+        atomic_write_json(output_path, state)
+
+        elapsed = time.perf_counter() - sweep_start
+        logger.info(
+            "[%s] [Config %d/%d] NC=%.1f%% p50=%.0fms elapsed=%.1fs",
+            phase_name,
+            idx + 1,
+            total,
+            100.0 * entry["raw_no_citation_rate"],
+            entry["latency_p50_ms"],
+            elapsed,
+        )
+
+    state["status"] = f"{phase_name}_complete"
+    state["completed_at"] = _now_iso()
+    atomic_write_json(output_path, state)
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 seed selection
+# ---------------------------------------------------------------------------
+
+
+def _seeds_from_phase1_json(path: Path, top_n: int) -> list[GraphBenchParams]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    configs = data.get("configs", [])
+    ordered = sorted(
+        configs,
+        key=lambda c: (
+            c.get("raw_no_citation_rate", 1.0),
+            c.get("latency_p50_ms", 0.0),
+        ),
+    )[:top_n]
+    seeds: list[GraphBenchParams] = []
+    for c in ordered:
+        p = c.get("params", {})
+        ge = p.get("graph_expansion", {})
+        ne = p.get("neighborhood_expansion", {})
+        ew = ge.get("edge_weights", {})
+        seeds.append(
+            GraphBenchParams(
+                max_hops=int(ge.get("max_hops", 1)),
+                max_nodes=int(ge.get("max_nodes", 24)),
+                neighborhood_before=int(ne.get("before", 1)),
+                neighborhood_after=int(ne.get("after", 1)),
+                edge_weights_call=float(ew.get("call", 1.0)),
+                edge_weights_inherit=float(ew.get("inherit", 0.8)),
+                edge_weights_import=float(ew.get("import", 0.5)),
+                adaptive_neighborhood=bool(ne.get("adaptive", False)),
+            )
+        )
+    return seeds
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    args = _parse_args(argv)
+
+    config_path = Path(args.config)
+    if not config_path.is_absolute():
+        config_path = REPO_ROOT / config_path
+    eval_set_path = Path(args.eval_set)
+    if not eval_set_path.is_absolute():
+        eval_set_path = REPO_ROOT / eval_set_path
+    output_path = Path(args.output)
+    if not output_path.is_absolute():
+        output_path = REPO_ROOT / output_path
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    logs_dir = Path(args.logs_dir)
+    if not logs_dir.is_absolute():
+        logs_dir = REPO_ROOT / logs_dir
+    logs_dir.mkdir(parents=True, exist_ok=True)
+
+    from baseline_reporag.config import load_config
+
+    base_cfg = load_config(config_path)
+    repo_id = base_cfg.repo.repo_id
+
+    if args.phase == "1":
+        grid = generate_graph_bench_grid()
+        phase_name = "phase1"
+    else:
+        seed_json = args.seed_json
+        if seed_json is None:
+            # Default: look for the phase-1 state sitting next to --output.
+            default_seed = output_path.with_name("graph_expansion_bench_phase1.json")
+            if default_seed.exists():
+                seed_json = str(default_seed)
+            else:
+                logger.error(
+                    "phase 2 requires --seed-json pointing at a phase-1 JSON "
+                    "(or a sibling graph_expansion_bench_phase1.json)."
+                )
+                return 2
+        seeds = _seeds_from_phase1_json(Path(seed_json), args.top_n_for_phase2)
+        grid = generate_graph_bench_phase2(seeds)
+        phase_name = "phase2"
+
+    if args.smoke:
+        grid = grid[:2]
+        logger.info("SMOKE: limiting grid to %d configs", len(grid))
+
+    if not grid:
+        logger.error("Empty grid — nothing to run.")
+        return 2
+
+    questions = load_questions(eval_set_path, args.max_questions)
+    unanswerable = unanswerable_ids_from(questions)
+    logger.info(
+        "Loaded %d questions (unanswerable: %d)", len(questions), len(unanswerable)
+    )
+
+    stop_flag: dict[str, bool] = {"stop": False}
+    _install_signal_handlers(stop_flag)
+
+    pipeline = build_pipeline_for_sweep(base_cfg, logs_dir / "graph_bench_scratch")
+    try:
+        run_grid(
+            base_cfg,
+            grid,
+            pipeline=pipeline,
+            questions=questions,
+            unanswerable_ids=unanswerable,
+            output_path=output_path,
+            repo_id=repo_id,
+            resume=args.resume,
+            phase_name=phase_name,
+            stop_flag=stop_flag,
+        )
+    except _InterruptedError:
+        logger.warning("Sweep interrupted; state flushed to %s", output_path)
+        return 130
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_graph_expansion_bench.py
+++ b/tests/test_graph_expansion_bench.py
@@ -1,0 +1,115 @@
+"""Pure-function tests for the graph-expansion benchmark core (Issue #91)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts._graph_bench_core import (  # noqa: E402
+    GraphBenchParams,
+    generate_graph_bench_grid,
+    generate_graph_bench_phase2,
+    is_invalid_graph_combo,
+)
+
+
+def _default_params(**kwargs) -> GraphBenchParams:
+    defaults = dict(
+        max_hops=1,
+        max_nodes=24,
+        neighborhood_before=1,
+        neighborhood_after=1,
+        edge_weights_call=1.0,
+        edge_weights_inherit=0.8,
+        edge_weights_import=0.5,
+        adaptive_neighborhood=False,
+    )
+    defaults.update(kwargs)
+    return GraphBenchParams(**defaults)
+
+
+def test_generate_grid_produces_unique_configs() -> None:
+    grid = generate_graph_bench_grid()
+    assert len(grid) > 0
+    keys = {json.dumps(p.to_override_dict(), sort_keys=True) for p in grid}
+    assert len(keys) == len(grid), "grid contains duplicate configs"
+
+
+def test_is_invalid_graph_combo_rules() -> None:
+    # Rule 1: max_nodes < max_hops * 8
+    assert is_invalid_graph_combo(_default_params(max_hops=2, max_nodes=8)) is True
+    assert is_invalid_graph_combo(_default_params(max_hops=2, max_nodes=24)) is False
+
+    # Rule 2: all zero disables expansion entirely
+    bad = _default_params(
+        max_hops=0,
+        neighborhood_before=0,
+        neighborhood_after=0,
+        max_nodes=24,
+    )
+    assert is_invalid_graph_combo(bad) is True
+
+    # Normal combo: valid
+    assert is_invalid_graph_combo(_default_params()) is False
+
+
+def test_to_override_dict_shape() -> None:
+    p = _default_params(
+        max_hops=2,
+        max_nodes=32,
+        neighborhood_before=2,
+        neighborhood_after=2,
+        edge_weights_call=1.0,
+        edge_weights_inherit=0.5,
+        edge_weights_import=0.0,
+        adaptive_neighborhood=True,
+    )
+    d = p.to_override_dict()
+    assert "graph_expansion" in d
+    assert "neighborhood_expansion" in d
+    ge = d["graph_expansion"]
+    assert ge["max_hops"] == 2
+    assert ge["max_nodes"] == 32
+    assert ge["edge_weights"]["call"] == 1.0
+    assert ge["edge_weights"]["inherit"] == 0.5
+    assert ge["edge_weights"]["import"] == 0.0
+    ne = d["neighborhood_expansion"]
+    assert ne["before"] == 2
+    assert ne["after"] == 2
+    assert ne["adaptive"] is True
+
+
+def test_phase2_narrows_around_seeds() -> None:
+    seed = _default_params(max_hops=1, max_nodes=24)
+    phase2 = generate_graph_bench_phase2([seed])
+    assert len(phase2) > 0
+    # Every phase-2 config is close to the seed on at least the integer axes.
+    for p in phase2:
+        # Near-seed: allow offsets of at most +/- 1 hop and +/- 8 nodes and +/- 1 before/after
+        assert abs(p.max_hops - seed.max_hops) <= 1
+        assert abs(p.max_nodes - seed.max_nodes) <= 8
+        assert abs(p.neighborhood_before - seed.neighborhood_before) <= 1
+        assert abs(p.neighborhood_after - seed.neighborhood_after) <= 1
+    # Phase 2 must not include the seed itself.
+    seed_key = json.dumps(seed.to_override_dict(), sort_keys=True)
+    assert seed_key not in {
+        json.dumps(p.to_override_dict(), sort_keys=True) for p in phase2
+    }
+
+
+def test_params_is_hashable() -> None:
+    p1 = _default_params()
+    p2 = _default_params()
+    s = {p1, p2}
+    assert len(s) == 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/tests/test_graph_expansion_bench_smoke.py
+++ b/tests/test_graph_expansion_bench_smoke.py
@@ -1,0 +1,135 @@
+"""Smoke test for scripts/graph_expansion_bench.py (Issue #91).
+
+Patches ``build_pipeline`` with a ``MagicMock`` so the sweep runs without
+loading MLX. Verifies --smoke runs 2 configs and produces JSON with the
+expected keys.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+@dataclass
+class _FakeLatency:
+    total_ms: float = 7000.0
+
+
+@dataclass
+class _FakeMemory:
+    peak_mb: float = 2000.0
+
+
+@dataclass
+class _FakeQueryResult:
+    answer: str = "dummy"
+    no_citation: bool = False
+    wrong_citation_indices: list[int] | None = None
+    latency: _FakeLatency = None  # type: ignore[assignment]
+    memory: _FakeMemory = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        if self.wrong_citation_indices is None:
+            self.wrong_citation_indices = []
+        if self.latency is None:
+            self.latency = _FakeLatency()
+        if self.memory is None:
+            self.memory = _FakeMemory()
+
+
+def _fake_eval_set(tmp_path: Path) -> Path:
+    q_path = tmp_path / "eval.jsonl"
+    lines = [
+        json.dumps({"id": "q1", "question": "Q1"}),
+        json.dumps({"id": "q2", "question": "Q2"}),
+    ]
+    q_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return q_path
+
+
+def test_smoke_runs_two_configs_and_writes_json(tmp_path: Path) -> None:
+    from scripts.graph_expansion_bench import main
+
+    mock_pipeline = MagicMock()
+    mock_pipeline.query.return_value = _FakeQueryResult()
+
+    output_path = tmp_path / "bench.json"
+    eval_path = _fake_eval_set(tmp_path)
+
+    config_path = REPO_ROOT / "configs" / "baseline.yaml"
+    rc = 1
+    with patch(
+        "scripts.graph_expansion_bench.build_pipeline_for_sweep",
+        return_value=mock_pipeline,
+    ):
+        rc = main(
+            [
+                "--config",
+                str(config_path.relative_to(REPO_ROOT)),
+                "--eval-set",
+                str(eval_path),
+                "--output",
+                str(output_path),
+                "--smoke",
+            ]
+        )
+    assert rc == 0, "CLI must return 0 on success"
+
+    # Output JSON contains the per-config results list with required keys.
+    assert output_path.exists()
+    data = json.loads(output_path.read_text(encoding="utf-8"))
+    assert "configs" in data
+    assert len(data["configs"]) == 2
+    for entry in data["configs"]:
+        for key in (
+            "config_idx",
+            "params",
+            "raw_no_citation_rate",
+            "latency_p95_ms",
+        ):
+            assert key in entry, f"missing required key {key!r}"
+
+
+def test_smoke_uses_small_config_subset(tmp_path: Path) -> None:
+    """--smoke must run strictly 2 configs, independent of grid size."""
+    from scripts import graph_expansion_bench as ge_bench
+
+    mock_pipeline = MagicMock()
+    mock_pipeline.query.return_value = _FakeQueryResult()
+
+    output_path = tmp_path / "bench.json"
+    eval_path = _fake_eval_set(tmp_path)
+    config_path = REPO_ROOT / "configs" / "baseline.yaml"
+
+    with patch(
+        "scripts.graph_expansion_bench.build_pipeline_for_sweep",
+        return_value=mock_pipeline,
+    ):
+        ge_bench.main(
+            [
+                "--config",
+                str(config_path.relative_to(REPO_ROOT)),
+                "--eval-set",
+                str(eval_path),
+                "--output",
+                str(output_path),
+                "--smoke",
+            ]
+        )
+
+    # 2 configs * 2 questions = 4 calls
+    assert mock_pipeline.query.call_count == 4
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import pytest
+
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Issue #91 を実装。Symbol graph に `EdgeKind` + weight メタデータを追加、v2 JSON で保存。`graph_expansion` も weight / adaptive neighborhood を活用するよう拡張。

## 変更内容

- `baseline_reporag/indexing/symbol_graph.py`: EdgeKind + v2 JSON
- `baseline_reporag/retrieval/graph_expansion.py`: weight / adaptive kwargs
- 全 configs で graph weight 設定追加
- `scripts/graph_expansion_bench.py`: in-process grid harness
- 単体テスト多数（symbol_graph_weights, graph_expansion, bench）
- v1 JSON との後方互換維持（既存 index は読み込み可能）

## マージ注意

`configs/*.yaml` が #88 #89 #90 と重複。**Rebase 必要**。

## Test Plan

- [x] `ruff check .` / `ruff format --check .` 全パス
- [x] `pytest` - 301 passed（2 pre-existing failures 無関係）

Closes #91

🤖 Generated with Claude Code