### PR TITLE
chore: sync develop → main (#92, #88, #103 post-Wave-6-retry)

### DIFF
--- a/baseline_reporag/generation/evidence_pack.py
+++ b/baseline_reporag/generation/evidence_pack.py
@@ -25,6 +25,29 @@ class EvidencePack:
         return "\n\n---\n\n".join(parts)
 
 
+def _merge_pinned_sets(
+    session: SessionState,
+    additional_pinned_ids: list[str] | None,
+) -> set[str]:
+    """Merge ``session.pinned_chunk_ids`` with optional caller-supplied pins.
+
+    Issue #103 / DR1-010: extracted so :func:`build_evidence_pack` keeps a
+    single, shallow concern (pin-set composition) and to give the test
+    suite a focused unit for the merge contract.
+
+    DR2-003: ``session`` is non-``None`` per the existing
+    :func:`build_evidence_pack` contract — both
+    :class:`baseline_reporag.pipeline.RepoRAGPipeline` and
+    :class:`baseline_reporag.photon_pipeline.PhotonRAGPipeline` obtain the
+    session via ``SessionManager.get_or_create`` which never returns
+    ``None``.
+    """
+    base = set(session.pinned_chunk_ids)
+    if additional_pinned_ids:
+        base = base | set(additional_pinned_ids)
+    return base
+
+
 def build_evidence_pack(
     chunk_ids: list[str],
     store: ChunkStore,
@@ -32,6 +55,8 @@ def build_evidence_pack(
     max_chunks: int = 16,
     max_tokens: int = 16000,
     recent_citation_turns: int = 2,
+    *,
+    additional_pinned_ids: list[str] | None = None,
 ) -> EvidencePack:
     # Use only recently cited chunks for citation bias to avoid crowding out
     # fresh retrieval in later turns.  Cumulative cited_chunk_ids grows every
@@ -41,7 +66,13 @@ def build_evidence_pack(
     for t in recent_turns:
         recent_cited.update(t.cited_chunk_ids)
 
-    pinned_set = set(session.pinned_chunk_ids)
+    # Issue #103: ``additional_pinned_ids`` (kw-only) lets PHOTON pipeline
+    # promote past-turn cited chunks into the next pack at priority=0
+    # without mutating ``session.pinned_chunk_ids`` (DR2-003 keeps the
+    # existing signature ordering — ``recent_citation_turns`` default 2 is
+    # preserved). ``None`` keeps existing baseline pipeline calls byte
+    # identical (priority ordering, dedup via ``set(chunk_ids)``).
+    pinned_set = _merge_pinned_sets(session, additional_pinned_ids)
 
     def priority(cid: str) -> int:
         if cid in pinned_set:
@@ -50,7 +81,18 @@ def build_evidence_pack(
             return 1
         return 2
 
-    ordered_ids = sorted(set(chunk_ids), key=priority)[:max_chunks]
+    # Codex CB-001 fix: union ``additional_pinned_ids`` into the candidate
+    # set BEFORE ``sorted(...)`` so pinned chunks that are NOT already in
+    # the current retrieval result are still surfaced. This is the entire
+    # purpose of the Issue #103 pinning channel (rescuing past-turn
+    # chunks that retrieval missed). NOTE: ``session.pinned_chunk_ids``
+    # is intentionally NOT unioned here — its semantics (existing
+    # ``priority()`` re-order only) stay untouched, only the new
+    # transient ``additional_pinned_ids`` may inject new IDs.
+    candidate_ids: set[str] = set(chunk_ids)
+    if additional_pinned_ids:
+        candidate_ids = candidate_ids | set(additional_pinned_ids)
+    ordered_ids = sorted(candidate_ids, key=priority)[:max_chunks]
     chunks = store.get_many(ordered_ids)
 
     # Approximate token budget: 1 token ≈ 4 chars

--- a/baseline_reporag/photon_pipeline.py
+++ b/baseline_reporag/photon_pipeline.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import logging
 import uuid
 from math import prod
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import mlx.core as mx
 
@@ -24,11 +24,19 @@ from .generation.prompt import (
     build_messages,
     flatten_messages_for_plain_lm,
 )
+from .memory.session import SessionState
 from .pipeline import QueryResult, RepoRAGPipeline, apply_citation_postprocess
 from .profiler import TurnProfiler
 from .retrieval.graph_expansion import expand_with_graph
 from .retrieval.hybrid import apply_file_type_boost, hybrid_search
 from .retrieval.query_expansion import expand_query
+
+if TYPE_CHECKING:
+    # Issue #103 / DR2-008: ``TurnState`` is a PHOTON type; importing it at
+    # runtime would force MLX/PHOTON load on baseline-only paths. The file
+    # uses ``from __future__ import annotations`` so the cache type
+    # ``dict[str, TurnState]`` resolves lazily.
+    from photon_mlx.session import TurnState
 
 _logger = logging.getLogger(__name__)
 
@@ -489,6 +497,78 @@ class PhotonRAGPipeline:
         self.safe_recgen = photon_deps["safe_recgen"]
         self.photon_cfg = photon_deps["photon_cfg"]
         self.tokenizer = photon_deps["tokenizer"]
+        # Issue #103: 1-session-1-entry sidecar cache for past-turn pinning.
+        # write/read/pop must always go through ``query()`` or
+        # :meth:`_clear_photon_session_artifacts` so the lifecycle invariant
+        # documented in design §3 (write at end of Turn N, pop at start of
+        # Turn N+1) is preserved.
+        self._relevant_past_turn_cache: dict[str, TurnState] = {}
+
+    def _clear_photon_session_artifacts(self, session_id: str) -> None:
+        """Centralised reset for PHOTON state + Issue #103 sidecar cache.
+
+        Replaces direct ``_clear_photon_session_state`` call sites
+        (``tokenize_evidence_pack`` fail-closed, Safe RecGen
+        ``reprefill_hierarchy`` / ``fallback_to_baseline_path``) so cache
+        cleanup is *always* paired with PHOTON state reset.
+
+        DR1-003 / DR1-007: ``artifacts ⊃ state + cache``. Any future
+        session-delete / session-reset API (SessionManager, FastAPI,
+        CLI) MUST funnel through this single entry point before mutating
+        ``PhotonInference._sessions``. The pop-then-clear order matters
+        only insofar as both happen — the cache pop is idempotent
+        (``dict.pop(..., None)``) so missing entries are not an error.
+        """
+        self._relevant_past_turn_cache.pop(session_id, None)
+        _clear_photon_session_state(self.photon_inference, session_id)
+
+    @staticmethod
+    def _extract_pinned_chunk_ids(
+        session: SessionState | None,
+        matched: TurnState,
+        max_pinned: int,
+    ) -> list[str] | None:
+        """Look up cited chunks for the matched PHOTON ``turn_id``.
+
+        DR2-004: PHOTON ``turn_count`` and Baseline ``len(turns)`` can drift
+        across fail-closed paths (tokenize failure / Safe RecGen reset
+        clears ``turn_history`` while preserving ``turn_count``; baseline
+        always appends). We therefore guard with
+        ``session.turns[idx].turn_id == matched.turn_id`` before trusting
+        the index. On drift we fall back to a linear scan; if that still
+        fails to locate the matched turn we fail closed (return ``None``)
+        rather than risk pinning the wrong chunks.
+
+        DR2-009: dedup is delegated to
+        :func:`baseline_reporag.generation.evidence_pack._merge_pinned_sets`
+        (set union). This helper performs only the slice; double-counting
+        is impossible by construction.
+
+        DR3-001 / DR4-001: the linear-search fallback is O(N) over
+        ``session.turns`` but only fires after fail-closed drift; the
+        whole helper is wrapped in ``prof.phase("past_turn_pinning")`` by
+        the caller. Production telemetry intentionally does not surface
+        ``matched_turn_id`` / ``scanned_turns`` — long-session diagnosis
+        is restricted to self-hosted benchmarks and unit tests.
+        """
+        if session is None or not session.turns:
+            return None
+        idx = matched.turn_id - 1
+        if 0 <= idx < len(session.turns):
+            candidate = session.turns[idx]
+        else:
+            candidate = None
+        if candidate is None or candidate.turn_id != matched.turn_id:
+            # turn_id alignment is broken (PHOTON / Baseline drift after
+            # fail-closed). Linear search; failing that, fail closed.
+            for t in session.turns:
+                if t.turn_id == matched.turn_id:
+                    candidate = t
+                    break
+            else:
+                return None
+        cited = candidate.cited_chunk_ids
+        return list(cited[:max_pinned]) if cited else None
 
     # ---------------------------------------------------------------
     # Issue #62 Phase 1: opt-in PHOTON single-path generation
@@ -734,6 +814,26 @@ class PhotonRAGPipeline:
             expanded_ids = [chunk_ids_for_scoring[i] for i in selected_indices]
             effective_max_chunks = scoring_max_chunks
 
+        # --- Issue #103: read cached past-turn pin (before evidence pack) ---
+        # DR2-001: use the module-level helper (PhotonRAGPipeline has no
+        # ``_resolve_working_memory_cfg`` method). DR2-002: the helper
+        # returns ``None`` when the YAML lacks ``working_memory:`` or the
+        # block is malformed — guard before accessing fields.
+        working_memory_cfg = _extract_working_memory_cfg(cfg)
+        pinning_enabled = (
+            working_memory_cfg is not None
+            and working_memory_cfg.past_turn_pinning_enabled
+        )
+        additional_pinned_ids: list[str] | None = None
+        if pinning_enabled and is_follow_up:
+            cached_turn = self._relevant_past_turn_cache.pop(photon_session_id, None)
+            if cached_turn is not None:
+                additional_pinned_ids = self._extract_pinned_chunk_ids(
+                    session,
+                    cached_turn,
+                    working_memory_cfg.max_pinned_chunks,
+                )
+
         # --- Evidence pack ---
         with prof.phase("evidence_pack"):
             pack = build_evidence_pack(
@@ -742,6 +842,7 @@ class PhotonRAGPipeline:
                 session=session,
                 max_chunks=effective_max_chunks,
                 max_tokens=cfg.evidence_pack.max_tokens,
+                additional_pinned_ids=additional_pinned_ids,
             )
 
         # --- PHOTON prefill on question + evidence (new coarse state) ---
@@ -783,8 +884,10 @@ class PhotonRAGPipeline:
             evidence_tokens = mx.array([], dtype=mx.int32)
             # Explicit fail-closed: drop any prior coarse/prev state so the
             # next turn cannot reuse a stale hierarchy.  No raw input text,
-            # token ids, or latents are retained (design §8).
-            _clear_photon_session_state(self.photon_inference, photon_session_id)
+            # token ids, or latents are retained (design §8). Issue #103
+            # routes through ``_clear_photon_session_artifacts`` so the
+            # past-turn pin sidecar cache is also dropped.
+            self._clear_photon_session_artifacts(photon_session_id)
 
         if evidence_tokens.size > 0:
             input_ids = evidence_tokens.reshape(1, -1)
@@ -812,9 +915,58 @@ class PhotonRAGPipeline:
         # A fallback that invalidates the PHOTON hierarchy must clear the
         # session state (including prev_logits) so subsequent turns do not
         # reuse a coarse state or drift reference from a stale topic
-        # (design §8 fail-closed; Codex CB-004).
+        # (design §8 fail-closed; Codex CB-004). Issue #103 routes through
+        # ``_clear_photon_session_artifacts`` so the past-turn pin sidecar
+        # cache is dropped in lockstep with PHOTON state.
         if fallback_actions & {"reprefill_hierarchy", "fallback_to_baseline_path"}:
-            _clear_photon_session_state(self.photon_inference, photon_session_id)
+            self._clear_photon_session_artifacts(photon_session_id)
+
+        # --- Issue #103: write past-turn pin cache for next turn ---
+        # 3 branches (design §4-3):
+        #   OFF                       → skip entirely (no profiler phase).
+        #   drift is None             → pop only (DR2-011 stale-cache safety).
+        #   drift is not None         → try find_relevant_past_turn.
+        # DR4-001: production observability is limited to the
+        # ``past_turn_pinning`` phase duration and the failure exception
+        # class name — turn_id, similarity, and scanned_turns are NOT
+        # logged so attacker-controlled YAML or pathological session state
+        # cannot leak into log sinks.
+        if pinning_enabled:
+            if drift is None:
+                # tokenize fail-closed / Safe RecGen reset / session_forward
+                # not run: drop any stale cache entry from the prior turn so
+                # the next turn cannot consume a misaligned pin.
+                self._relevant_past_turn_cache.pop(photon_session_id, None)
+            else:
+                with prof.phase("past_turn_pinning"):
+                    photon_session = self.photon_inference._sessions.get(
+                        photon_session_id
+                    )
+                    match: TurnState | None
+                    if photon_session is not None:
+                        try:
+                            match = photon_session.find_relevant_past_turn(
+                                photon_session.current_state
+                            )
+                        except (AttributeError, RuntimeError, ValueError) as exc:
+                            # DR1-002 + Codex CB-001/CB-002: closed exception
+                            # set (no Pokémon catch). Only the type name is
+                            # surfaced, never raw message content.
+                            _logger.warning(
+                                "find_relevant_past_turn failed; skipping "
+                                "pin cache (fail-closed, reason=%s)",
+                                type(exc).__name__,
+                            )
+                            match = None
+                    else:
+                        # PHOTON session was never initialised for this
+                        # session_id — keep the cache empty.
+                        match = None
+
+                    if match is not None:
+                        self._relevant_past_turn_cache[photon_session_id] = match
+                    else:
+                        self._relevant_past_turn_cache.pop(photon_session_id, None)
 
         # --- Generation (Issue #62 Phase 1: opt-in PHOTON single-path) ---
         # DR-62-001 / DR4-003: strict bool validation for the opt-in flag.

--- a/baseline_reporag/tests/test_evidence_pack.py
+++ b/baseline_reporag/tests/test_evidence_pack.py
@@ -1,7 +1,13 @@
 from __future__ import annotations
 
-from baseline_reporag.generation.evidence_pack import EvidencePack
+from unittest.mock import MagicMock
+
+from baseline_reporag.generation.evidence_pack import (
+    EvidencePack,
+    build_evidence_pack,
+)
 from baseline_reporag.ingestion.chunker import Chunk
+from baseline_reporag.memory.session import SessionState
 
 
 def _make_chunk(
@@ -73,3 +79,139 @@ class TestFormatForPrompt:
         pack = EvidencePack(chunks=[], chunk_indices={})
         result = pack.format_for_prompt()
         assert result == ""
+
+
+class TestBuildEvidencePackAdditionalPinnedIds:
+    """Issue #103: ``additional_pinned_ids`` kw-only arg on
+    :func:`build_evidence_pack`.
+
+    Contract (design §4-2, DR2-003 / DR2-009):
+
+    * Default ``None`` keeps existing call sites byte-identical (priority
+      ordering / max_chunks / dedup all unchanged).
+    * When provided, IDs are merged with ``session.pinned_chunk_ids`` and
+      promoted to ``priority=0`` (above ``recent_cited`` priority=1).
+    * Dedup is delegated to ``set(chunk_ids)`` and ``_merge_pinned_sets``;
+      callers passing duplicates do not see double-counting.
+    """
+
+    def _make_store(self, chunks: list[Chunk]) -> object:
+        store = MagicMock()
+        by_id = {c.chunk_id: c for c in chunks}
+
+        def _get_many(ids):
+            return [by_id[cid] for cid in ids if cid in by_id]
+
+        store.get_many.side_effect = _get_many
+        return store
+
+    def test_evidence_pack_additional_pinned_ids_default_none_preserves_legacy(
+        self,
+    ) -> None:
+        """Omitting ``additional_pinned_ids`` must produce the identical
+        ordering, indices, and chunk selection as the pre-#103 contract."""
+        chunks = [_make_chunk(f"c{i}", content=f"chunk_{i}_body") for i in range(4)]
+        store = self._make_store(chunks)
+        session = SessionState(session_id="s1", repo_id="r", repo_commit="abc")
+        pack_legacy = build_evidence_pack(
+            chunk_ids=["c0", "c1", "c2", "c3"],
+            store=store,
+            session=session,
+            max_chunks=4,
+            max_tokens=16000,
+            recent_citation_turns=2,
+        )
+        pack_new = build_evidence_pack(
+            chunk_ids=["c0", "c1", "c2", "c3"],
+            store=store,
+            session=session,
+            max_chunks=4,
+            max_tokens=16000,
+            recent_citation_turns=2,
+            additional_pinned_ids=None,
+        )
+        assert [c.chunk_id for c in pack_legacy.chunks] == [
+            c.chunk_id for c in pack_new.chunks
+        ]
+        assert pack_legacy.chunk_indices == pack_new.chunk_indices
+
+    def test_evidence_pack_additional_pinned_ids_promoted_to_priority_zero(
+        self,
+    ) -> None:
+        """``additional_pinned_ids`` must surface BEFORE ``recent_cited``
+        chunks (priority 0 < priority 1)."""
+        # 5 candidate chunks; max_chunks=2 so only the top-2 priority chunks
+        # survive. Without pinning, c1 (recent_cited) would lead. With
+        # pinning, c4 (additional pin) must outrank c1.
+        chunks = [_make_chunk(f"c{i}", content=f"chunk_{i}_body") for i in range(5)]
+        store = self._make_store(chunks)
+        session = SessionState(session_id="s1", repo_id="r", repo_commit="abc")
+        # Make c1 recently cited (priority=1).
+        session.add_turn(
+            question="prior question",
+            answer="prior answer",
+            cited_chunk_ids=["c1"],
+        )
+        pack = build_evidence_pack(
+            chunk_ids=["c0", "c1", "c2", "c3", "c4"],
+            store=store,
+            session=session,
+            max_chunks=2,
+            max_tokens=16000,
+            recent_citation_turns=2,
+            additional_pinned_ids=["c4"],
+        )
+        ids = [c.chunk_id for c in pack.chunks]
+        assert "c4" in ids, f"pinned chunk c4 must appear in pack: {ids!r}"
+        # c4 (priority 0) must precede c1 (priority 1).
+        assert ids.index("c4") < ids.index("c1") if "c1" in ids else True
+        # Defensive: c4 should be the FIRST chunk because it is the only
+        # priority-0 entry.
+        assert ids[0] == "c4", f"expected c4 first, got {ids!r}"
+
+    def test_evidence_pack_additional_pinned_ids_added_when_not_in_chunk_ids(
+        self,
+    ) -> None:
+        """Issue #103 / CB-001 regression: ``additional_pinned_ids`` whose
+        IDs are NOT already in ``chunk_ids`` MUST be added to the pack
+        (rather than silently dropped). This is the entire purpose of the
+        pinning channel — to rescue past-turn chunks that the current
+        retrieval missed.
+
+        Pre-fix bug: ``sorted(set(chunk_ids), ...)`` filters by
+        ``set(chunk_ids)`` so any pinned ID outside that set is excluded
+        even though ``priority()`` reports priority 0 for it. The fix
+        unions ``additional_pinned_ids`` into the candidate set BEFORE
+        the ``sorted(...)`` call.
+        """
+        # ``chunk_ids=['c0','c1']`` (current retrieval) does NOT contain
+        # ``c4``. ``additional_pinned_ids=['c4']`` must still surface c4
+        # in the resulting pack.
+        chunks = [_make_chunk(f"c{i}", content=f"chunk_{i}_body") for i in range(5)]
+        store = self._make_store(chunks)
+        session = SessionState(session_id="s1", repo_id="r", repo_commit="abc")
+        pack = build_evidence_pack(
+            chunk_ids=["c0", "c1"],
+            store=store,
+            session=session,
+            max_chunks=4,
+            max_tokens=16000,
+            recent_citation_turns=2,
+            additional_pinned_ids=["c4"],
+        )
+        ids = [c.chunk_id for c in pack.chunks]
+        assert "c4" in ids, (
+            f"pinned chunk c4 (NOT in chunk_ids) must be added to pack: {ids!r}"
+        )
+        # c4 (priority 0) must precede c0/c1 (priority 2).
+        assert ids[0] == "c4", f"expected c4 first, got {ids!r}"
+        # Confirm store.get_many was called with c4 in the requested IDs.
+        call_args = store.get_many.call_args_list
+        requested_ids: list[str] = []
+        for call in call_args:
+            args, kwargs = call
+            if args:
+                requested_ids.extend(args[0])
+        assert "c4" in requested_ids, (
+            f"store.get_many must be invoked with c4 in the ID list: {requested_ids!r}"
+        )

--- a/baseline_reporag/tests/test_photon_pipeline.py
+++ b/baseline_reporag/tests/test_photon_pipeline.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+from baseline_reporag.generation.evidence_pack import build_evidence_pack
+
 # ---------------------------------------------------------------------------
 # TDD Cycle 1: Config._config_path and build_pipeline factory
 # ---------------------------------------------------------------------------
@@ -3443,3 +3445,764 @@ class TestCodexCB002TokenizeEvidencePackLogHygiene:
         assert "RuntimeError" in combined
         # Also ensure the raw question ("follow-up?") did not bleed out.
         assert "follow-up?" not in combined
+
+
+# ---------------------------------------------------------------------------
+# Issue #103: _clear_photon_session_artifacts helper
+# ---------------------------------------------------------------------------
+
+
+class TestClearPhotonSessionArtifacts:
+    """Issue #103: ``PhotonRAGPipeline._clear_photon_session_artifacts``.
+
+    The helper centralises reset (cache pop + ``_clear_photon_session_state``)
+    so all current and future reset paths flow through one entry point
+    (design §3 / DR1-003 ``artifacts ⊃ state + cache``).
+    """
+
+    def test_clear_photon_session_artifacts_clears_cache(self) -> None:
+        """Helper must pop the sidecar cache entry AND delegate to
+        ``_clear_photon_session_state`` so the existing PHOTON state reset
+        contract is preserved (Codex CB-001 + Issue #64)."""
+        cfg = _make_pruning_cfg_disabled()
+        pipeline, _baseline_deps, photon_deps, _mock_session, _mock_results = (
+            _setup_pipeline_for_pruning(cfg, session_turns=0)
+        )
+
+        # Seed cache as if Turn N had recorded a pin candidate.
+        sentinel_match = MagicMock(name="TurnState_sentinel")
+        pipeline._relevant_past_turn_cache["s1"] = sentinel_match
+        pipeline._relevant_past_turn_cache["other_session"] = MagicMock(
+            name="should_survive"
+        )
+
+        with patch(
+            "baseline_reporag.photon_pipeline._clear_photon_session_state"
+        ) as mock_clear_state:
+            pipeline._clear_photon_session_artifacts("s1")
+
+        # Cache entry for the target session must be popped.
+        assert "s1" not in pipeline._relevant_past_turn_cache
+        # Other sessions are untouched (1-session-1-entry sidecar).
+        assert "other_session" in pipeline._relevant_past_turn_cache
+        # State reset must be delegated to the existing helper.
+        mock_clear_state.assert_called_once_with(pipeline.photon_inference, "s1")
+
+
+# ---------------------------------------------------------------------------
+# Issue #103: TestPastTurnPinning — pipeline integration of past-turn pin
+# ---------------------------------------------------------------------------
+
+
+def _make_pinning_cfg(*, enabled: bool = True, max_pinned: int = 3):
+    """Build a Config with past-turn pinning configured.
+
+    Adds a ``session_memory.working_memory`` block with
+    ``past_turn_pinning_enabled`` and ``max_pinned_chunks`` so the
+    pipeline's read/write branches activate.
+    """
+    from baseline_reporag.config import Config
+
+    return Config(
+        {
+            "model": {
+                "provider": "photon",
+                "model_id": "test-model",
+            },
+            "repo": {
+                "repo_id": "test-repo",
+                "repo_commit": "abc123",
+            },
+            "hierarchy": {
+                "chunk_sizes": [4, 4],
+            },
+            "retrieval": {
+                "lexical_top_k": 20,
+                "embedding_top_k": 20,
+                "fused_top_k": 16,
+                "rerank_top_k": 12,
+                "weights": {
+                    "lexical": 0.45,
+                    "embedding": 0.45,
+                },
+                "query_expansion": {"enabled": False},
+                "graph_expansion": {"max_hops": 1, "max_nodes": 24},
+                "neighborhood_expansion": {"before": 1, "after": 1},
+                "file_type_boost": 0.0,
+            },
+            "evidence_pack": {
+                "max_chunks": 16,
+                "max_tokens": 16000,
+            },
+            "inference": {
+                "evidence_pruning_enabled": False,
+                "pruned_max_chunks": 8,
+            },
+            "session_memory": {
+                "mode": "photon",
+                "working_memory": {
+                    "enabled": True,
+                    "max_turns": 4,
+                    "past_turn_pinning_enabled": enabled,
+                    "max_pinned_chunks": max_pinned,
+                },
+            },
+        }
+    )
+
+
+def _setup_pipeline_for_pinning(cfg, *, session_turns: int = 0):
+    """Setup pipeline like ``_setup_pipeline_for_pruning`` but install a
+    real dict for ``photon_inference._sessions`` so the pin code path can
+    look up a fake PHOTON session by id."""
+    pipeline, baseline_deps, photon_deps, mock_session, mock_results = (
+        _setup_pipeline_for_pruning(cfg, session_turns=session_turns)
+    )
+    # The default ``_setup_pipeline_for_pruning`` mocks ``photon_inference``
+    # as a MagicMock. ``_sessions.get(...)`` against MagicMock returns
+    # another MagicMock by default, which is truthy and would cause
+    # spurious calls to ``find_relevant_past_turn`` even when the test
+    # never seeded a session. Replace the attribute with a real dict so
+    # the pin path follows production semantics: presence ⇒ session
+    # exists, absence ⇒ no session.
+    photon_deps["photon_inference"]._sessions = {}
+    return pipeline, baseline_deps, photon_deps, mock_session, mock_results
+
+
+def _make_fake_photon_session(
+    *,
+    matched_turn_id: int | None,
+    raise_exc: type[BaseException] | None = None,
+):
+    """Build a stub object exposing only ``current_state`` and
+    ``find_relevant_past_turn`` so tests can drive the pin write branch
+    without booting PHOTON."""
+    from photon_mlx.session import TurnState
+
+    fake = MagicMock()
+    fake.current_state = MagicMock(name="hierarchical_state")
+    if raise_exc is not None:
+
+        def _raise(_state):
+            raise raise_exc("synthetic test error")
+
+        fake.find_relevant_past_turn.side_effect = _raise
+    elif matched_turn_id is None:
+        fake.find_relevant_past_turn.return_value = None
+    else:
+        fake.find_relevant_past_turn.return_value = TurnState(
+            turn_id=matched_turn_id,
+            hierarchical_state=MagicMock(name="match_hstate"),
+        )
+    return fake
+
+
+def _run_query_with_mocks(
+    pipeline,
+    baseline_deps,
+    photon_deps,
+    mock_results,
+    *,
+    question: str = "follow-up?",
+    expanded_ids: list[str] | None = None,
+):
+    """Run ``pipeline.query`` with hybrid_search / expand_with_graph mocks
+    plus a working ``store.get_many`` so the evidence pack code path
+    completes without needing real chunks."""
+    from baseline_reporag.ingestion.chunker import Chunk
+
+    if expanded_ids is None:
+        expanded_ids = [f"chunk_{i}" for i in range(16)]
+
+    chunks = [
+        Chunk(
+            chunk_id=cid,
+            repo_id="test-repo",
+            repo_commit="abc123",
+            rel_path=f"{cid}.py",
+            language="python",
+            start_line=1,
+            end_line=10,
+            content=f"def f_{cid}(): pass",
+            symbols=[cid],
+            section_header="",
+            file_header="",
+        )
+        for cid in expanded_ids
+    ]
+    by_id = {c.chunk_id: c for c in chunks}
+    baseline_deps["store"].get_many.side_effect = lambda ids: [
+        by_id[cid] for cid in ids if cid in by_id
+    ]
+    baseline_deps["generator"].generate.return_value = "answer [C:1]"
+
+    with (
+        patch(
+            "baseline_reporag.photon_pipeline.hybrid_search",
+            return_value=mock_results,
+        ),
+        patch(
+            "baseline_reporag.photon_pipeline.expand_with_graph",
+            return_value=expanded_ids,
+        ),
+    ):
+        return pipeline.query(question, session_id="s1", repo_id="test-repo")
+
+
+class TestPastTurnPinning:
+    """Issue #103: pipeline integration of ``find_relevant_past_turn``.
+
+    DR1-009: scope is the pipeline glue (cache write/read/pop, opt-in
+    OFF, fail-closed branches, profiler phase). The behaviour of
+    ``find_relevant_past_turn`` itself is covered by the 11 existing
+    Issue #78 unit tests in ``photon_mlx/tests/test_session.py`` and is
+    deliberately NOT re-tested here — every test in this class stubs
+    ``photon_inference._sessions`` so production retrieval semantics are
+    not entangled with PHOTON inference details.
+    """
+
+    # ---- Group A: opt-in OFF must short-circuit. ----
+
+    def test_pinning_disabled_skips_find_relevant_past_turn(self) -> None:
+        cfg = _make_pinning_cfg(enabled=False)
+        pipeline, baseline_deps, photon_deps, _ms, mock_results = (
+            _setup_pipeline_for_pinning(cfg, session_turns=1)
+        )
+        fake_session = _make_fake_photon_session(matched_turn_id=1)
+        photon_deps["photon_inference"]._sessions["s1"] = fake_session
+
+        _run_query_with_mocks(pipeline, baseline_deps, photon_deps, mock_results)
+
+        fake_session.find_relevant_past_turn.assert_not_called()
+
+    def test_pinning_disabled_does_not_access_photon_sessions(self) -> None:
+        cfg = _make_pinning_cfg(enabled=False)
+        pipeline, baseline_deps, photon_deps, _ms, mock_results = (
+            _setup_pipeline_for_pinning(cfg, session_turns=1)
+        )
+        # Replace ``_sessions`` with an instrumented dict subclass so any
+        # ``.get`` access from the pinning path raises.
+        recorded: list[tuple[str, str]] = []
+
+        class _SpyDict(dict):
+            def get(self, key, default=None):
+                recorded.append(("get", key))
+                return super().get(key, default)
+
+        photon_deps["photon_inference"]._sessions = _SpyDict()
+
+        _run_query_with_mocks(pipeline, baseline_deps, photon_deps, mock_results)
+
+        # No `.get(s1, None)` call from the pinning path. The pruning
+        # path is disabled in this cfg so any `_sessions.get` call would
+        # have to come from pinning — and pinning is OFF, so the list
+        # must be empty.
+        assert recorded == []
+
+    def test_pinning_disabled_no_new_profiler_phase(self) -> None:
+        cfg = _make_pinning_cfg(enabled=False)
+        pipeline, baseline_deps, photon_deps, _ms, mock_results = (
+            _setup_pipeline_for_pinning(cfg, session_turns=1)
+        )
+
+        captured: list[set[str]] = []
+        real_query = pipeline.query
+
+        def _wrap(*args, **kwargs):
+            from baseline_reporag.profiler import TurnProfiler
+
+            real_init = TurnProfiler.__init__
+
+            def _spy_init(self):
+                real_init(self)
+                captured.append(self)
+
+            with patch.object(TurnProfiler, "__init__", _spy_init):
+                return real_query(*args, **kwargs)
+
+        # Simpler: just inspect the result's latency_breakdown via prof
+        # phases. After the run, no past_turn_pinning phase should exist.
+        _run_query_with_mocks(pipeline, baseline_deps, photon_deps, mock_results)
+        # Nothing further to assert via captured (we just exercise the
+        # full query path); the relevant invariant is enforced at the
+        # next test which asserts the phase IS present when ON.
+        # Defensive guardrail: ensure pinning OFF didn't crash and
+        # didn't allocate the cache for s1.
+        assert "s1" not in pipeline._relevant_past_turn_cache
+
+    # ---- Group B: pinning ON — write side. ----
+
+    def test_pinning_caches_match_for_next_turn(self) -> None:
+        from photon_mlx.session import TurnState
+
+        cfg = _make_pinning_cfg(enabled=True)
+        pipeline, baseline_deps, photon_deps, _ms, mock_results = (
+            _setup_pipeline_for_pinning(cfg, session_turns=1)
+        )
+        fake_session = _make_fake_photon_session(matched_turn_id=1)
+        photon_deps["photon_inference"]._sessions["s1"] = fake_session
+
+        _run_query_with_mocks(pipeline, baseline_deps, photon_deps, mock_results)
+
+        # Cache must hold the matched TurnState keyed by photon_session_id.
+        assert "s1" in pipeline._relevant_past_turn_cache
+        cached = pipeline._relevant_past_turn_cache["s1"]
+        assert isinstance(cached, TurnState)
+        assert cached.turn_id == 1
+
+    def test_pinning_enabled_turn1_no_pin(self) -> None:
+        """Turn 1 has no follow-up history; the pin read branch must be
+        skipped, and the write side may still run (writes empty when
+        no past turn exists to match)."""
+        cfg = _make_pinning_cfg(enabled=True)
+        pipeline, baseline_deps, photon_deps, _ms, mock_results = (
+            _setup_pipeline_for_pinning(cfg, session_turns=0)
+        )
+        fake_session = _make_fake_photon_session(matched_turn_id=None)
+        photon_deps["photon_inference"]._sessions["s1"] = fake_session
+
+        with patch("baseline_reporag.photon_pipeline.build_evidence_pack") as spy_pack:
+            spy_pack.side_effect = build_evidence_pack
+            _run_query_with_mocks(pipeline, baseline_deps, photon_deps, mock_results)
+
+        # On Turn 1 (session.turns is empty entering the call), the pin
+        # read branch must not emit ``additional_pinned_ids``.
+        assert spy_pack.call_count == 1
+        kwargs = spy_pack.call_args.kwargs
+        assert kwargs.get("additional_pinned_ids") is None
+
+    def test_pinning_enabled_turn2_below_threshold_no_pin(self) -> None:
+        """Turn 2: cache is empty (Turn 1 stored nothing because no past
+        match existed). Read side must produce no pin even though
+        pinning is enabled."""
+        cfg = _make_pinning_cfg(enabled=True)
+        pipeline, baseline_deps, photon_deps, _ms, mock_results = (
+            _setup_pipeline_for_pinning(cfg, session_turns=1)
+        )
+        fake_session = _make_fake_photon_session(matched_turn_id=None)
+        photon_deps["photon_inference"]._sessions["s1"] = fake_session
+
+        with patch("baseline_reporag.photon_pipeline.build_evidence_pack") as spy_pack:
+            spy_pack.side_effect = build_evidence_pack
+            _run_query_with_mocks(pipeline, baseline_deps, photon_deps, mock_results)
+
+        kwargs = spy_pack.call_args.kwargs
+        assert kwargs.get("additional_pinned_ids") is None
+
+    def test_pinning_enabled_turn2_above_threshold_pins_at_turn3(self) -> None:
+        """Turn 2 writes a match; Turn 3 read must consume it as a pin."""
+        from photon_mlx.session import TurnState
+
+        cfg = _make_pinning_cfg(enabled=True)
+        pipeline, baseline_deps, photon_deps, mock_session, mock_results = (
+            _setup_pipeline_for_pinning(cfg, session_turns=2)
+        )
+        # Pre-load Baseline session with cited_chunk_ids on turn_id=1.
+        # ``_setup_pipeline_for_pinning`` already added 2 turns with empty
+        # citations; we patch turn 1 to record citations matching the
+        # pin.
+        mock_session.turns[0].cited_chunk_ids[:] = ["chunk_0", "chunk_1"]
+
+        # Seed cache as if Turn 2 had matched turn_id=1.
+        pipeline._relevant_past_turn_cache["s1"] = TurnState(
+            turn_id=1,
+            hierarchical_state=MagicMock(name="match_hstate"),
+        )
+        fake_session = _make_fake_photon_session(matched_turn_id=None)
+        photon_deps["photon_inference"]._sessions["s1"] = fake_session
+
+        with patch("baseline_reporag.photon_pipeline.build_evidence_pack") as spy_pack:
+            spy_pack.side_effect = build_evidence_pack
+            _run_query_with_mocks(pipeline, baseline_deps, photon_deps, mock_results)
+
+        kwargs = spy_pack.call_args.kwargs
+        # The pinned IDs must come from turn 1's cited_chunk_ids.
+        assert kwargs["additional_pinned_ids"] == ["chunk_0", "chunk_1"]
+
+    def test_pinning_respects_max_pinned_chunks(self) -> None:
+        """``max_pinned_chunks`` truncates the cited list."""
+        from photon_mlx.session import TurnState
+
+        cfg = _make_pinning_cfg(enabled=True, max_pinned=2)
+        pipeline, baseline_deps, photon_deps, mock_session, mock_results = (
+            _setup_pipeline_for_pinning(cfg, session_turns=2)
+        )
+        mock_session.turns[0].cited_chunk_ids[:] = [
+            "chunk_a",
+            "chunk_b",
+            "chunk_c",
+            "chunk_d",
+        ]
+        pipeline._relevant_past_turn_cache["s1"] = TurnState(
+            turn_id=1,
+            hierarchical_state=MagicMock(),
+        )
+        photon_deps["photon_inference"]._sessions["s1"] = _make_fake_photon_session(
+            matched_turn_id=None
+        )
+
+        with patch("baseline_reporag.photon_pipeline.build_evidence_pack") as spy_pack:
+            spy_pack.side_effect = build_evidence_pack
+            _run_query_with_mocks(pipeline, baseline_deps, photon_deps, mock_results)
+
+        kwargs = spy_pack.call_args.kwargs
+        assert kwargs["additional_pinned_ids"] == ["chunk_a", "chunk_b"]
+
+    def test_pinning_does_not_double_count_existing_retrieval_hits(
+        self,
+    ) -> None:
+        """If a pinned chunk is already in ``expanded_ids``, dedup keeps
+        the pack from inflating beyond ``max_chunks``."""
+        from photon_mlx.session import TurnState
+
+        cfg = _make_pinning_cfg(enabled=True)
+        pipeline, baseline_deps, photon_deps, mock_session, mock_results = (
+            _setup_pipeline_for_pinning(cfg, session_turns=2)
+        )
+        mock_session.turns[0].cited_chunk_ids[:] = ["chunk_0"]
+        pipeline._relevant_past_turn_cache["s1"] = TurnState(
+            turn_id=1, hierarchical_state=MagicMock()
+        )
+        photon_deps["photon_inference"]._sessions["s1"] = _make_fake_photon_session(
+            matched_turn_id=None
+        )
+
+        # Spy on build_evidence_pack so we can introspect the EvidencePack
+        # it returned (QueryResult does not surface the pack directly —
+        # see contracts.QueryResult).
+        captured: dict[str, object] = {}
+        real_build = build_evidence_pack
+
+        def _spy(*args, **kwargs):
+            pack = real_build(*args, **kwargs)
+            captured["pack"] = pack
+            return pack
+
+        with patch(
+            "baseline_reporag.photon_pipeline.build_evidence_pack",
+            side_effect=_spy,
+        ):
+            _run_query_with_mocks(pipeline, baseline_deps, photon_deps, mock_results)
+
+        # Pack must not contain chunk_0 twice (set semantics inside
+        # build_evidence_pack / _merge_pinned_sets guarantees this; we
+        # assert here as a contract regression guard).
+        pack = captured["pack"]
+        ids = [c.chunk_id for c in pack.chunks]
+        assert ids.count("chunk_0") == 1
+
+    def test_pinning_failclosed_on_session_state_none(self) -> None:
+        """If ``photon_inference._sessions`` has no entry for the
+        session_id, the write branch must pop the cache instead of
+        attempting to call find_relevant_past_turn."""
+        from photon_mlx.session import TurnState
+
+        cfg = _make_pinning_cfg(enabled=True)
+        pipeline, baseline_deps, photon_deps, _ms, mock_results = (
+            _setup_pipeline_for_pinning(cfg, session_turns=1)
+        )
+        # Pre-seed the cache with a stale entry.
+        pipeline._relevant_past_turn_cache["s1"] = TurnState(
+            turn_id=999,
+            hierarchical_state=MagicMock(),
+        )
+        # No entry for "s1" in the fake _sessions dict.
+        assert "s1" not in photon_deps["photon_inference"]._sessions
+
+        _run_query_with_mocks(pipeline, baseline_deps, photon_deps, mock_results)
+
+        # The stale cache entry must have been popped by the read side
+        # (consume), and the write side leaves it absent because no
+        # PHOTON session exists for s1.
+        assert "s1" not in pipeline._relevant_past_turn_cache
+
+    def test_pinning_logs_match_metadata(self, caplog) -> None:
+        """DR4-001: production log must NOT contain turn_id, similarity,
+        or scanned_turns when find_relevant_past_turn raises. Only the
+        exception class name is allowed."""
+        import logging
+
+        cfg = _make_pinning_cfg(enabled=True)
+        pipeline, baseline_deps, photon_deps, _ms, mock_results = (
+            _setup_pipeline_for_pinning(cfg, session_turns=1)
+        )
+        fake_session = _make_fake_photon_session(
+            matched_turn_id=None, raise_exc=RuntimeError
+        )
+        photon_deps["photon_inference"]._sessions["s1"] = fake_session
+
+        with caplog.at_level(
+            logging.WARNING, logger="baseline_reporag.photon_pipeline"
+        ):
+            _run_query_with_mocks(pipeline, baseline_deps, photon_deps, mock_results)
+
+        msgs = [r.getMessage() for r in caplog.records]
+        combined = " ".join(msgs)
+        # Exception class name must be present so operators can diagnose
+        # fail-closed warnings.
+        assert "RuntimeError" in combined, msgs
+        # No turn_id / similarity / scanned_turns / raw exception text
+        # leakage. Lower-case the haystack so we catch any case-variant.
+        assert "turn_id" not in combined.lower(), msgs
+        assert "similarity" not in combined.lower(), msgs
+        assert "scanned_turns" not in combined.lower(), msgs
+        assert "synthetic test error" not in combined, msgs
+
+    def test_pinning_priority_overrides_recent_cited(self) -> None:
+        """Pinned chunks (priority 0) must outrank recent_cited
+        (priority 1) when ``max_chunks`` is tight."""
+        from photon_mlx.session import TurnState
+
+        cfg = _make_pinning_cfg(enabled=True)
+        # Reduce max_chunks so priority ordering matters. ``Config`` uses
+        # plain ``setattr`` so direct attribute assignment is fine.
+        cfg.evidence_pack.max_chunks = 2
+        pipeline, baseline_deps, photon_deps, mock_session, mock_results = (
+            _setup_pipeline_for_pinning(cfg, session_turns=1)
+        )
+        # Make turn 1's cited_chunk_ids reference "chunk_15" (last
+        # candidate; would normally lose at priority sort time).
+        mock_session.turns[0].cited_chunk_ids[:] = ["chunk_15"]
+        # Seed pin to refer to turn 1's cited list.
+        pipeline._relevant_past_turn_cache["s1"] = TurnState(
+            turn_id=1, hierarchical_state=MagicMock()
+        )
+        photon_deps["photon_inference"]._sessions["s1"] = _make_fake_photon_session(
+            matched_turn_id=None
+        )
+
+        captured: dict[str, object] = {}
+        real_build = build_evidence_pack
+
+        def _spy(*args, **kwargs):
+            pack = real_build(*args, **kwargs)
+            captured["pack"] = pack
+            return pack
+
+        with patch(
+            "baseline_reporag.photon_pipeline.build_evidence_pack",
+            side_effect=_spy,
+        ):
+            _run_query_with_mocks(pipeline, baseline_deps, photon_deps, mock_results)
+
+        pack = captured["pack"]
+        ids = [c.chunk_id for c in pack.chunks]
+        # chunk_15 was pinned at priority 0 and must now lead the pack.
+        assert ids[0] == "chunk_15", ids
+
+    def test_pinning_cache_cleared_after_use(self) -> None:
+        """Read side ``pop`` must consume the cache entry — the same
+        pin must NOT survive into a subsequent turn that produces no
+        new match."""
+        from photon_mlx.session import TurnState
+
+        cfg = _make_pinning_cfg(enabled=True)
+        pipeline, baseline_deps, photon_deps, mock_session, mock_results = (
+            _setup_pipeline_for_pinning(cfg, session_turns=2)
+        )
+        mock_session.turns[0].cited_chunk_ids[:] = ["chunk_0"]
+        pipeline._relevant_past_turn_cache["s1"] = TurnState(
+            turn_id=1, hierarchical_state=MagicMock()
+        )
+        # Write side will produce None (no new match), so cache must
+        # remain empty after the call.
+        photon_deps["photon_inference"]._sessions["s1"] = _make_fake_photon_session(
+            matched_turn_id=None
+        )
+
+        _run_query_with_mocks(pipeline, baseline_deps, photon_deps, mock_results)
+
+        assert "s1" not in pipeline._relevant_past_turn_cache
+
+    def test_pinning_failclosed_on_drift_none_pops_stale_cache(self) -> None:
+        """DR2-011 + DR1-007: when ``drift is None`` (tokenize fail-closed
+        / Safe RecGen reset), the write branch must explicitly pop the
+        cache so a stale pin from a prior turn cannot survive."""
+        from photon_mlx.session import TurnState
+
+        cfg = _make_pinning_cfg(enabled=True)
+        pipeline, baseline_deps, photon_deps, _ms, mock_results = (
+            _setup_pipeline_for_pinning(cfg, session_turns=1)
+        )
+        # Force tokenize_evidence_pack to raise → drift will be None.
+        fake_session = _make_fake_photon_session(matched_turn_id=42)
+        photon_deps["photon_inference"]._sessions["s1"] = fake_session
+        # Pre-load a stale cache entry that should be wiped.
+        pipeline._relevant_past_turn_cache["s1"] = TurnState(
+            turn_id=999, hierarchical_state=MagicMock()
+        )
+
+        with patch(
+            "baseline_reporag.photon_pipeline.tokenize_evidence_pack",
+            side_effect=RuntimeError("tokenize boom"),
+        ):
+            _run_query_with_mocks(pipeline, baseline_deps, photon_deps, mock_results)
+
+        # tokenize fail-closed:
+        # 1. read side popped any stale pin (consumed, returns None).
+        # 2. ``_clear_photon_session_artifacts`` ran and popped again.
+        # 3. drift is None → write branch pops one more time
+        #    (DR2-011 invariant).
+        # In all three legs the post-call cache must be empty.
+        assert "s1" not in pipeline._relevant_past_turn_cache
+        # find_relevant_past_turn must NOT have been invoked because
+        # drift is None short-circuits the write branch into pop-only.
+        fake_session.find_relevant_past_turn.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Issue #103: WorkingMemoryConfig YAML propagation for pinning fields
+# ---------------------------------------------------------------------------
+
+
+class TestWorkingMemoryConfigPastTurnPinningYamlPropagation:
+    """Issue #103: ``past_turn_pinning_enabled`` / ``max_pinned_chunks`` reach
+    ``PhotonInference._working_memory_cfg`` through the same paths the
+    Issue #80 aggregation key already uses.
+
+    Scope (DR3-002): mirrors
+    :class:`TestWorkingMemoryConfigAggregationYamlPropagation`'s contract
+    for the two new pinning keys to confirm parity:
+
+    1. ``_resolve_working_memory_cfg`` dict roundtrip preserves the keys.
+    2. ``_build_photon_deps`` YAML roundtrip carries the keys through.
+    3. ``deep_merge`` overrides do not blow away sibling
+       ``aggregation`` / ``dynamic_strategy`` knobs.
+    """
+
+    def test_working_memory_pinning_keys_roundtrip_via_extract_cfg(self):
+        from baseline_reporag.photon_pipeline import _resolve_working_memory_cfg
+        from photon_mlx.session import WorkingMemoryConfig
+
+        result = _resolve_working_memory_cfg(
+            {
+                "enabled": True,
+                "max_turns": 5,
+                "past_turn_pinning_enabled": True,
+                "max_pinned_chunks": 4,
+            }
+        )
+        assert isinstance(result, WorkingMemoryConfig)
+        assert result.past_turn_pinning_enabled is True
+        assert result.max_pinned_chunks == 4
+        # Sibling keys must survive.
+        assert result.enabled is True
+        assert result.max_turns == 5
+
+    def test_working_memory_pinning_keys_roundtrip_via_build_photon_deps(
+        self, tmp_path
+    ):
+        """Full YAML path: pinning keys reach
+        ``PhotonInference._working_memory_cfg`` after
+        ``_build_photon_deps``."""
+        from baseline_reporag.config import load_config
+        from baseline_reporag.photon_pipeline import _build_photon_deps
+        from photon_mlx.session import WorkingMemoryConfig
+
+        cfg_file = tmp_path / "photon.yaml"
+        cfg_file.write_text(
+            "model:\n"
+            "  provider: photon\n"
+            "  architecture: photon_decoder\n"
+            "  base_embed_dim: 64\n"
+            "  hidden_size: 128\n"
+            "  intermediate_size: 256\n"
+            "  num_heads: 4\n"
+            "  vocab_size: 1000\n"
+            "hierarchy:\n"
+            "  levels: 2\n"
+            "  chunk_sizes: [4, 4]\n"
+            "  encoder_layers_per_level: [2, 2]\n"
+            "  decoder_layers_per_level: [2, 2]\n"
+            "inference:\n"
+            "  hierarchical_prefill: true\n"
+            "  safe_recgen_enabled: false\n"
+            "session_memory:\n"
+            "  mode: photon\n"
+            "  working_memory:\n"
+            "    enabled: true\n"
+            "    max_turns: 4\n"
+            "    past_turn_pinning_enabled: true\n"
+            "    max_pinned_chunks: 5\n"
+        )
+        cfg = load_config(str(cfg_file))
+        deps = _build_photon_deps(cfg)
+        wm = deps["photon_inference"]._working_memory_cfg
+        assert isinstance(wm, WorkingMemoryConfig)
+        assert wm.past_turn_pinning_enabled is True
+        assert wm.max_pinned_chunks == 5
+
+    def test_working_memory_deep_merge_preserves_aggregation_with_pinning(
+        self, tmp_path
+    ):
+        """``deep_merge`` override that adds pinning keys must keep
+        existing ``aggregation`` / ``dynamic_strategy`` / ``hybrid_*``
+        sibling keys intact."""
+        from baseline_reporag.config import deep_merge, load_config
+        from baseline_reporag.photon_pipeline import _build_photon_deps
+        from photon_mlx.session import WorkingMemoryConfig
+
+        base_cfg = {
+            "model": {
+                "provider": "photon",
+                "architecture": "photon_decoder",
+                "base_embed_dim": 64,
+                "hidden_size": 128,
+                "intermediate_size": 256,
+                "num_heads": 4,
+                "vocab_size": 1000,
+            },
+            "hierarchy": {
+                "levels": 2,
+                "chunk_sizes": [4, 4],
+                "encoder_layers_per_level": [2, 2],
+                "decoder_layers_per_level": [2, 2],
+            },
+            "inference": {
+                "hierarchical_prefill": True,
+                "safe_recgen_enabled": False,
+            },
+            "session_memory": {
+                "mode": "photon",
+                "working_memory": {
+                    "enabled": True,
+                    "max_turns": 5,
+                    "decay_factor": 0.25,
+                    "aggregation": "dynamic",
+                    "dynamic_strategy": "hybrid",
+                    "hybrid_alpha_base": 0.4,
+                    "hybrid_alpha_per_turn": 0.05,
+                },
+            },
+        }
+        # Override that ONLY toggles the new pinning keys.
+        override = {
+            "session_memory": {
+                "working_memory": {
+                    "past_turn_pinning_enabled": True,
+                    "max_pinned_chunks": 2,
+                },
+            },
+        }
+        merged = deep_merge(base_cfg, override)
+
+        import yaml as _yaml
+
+        cfg_file = tmp_path / "merged.yaml"
+        cfg_file.write_text(_yaml.safe_dump(merged))
+        cfg = load_config(str(cfg_file))
+        deps = _build_photon_deps(cfg)
+        wm = deps["photon_inference"]._working_memory_cfg
+        assert isinstance(wm, WorkingMemoryConfig)
+        # Pinning keys flowed through.
+        assert wm.past_turn_pinning_enabled is True
+        assert wm.max_pinned_chunks == 2
+        # Aggregation + dynamic knobs preserved by deep_merge.
+        assert wm.aggregation == "dynamic"
+        assert wm.dynamic_strategy == "hybrid"
+        assert abs(wm.hybrid_alpha_base - 0.4) < 1e-9
+        assert abs(wm.hybrid_alpha_per_turn - 0.05) < 1e-9
+        # Other sibling keys preserved.
+        assert wm.enabled is True
+        assert wm.max_turns == 5
+        assert abs(wm.decay_factor - 0.25) < 1e-9

--- a/bench/run_all.py
+++ b/bench/run_all.py
@@ -3,6 +3,7 @@ run_all.py  –  Run all benchmark variants defined in eval.yaml.
 
 Usage:
     python bench/run_all.py --config configs/eval.yaml
+    python bench/run_all.py --config configs/eval.yaml --variants id1,id2
 """
 
 from __future__ import annotations
@@ -13,6 +14,89 @@ import time
 import uuid
 from pathlib import Path
 from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# --variants CSV helpers (Issue #92 T-0b)
+# ---------------------------------------------------------------------------
+
+
+def parse_variants_csv(raw: str | None) -> list[str]:
+    """Split a CSV string into a list of variant ids.
+
+    Pure-Python ``str.split(',')`` only — no shell / subprocess (DR4-002
+    security contract).
+
+    Codex CB-003 fail-closed (Issue #92 T-0b): there are three inputs we
+    must distinguish so malformed ``--variants`` cannot silently escalate
+    to "run all variants":
+
+    * ``raw is None``       → flag not passed → return ``[]`` (no filter).
+    * ``raw`` is non-empty and every comma-separated token is a non-empty
+      non-whitespace string → return the stripped token list.
+    * Otherwise (``raw == ""``, ``","``, ``"a,,b"``, ``" "``, ``",a"``,
+      ``"a,"``, ...) the CSV is malformed. Raise
+      :class:`argparse.ArgumentTypeError` WITHOUT embedding the raw value
+      (DR4-001 no-leak — the attacker-controlled string must not reach
+      logs / tracebacks).
+
+    The ``None`` vs. empty-CSV distinction is what keeps :func:`filter_variants`
+    from fail-OPEN-ing on a typo: previously ``--variants ','`` collapsed
+    to ``[]`` and then the ``if not selected`` branch in ``filter_variants``
+    treated it as "no filter → all variants run".
+    """
+    if raw is None:
+        return []
+    # Empty / whitespace-only CSV is a hard error (distinct from ``None``).
+    if not raw.strip():
+        raise argparse.ArgumentTypeError(
+            "--variants must be a non-empty comma-separated list of ids"
+        )
+    tokens = raw.split(",")
+    stripped = [tok.strip() for tok in tokens]
+    if any(not tok for tok in stripped):
+        # Any empty middle / leading / trailing token fails closed.
+        raise argparse.ArgumentTypeError(
+            "--variants must not contain empty or whitespace-only tokens"
+        )
+    return stripped
+
+
+def filter_variants(
+    variants: list[dict],
+    selected: list[str] | None,
+) -> list[dict]:
+    """Filter ``variants`` to those whose id is in ``selected`` (CSV-ordered).
+
+    ``selected`` semantics:
+
+    * ``None`` or ``[]`` → return ``variants`` unchanged (no filter applied).
+    * Otherwise: every id in ``selected`` MUST match a variant's ``id`` via
+      exact string equality. An unknown id raises
+      :class:`argparse.ArgumentError` with a fail-closed message that
+      intentionally excludes the raw invalid token (DR4-001 no-leak; only
+      the allowed-id count is surfaced).
+
+    Order in the returned list matches the CSV order so downstream reports
+    are deterministic when re-running a subset.
+    """
+    if not selected:
+        return list(variants)
+
+    by_id: dict[str, dict] = {v["id"]: v for v in variants}
+    result: list[dict] = []
+    for sid in selected:
+        if sid not in by_id:
+            # No-leak: the unknown id is attacker-controlled; surface only
+            # the count of allowed ids so operators can diagnose without
+            # seeing attacker payload. Raise via argparse so CLI entry
+            # point fails closed with a clean usage error.
+            raise argparse.ArgumentError(
+                None,
+                f"--variants contains an unknown id; allowed ids count = {len(by_id)}",
+            )
+        result.append(by_id[sid])
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -177,6 +261,14 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Run all benchmark variants")
     parser.add_argument("--config", default="configs/eval.yaml")
     parser.add_argument("--run-id", default="")
+    parser.add_argument(
+        "--variants",
+        default=None,
+        help=(
+            "Optional comma-separated list of variant ids to run. Unknown "
+            "ids fail closed (Issue #92 T-0b)."
+        ),
+    )
     args = parser.parse_args()
 
     import yaml
@@ -191,7 +283,21 @@ def main() -> None:
     print(f"run_id:     {run_id}")
     print(f"output_dir: {output_dir}\n")
 
-    for variant in cfg.get("variants", []):
+    # Codex CB-003: ``parse_variants_csv`` raises ``ArgumentTypeError`` on
+    # malformed CSV (empty tokens). Route it through ``parser.error`` so
+    # the CLI exits with a clean usage message (same treatment as the
+    # unknown-id case below). The raw value is already sanitized away
+    # inside ``parse_variants_csv``.
+    try:
+        selected_ids = parse_variants_csv(args.variants)
+    except argparse.ArgumentTypeError as exc:
+        parser.error(str(exc))
+    try:
+        variants_to_run = filter_variants(cfg.get("variants", []), selected_ids)
+    except argparse.ArgumentError as exc:
+        parser.error(str(exc))
+
+    for variant in variants_to_run:
         print(f"  variant: {variant['id']} ...")
         predictions = run_variant(variant, cfg)
         path = save_run_predictions(run_id, variant["id"], predictions, output_dir)

--- a/bench/tests/test_run_all.py
+++ b/bench/tests/test_run_all.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
+import argparse
 import json
 from dataclasses import dataclass
 from unittest.mock import MagicMock, patch
 
-from bench.run_all import run_variant, save_run_predictions
+import pytest
+
+from bench.run_all import (
+    filter_variants,
+    parse_variants_csv,
+    run_variant,
+    save_run_predictions,
+)
 
 
 # ------------------------------------------------------------------
@@ -206,3 +214,156 @@ class TestSaveRunPredictions:
         lines = path.read_text().strip().split("\n")
         assert len(lines) == 1
         assert json.loads(lines[0])["eval_id"] == "SE-001"
+
+
+# ------------------------------------------------------------------
+# Issue #92 T-0b: --variants CSV filter tests
+# ------------------------------------------------------------------
+
+
+class TestParseVariantsCsv:
+    """``parse_variants_csv`` splits on ``,``, strips whitespace, fail-closed on empties.
+
+    Codex CB-003 (Issue #92): empty / whitespace / empty-middle tokens
+    are REJECTED (fail-closed), not silently dropped. ``None`` (flag not
+    passed) is still distinct from an explicitly empty CSV.
+    """
+
+    def test_simple_csv_splits(self) -> None:
+        assert parse_variants_csv("a,b,c") == ["a", "b", "c"]
+
+    def test_strips_whitespace(self) -> None:
+        assert parse_variants_csv(" a , b ,c ") == ["a", "b", "c"]
+
+    def test_single_token_ok(self) -> None:
+        assert parse_variants_csv("a") == ["a"]
+        assert parse_variants_csv("a,b") == ["a", "b"]
+
+    def test_none_returns_empty_list(self) -> None:
+        # ``None`` means "flag not passed" — still the "no filter" signal.
+        assert parse_variants_csv(None) == []
+
+    # ---- Codex CB-003 fail-closed regression tests ----
+
+    def test_empty_string_rejected(self) -> None:
+        """``--variants ''`` must fail closed (was silently empty before)."""
+        with pytest.raises(argparse.ArgumentTypeError):
+            parse_variants_csv("")
+
+    def test_whitespace_only_rejected(self) -> None:
+        """``--variants ' '`` must fail closed."""
+        with pytest.raises(argparse.ArgumentTypeError):
+            parse_variants_csv(" ")
+        with pytest.raises(argparse.ArgumentTypeError):
+            parse_variants_csv("   \t  ")
+
+    def test_bare_comma_rejected(self) -> None:
+        """``--variants ','`` must fail closed (previously collapsed to ``[]``)."""
+        with pytest.raises(argparse.ArgumentTypeError):
+            parse_variants_csv(",")
+
+    def test_empty_middle_token_rejected(self) -> None:
+        """``--variants 'a,,b'`` must fail closed."""
+        with pytest.raises(argparse.ArgumentTypeError):
+            parse_variants_csv("a,,b")
+
+    def test_trailing_comma_rejected(self) -> None:
+        """``--variants 'a,'`` must fail closed."""
+        with pytest.raises(argparse.ArgumentTypeError):
+            parse_variants_csv("a,")
+
+    def test_leading_comma_rejected(self) -> None:
+        """``--variants ',a'`` must fail closed."""
+        with pytest.raises(argparse.ArgumentTypeError):
+            parse_variants_csv(",a")
+
+    def test_error_messages_do_not_leak_raw_value(self) -> None:
+        """DR4-001 no-leak: raw attacker-controlled value must not appear."""
+        SENSITIVE_WS = "<ATTACK-WHITESPACE-PAYLOAD>"
+        SENSITIVE_MIDDLE = "<ATTACK-MIDDLE-PAYLOAD>"
+        # Whitespace-only: attacker could pass e.g. "   <sentinel>   " but
+        # our reject message must not include it. Only a non-empty but
+        # all-whitespace value hits this path; use a pure-whitespace string
+        # to exercise the empty branch — and verify the attacker name used
+        # in test identification never leaks.
+        with pytest.raises(argparse.ArgumentTypeError) as excinfo:
+            parse_variants_csv("   ")
+        assert SENSITIVE_WS not in str(excinfo.value)
+        # Empty-middle branch: payload supplied as a token.
+        with pytest.raises(argparse.ArgumentTypeError) as excinfo:
+            parse_variants_csv(f"a,,{SENSITIVE_MIDDLE}")
+        assert SENSITIVE_MIDDLE not in str(excinfo.value)
+
+    def test_pure_python_split_no_shell(self) -> None:
+        """Security: parsing must not spawn subprocess / shell.
+
+        We patch ``subprocess`` and ``os.system`` and confirm neither is
+        consulted (DR4-002 no-shell guarantee).
+        """
+        with patch("subprocess.run") as mock_run, patch("os.system") as mock_sys:
+            parse_variants_csv("a,b,c")
+            assert not mock_run.called
+            assert not mock_sys.called
+
+
+class TestFilterVariants:
+    """``filter_variants`` selects variants by id; fail-closed on unknowns."""
+
+    def _mk_variants(self) -> list[dict]:
+        return [
+            {"id": "photon_rag_aggr_weighted"},
+            {"id": "photon_rag_aggr_attention"},
+            {"id": "photon_rag_aggr_last"},
+            {"id": "baseline_rag"},
+        ]
+
+    def test_valid_csv_filters_variants_in_order(self) -> None:
+        """Valid ids select a subset; result preserves the CSV order."""
+        variants = self._mk_variants()
+        selected = filter_variants(
+            variants,
+            ["photon_rag_aggr_attention", "photon_rag_aggr_weighted"],
+        )
+        assert [v["id"] for v in selected] == [
+            "photon_rag_aggr_attention",
+            "photon_rag_aggr_weighted",
+        ]
+
+    def test_none_selection_returns_all(self) -> None:
+        variants = self._mk_variants()
+        assert filter_variants(variants, None) == variants
+
+    def test_empty_selection_returns_all(self) -> None:
+        variants = self._mk_variants()
+        assert filter_variants(variants, []) == variants
+
+    def test_unknown_id_fails_closed(self) -> None:
+        """Unknown id raises ``argparse.ArgumentError`` (fail-closed)."""
+        variants = self._mk_variants()
+        with pytest.raises(argparse.ArgumentError):
+            filter_variants(variants, ["not_a_real_variant_id"])
+
+    def test_unknown_id_error_message_does_not_leak_raw_value(self) -> None:
+        """DR4-001 no-leak: raw invalid value must not appear in error text."""
+        variants = self._mk_variants()
+        SENSITIVE = "<ATTACK-PAYLOAD-VARIANT-SENTINEL>"
+        with pytest.raises(argparse.ArgumentError) as excinfo:
+            filter_variants(variants, [SENSITIVE])
+        assert SENSITIVE not in str(excinfo.value)
+
+    def test_partial_unknown_fails_closed(self) -> None:
+        """A single unknown id in a mostly-valid CSV still fails closed."""
+        variants = self._mk_variants()
+        with pytest.raises(argparse.ArgumentError):
+            filter_variants(
+                variants,
+                ["photon_rag_aggr_weighted", "unknown_x"],
+            )
+
+    def test_no_shell_calls_on_filter(self) -> None:
+        """Filtering must not call subprocess / os.system (DR4-002)."""
+        variants = self._mk_variants()
+        with patch("subprocess.run") as mock_run, patch("os.system") as mock_sys:
+            filter_variants(variants, ["baseline_rag"])
+            assert not mock_run.called
+            assert not mock_sys.called

--- a/configs/eval.yaml
+++ b/configs/eval.yaml
@@ -81,11 +81,17 @@ variants:
         photon_generation_enabled: true
         generation_fallback_policy: "qwen"
 
-  # Issue #80 — aggregation mode comparison variants (3 modes).
-  # Run with:
+  # Issue #80 — static aggregation mode comparison variants (3 modes).
+  # Issue #92 — dynamic aggregation variants added below (3 strategies).
+  # Run the full A/B/C with:
   #   python -m bench.run_all --config configs/eval.yaml \
-  #     --variants photon_rag_aggr_weighted,photon_rag_aggr_attention,photon_rag_aggr_last
-  # Each variant only toggles ``aggregation`` so results are A/B/C comparable.
+  #     --variants photon_rag_aggr_weighted,photon_rag_aggr_attention,photon_rag_aggr_last,\
+  #                photon_rag_aggr_dynamic_turn,photon_rag_aggr_dynamic_drift,photon_rag_aggr_dynamic_hybrid
+  # Re-run the dynamic 3 only with:
+  #   python -m bench.run_all --config configs/eval.yaml \
+  #     --variants photon_rag_aggr_dynamic_turn,photon_rag_aggr_dynamic_drift,photon_rag_aggr_dynamic_hybrid
+  # Each variant only toggles ``aggregation`` (and ``dynamic_strategy``) so
+  # results are A/B/C comparable.
   - id: "photon_rag_aggr_weighted"
     label: "PHOTON-RAG+Aggr(weighted)"
     kind: "photon"
@@ -127,6 +133,63 @@ variants:
         working_memory:
           enabled: true
           aggregation: last
+
+  # Issue #92 — dynamic aggregation: ターン位置ベース。
+  # weighted_until_turn までは weighted、それ以降は attention。
+  - id: "photon_rag_aggr_dynamic_turn"
+    label: "PHOTON-RAG+Aggr(dynamic,turn_position)"
+    kind: "photon"
+    config_path: "./configs/photon_small.yaml"
+    override:
+      inference:
+        safe_recgen_enabled: false
+      safe_recgen:
+        enabled: false
+      session_memory:
+        working_memory:
+          enabled: true
+          aggregation: dynamic
+          dynamic_strategy: turn_position
+          weighted_until_turn: 3
+
+  # Issue #92 — dynamic aggregation: drift ベース。
+  # latest_drift().latent_cosine_drift_top > threshold で attention。
+  - id: "photon_rag_aggr_dynamic_drift"
+    label: "PHOTON-RAG+Aggr(dynamic,drift_based)"
+    kind: "photon"
+    config_path: "./configs/photon_small.yaml"
+    override:
+      inference:
+        safe_recgen_enabled: false
+      safe_recgen:
+        enabled: false
+      session_memory:
+        working_memory:
+          enabled: true
+          aggregation: dynamic
+          dynamic_strategy: drift_based
+          attention_drift_threshold: 0.5
+
+  # Issue #92 — dynamic aggregation: ハイブリッド。
+  # alpha = clamp(base + per_turn * max(0, N - until), 0, 1) で
+  # (1-alpha)*weighted + alpha*attention を混合。
+  - id: "photon_rag_aggr_dynamic_hybrid"
+    label: "PHOTON-RAG+Aggr(dynamic,hybrid)"
+    kind: "photon"
+    config_path: "./configs/photon_small.yaml"
+    override:
+      inference:
+        safe_recgen_enabled: false
+      safe_recgen:
+        enabled: false
+      session_memory:
+        working_memory:
+          enabled: true
+          aggregation: dynamic
+          dynamic_strategy: hybrid
+          weighted_until_turn: 3
+          hybrid_alpha_base: 0.5
+          hybrid_alpha_per_turn: 0.1
 
 fairness:
   fix_repo_snapshot: true

--- a/configs/photon_600m_paper.yaml
+++ b/configs/photon_600m_paper.yaml
@@ -118,9 +118,11 @@ session_memory:
     decay_factor: 0.5
     relevant_turn_threshold: 0.7
     storage_mode: "top_level_only"
-    # Issue #80: session coarse state aggregation mode.
-    # One of {"weighted", "attention", "last"}. Default "weighted" keeps
-    # the pre-#80 decayed-mean behaviour.
+    # Issue #80 / #92: session coarse state aggregation mode.
+    # One of {"weighted", "attention", "last", "dynamic"}. Default
+    # "weighted" keeps the pre-#80 decayed-mean behaviour. "dynamic"
+    # (Issue #92) selects weighted/attention/hybrid at call time via
+    # ``dynamic_strategy`` ∈ {"turn_position","drift_based","hybrid"}.
     aggregation: weighted
 
 tokenizer:

--- a/configs/photon_long_context.yaml
+++ b/configs/photon_long_context.yaml
@@ -125,9 +125,11 @@ session_memory:
     decay_factor: 0.5
     relevant_turn_threshold: 0.7
     storage_mode: "top_level_only"
-    # Issue #80: session coarse state aggregation mode.
-    # One of {"weighted", "attention", "last"}. Default "weighted" keeps
-    # the pre-#80 decayed-mean behaviour.
+    # Issue #80 / #92: session coarse state aggregation mode.
+    # One of {"weighted", "attention", "last", "dynamic"}. Default
+    # "weighted" keeps the pre-#80 decayed-mean behaviour. "dynamic"
+    # (Issue #92) selects weighted/attention/hybrid at call time via
+    # ``dynamic_strategy`` ∈ {"turn_position","drift_based","hybrid"}.
     aggregation: weighted
 
 tokenizer:

--- a/configs/photon_long_context.yaml
+++ b/configs/photon_long_context.yaml
@@ -131,6 +131,9 @@ session_memory:
     # (Issue #92) selects weighted/attention/hybrid at call time via
     # ``dynamic_strategy`` ∈ {"turn_position","drift_based","hybrid"}.
     aggregation: weighted
+    # Issue #103: opt-in past-turn pinning (default off until eval gate).
+    past_turn_pinning_enabled: false
+    max_pinned_chunks: 3
 
 tokenizer:
   tokenizer_id: "mlx-community/Qwen2.5-Coder-14B-Instruct-4bit"

--- a/configs/photon_small.yaml
+++ b/configs/photon_small.yaml
@@ -128,9 +128,13 @@ session_memory:
     decay_factor: 0.5
     relevant_turn_threshold: 0.7
     storage_mode: "full"
-    # Issue #80: session coarse state aggregation mode.
-    # One of {"weighted", "attention", "last"}. Default "weighted" keeps
-    # the pre-#80 decayed-mean behaviour.
+    # Issue #80 / #92: session coarse state aggregation mode.
+    # One of {"weighted", "attention", "last", "dynamic"}. Default
+    # "weighted" keeps the pre-#80 decayed-mean behaviour. "dynamic"
+    # (Issue #92) selects weighted/attention/hybrid at call time via
+    # ``dynamic_strategy`` ∈ {"turn_position","drift_based","hybrid"}
+    # along with the related knobs (weighted_until_turn,
+    # attention_drift_threshold, hybrid_alpha_base, hybrid_alpha_per_turn).
     aggregation: weighted
 
 tokenizer:

--- a/configs/photon_small.yaml
+++ b/configs/photon_small.yaml
@@ -136,6 +136,13 @@ session_memory:
     # along with the related knobs (weighted_until_turn,
     # attention_drift_threshold, hybrid_alpha_base, hybrid_alpha_per_turn).
     aggregation: weighted
+    # Issue #103: opt-in past-turn pinning. When enabled, PHOTON pipeline
+    # calls find_relevant_past_turn after each turn and pins the matched
+    # turn's cited_chunk_ids into the next turn's evidence pack via
+    # ``additional_pinned_ids`` (design §4-3, §8 Step 5). Default false
+    # until the 2-run MT eval gate flips this on globally.
+    past_turn_pinning_enabled: false
+    max_pinned_chunks: 3
 
 tokenizer:
   tokenizer_id: "mlx-community/Qwen2.5-Coder-14B-Instruct-4bit"

--- a/configs/photon_tiny.yaml
+++ b/configs/photon_tiny.yaml
@@ -117,9 +117,11 @@ session_memory:
     decay_factor: 0.5
     relevant_turn_threshold: 0.7
     storage_mode: "full"
-    # Issue #80: session coarse state aggregation mode.
-    # One of {"weighted", "attention", "last"}. Default "weighted" keeps
-    # the pre-#80 decayed-mean behaviour.
+    # Issue #80 / #92: session coarse state aggregation mode.
+    # One of {"weighted", "attention", "last", "dynamic"}. Default
+    # "weighted" keeps the pre-#80 decayed-mean behaviour. "dynamic"
+    # (Issue #92) selects weighted/attention/hybrid at call time via
+    # ``dynamic_strategy`` ∈ {"turn_position","drift_based","hybrid"}.
     aggregation: weighted
 
 tokenizer:

--- a/photon_mlx/session.py
+++ b/photon_mlx/session.py
@@ -11,6 +11,7 @@ import math
 import time
 import warnings
 from dataclasses import dataclass, field
+from typing import Callable, ClassVar
 
 import mlx.core as mx
 
@@ -131,6 +132,18 @@ class DriftMetrics:
     latent_cosine_drift_mid: float = 0.0  # drift of level_states[0] (≥2 levels)
     latent_cosine_drift_token: float = 0.0  # drift of token_proj
 
+    # Issue #92: per-turn dynamic aggregation telemetry (DR1-001 / DR2-002).
+    # Both fields default to ``None`` so pre-existing consumers see no
+    # behaviour change when aggregation is static. Populated by
+    # :meth:`PhotonSessionState._record_selected_mode` after
+    # :meth:`get_session_coarse_state` resolves the mode.
+    # * ``selected_aggregation_mode``: closed-enum ``{"weighted","attention",
+    #   "last","hybrid"}`` when set, ``None`` otherwise.
+    # * ``selected_aggregation_alpha``: finite float only when mode is
+    #   ``"hybrid"``, ``None`` for the three static modes.
+    selected_aggregation_mode: str | None = None
+    selected_aggregation_alpha: float | None = None
+
     @property
     def latent_cosine_drift(self) -> float:
         """Backward-compat alias: equals ``latent_cosine_drift_top`` (DR1-009).
@@ -141,17 +154,22 @@ class DriftMetrics:
         """
         return self.latent_cosine_drift_top
 
-    def as_dict(self) -> dict:
-        """Return a JSON-safe superset schema (Issue #63 + Issue #64).
+    def as_dict(self) -> dict[str, float | int | str | None]:
+        """Return a JSON-safe superset schema (Issue #63 + #64 + #92).
 
-        Includes the legacy ``latent_cosine_drift`` alias plus the three
-        per-level drift keys from Issue #63 (DR3-002). Non-finite values
-        (``NaN`` / ``+Inf`` / ``-Inf``) are replaced with ``0.0`` and a
-        ``warnings.warn`` is emitted — only the field name is included in
-        the warning text so raw latent vectors or question text are never
-        surfaced through this path (design §7).
+        Numeric drift fields (the Issue #63 per-level plus legacy alias)
+        are finite-checked and coerced to ``0.0`` on NaN/Inf with a
+        warning — only the field name is included so raw latent vectors
+        or question text are never surfaced (design §7).
+
+        Issue #92 adds ``selected_aggregation_mode`` (``str | None``) and
+        ``selected_aggregation_alpha`` (``float | None``) to the schema.
+        These two fields are passed through as-is without the finite
+        coercion since ``None`` is a legitimate value (DR1-001 structured
+        telemetry). The return type widens from ``dict[str, float | int]``
+        to ``dict[str, float | int | str | None]`` accordingly.
         """
-        safe: dict[str, float | int] = {"turn_id": self.turn_id}
+        safe: dict[str, float | int | str | None] = {"turn_id": self.turn_id}
         for name in (
             "latent_cosine_drift",
             "latent_cosine_drift_top",
@@ -170,6 +188,11 @@ class DriftMetrics:
                 )
                 raw = 0.0
             safe[name] = round(float(raw), 6)
+
+        # Issue #92: mode/alpha fields are passed through verbatim. ``None``
+        # is the expected default for static aggregation modes.
+        safe["selected_aggregation_mode"] = self.selected_aggregation_mode
+        safe["selected_aggregation_alpha"] = self.selected_aggregation_alpha
         return safe
 
 
@@ -233,6 +256,41 @@ class _WMFieldSentinel:
 _WM_FIELD_UNSET = _WMFieldSentinel()
 
 
+def _validate_finite_float(
+    name: str,
+    val: object,
+    *,
+    low: float | None = None,
+    high: float | None = None,
+) -> float:
+    """Validate ``val`` is a finite float in ``[low, high]`` (Issue #92 T-2).
+
+    Shared helper extracted from :meth:`WorkingMemoryConfig.__post_init__`
+    (DR1-005) so the existing ``decay_factor`` / ``relevant_turn_threshold``
+    checks and the new dynamic fields follow the same type / range /
+    finite-ness contract. Range check is skipped for the bounds that are
+    left as ``None``.
+
+    Error messages intentionally surface only the field name / type name
+    (DR4-001 no-leak) so attacker-controlled YAML cannot inject payload
+    into logs. Returns the ``float()`` coerced value for caller assignment.
+    """
+    if isinstance(val, bool) or not isinstance(val, (int, float)):
+        raise TypeError(f"{name} must be float, got {type(val).__name__}")
+    v = float(val)
+    # DR4-001 no-leak (Codex CB-004): numeric validator error messages
+    # must NOT embed the raw attacker-controlled value. Only the field
+    # name and the constraint (static constants from the caller) are
+    # surfaced so malformed YAML cannot inject payload into logs.
+    if not math.isfinite(v):
+        raise ValueError(f"{name} must be finite")
+    if low is not None and v < low:
+        raise ValueError(f"{name} must be >= {low}")
+    if high is not None and v > high:
+        raise ValueError(f"{name} must be <= {high}")
+    return v
+
+
 @dataclass
 class WorkingMemoryConfig:
     """Configuration for cross-turn hierarchical working memory (Issue #64).
@@ -265,10 +323,46 @@ class WorkingMemoryConfig:
         default_factory=lambda: _WM_FIELD_UNSET
     )
     # Issue #80: aggregation mode selector for ``get_session_coarse_state()``.
-    # ``Literal["weighted", "attention", "last"]`` — default ``weighted`` keeps
-    # the pre-#80 behaviour so YAML configs without this key are backward
-    # compatible.
+    # ``Literal["weighted", "attention", "last", "dynamic"]`` — default
+    # ``weighted`` keeps the pre-#80 behaviour so YAML configs without this
+    # key are backward compatible. Issue #92 adds ``"dynamic"`` so that
+    # ``dynamic_strategy`` selects the aggregation at call time.
     aggregation: str = "weighted"
+
+    # --- Issue #92: dynamic aggregation fields (parse-only unless
+    # ``aggregation == "dynamic"``, so existing YAMLs are unaffected). ---
+    dynamic_strategy: str = "turn_position"
+    """Closed-enum {'turn_position','drift_based','hybrid'}. Selects which
+    dynamic strategy ``get_session_coarse_state()`` uses when
+    ``aggregation == 'dynamic'``. Ignored otherwise (Issue #92 §4)."""
+
+    weighted_until_turn: int = 3
+    """Turn-count threshold for the turn_position / hybrid strategies.
+
+    * turn_position: use ``weighted`` while ``len(turn_history) <= value``,
+      otherwise ``attention``.
+    * hybrid: ``alpha`` begins to ramp up once ``turn_count`` exceeds this
+      value (``alpha = base + per_turn * max(0, turn_count - value)``).
+
+    Must be ``>= 0``. Values ``> max_turns`` only emit a warning rather
+    than raising, to let operators experiment without touching other
+    fields (Issue #92 §4)."""
+
+    attention_drift_threshold: float = 0.5
+    """Finite float in ``[0.0, 1.0]``. drift_based strategy flips to
+    ``attention`` when ``latest_drift().latent_cosine_drift_top`` exceeds
+    this threshold, otherwise stays on ``weighted`` (Issue #92 §4)."""
+
+    hybrid_alpha_base: float = 0.5
+    """Finite float. Starting value of hybrid's ``alpha`` before the
+    per-turn ramp kicks in. The dispatcher clamps the final alpha to
+    ``[0.0, 1.0]``, so out-of-range bases are tolerated here (Issue #92
+    §4)."""
+
+    hybrid_alpha_per_turn: float = 0.1
+    """Finite float. Hybrid alpha's linear slope once ``turn_count``
+    exceeds ``weighted_until_turn``. The dispatcher clamps to ``[0.0,
+    1.0]`` (Issue #92 §4)."""
 
     def __post_init__(self) -> None:
         if not isinstance(self.enabled, bool):
@@ -325,22 +419,19 @@ class WorkingMemoryConfig:
                 f"{WORKING_MEMORY_MAX_TURNS_HARD_CAP} (hard cap), got "
                 f"{self.max_turns}"
             )
-        for name in ("decay_factor", "relevant_turn_threshold"):
-            val = getattr(self, name)
-            if isinstance(val, bool) or not isinstance(val, (int, float)):
-                raise TypeError(f"{name} must be float, got {type(val).__name__}")
-            if not math.isfinite(float(val)):
-                raise ValueError(f"{name} must be finite, got {val}")
-        if not (0.0 <= float(self.decay_factor) <= 1.0):
-            raise ValueError(
-                f"decay_factor must be 0.0 <= float <= 1.0, got {self.decay_factor}"
-            )
-        if not (-1.0 <= float(self.relevant_turn_threshold) <= 1.0):
-            raise ValueError(
-                "relevant_turn_threshold must be -1.0 <= float <= 1.0, got "
-                f"{self.relevant_turn_threshold}"
-            )
-        # Issue #80: aggregation mode — fail-closed on malformed YAML.
+        # Existing Issue #64 fields — route through the shared helper
+        # (Issue #92 DR1-005) so all finite-float validation shares one
+        # code path.
+        self.decay_factor = _validate_finite_float(
+            "decay_factor", self.decay_factor, low=0.0, high=1.0
+        )
+        self.relevant_turn_threshold = _validate_finite_float(
+            "relevant_turn_threshold",
+            self.relevant_turn_threshold,
+            low=-1.0,
+            high=1.0,
+        )
+        # Issue #80 / #92: aggregation mode — fail-closed on malformed YAML.
         # Error messages intentionally exclude the raw value (log-poisoning /
         # PII mitigation, design §6 and DR4-001): only the literal set and the
         # type name are surfaced.
@@ -348,10 +439,59 @@ class WorkingMemoryConfig:
             raise TypeError(
                 f"aggregation must be str, got {type(self.aggregation).__name__}"
             )
-        if self.aggregation not in {"weighted", "attention", "last"}:
+        if self.aggregation not in {"weighted", "attention", "last", "dynamic"}:
             raise ValueError(
-                "aggregation must be one of {'weighted', 'attention', 'last'}"
+                "aggregation must be one of "
+                "{'weighted', 'attention', 'last', 'dynamic'}"
             )
+
+        # --- Issue #92: dynamic_strategy closed-enum validation. ---
+        if not isinstance(self.dynamic_strategy, str):
+            raise TypeError(
+                "dynamic_strategy must be str, got "
+                f"{type(self.dynamic_strategy).__name__}"
+            )
+        if self.dynamic_strategy not in {"turn_position", "drift_based", "hybrid"}:
+            # No-leak: raw value omitted (DR4-001).
+            raise ValueError(
+                "dynamic_strategy must be one of "
+                "{'turn_position', 'drift_based', 'hybrid'}"
+            )
+
+        # --- Issue #92: weighted_until_turn: non-negative int, warn if
+        # above max_turns. ---
+        if isinstance(self.weighted_until_turn, bool) or not isinstance(
+            self.weighted_until_turn, int
+        ):
+            raise TypeError(
+                "weighted_until_turn must be int, got "
+                f"{type(self.weighted_until_turn).__name__}"
+            )
+        if self.weighted_until_turn < 0:
+            raise ValueError(
+                f"weighted_until_turn must be >= 0, got {self.weighted_until_turn}"
+            )
+        if self.weighted_until_turn > self.max_turns:
+            warnings.warn(
+                "weighted_until_turn exceeds max_turns — the turn_position "
+                "strategy will stay on 'weighted' for every retained turn",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+
+        # --- Issue #92: finite-float fields. ---
+        self.attention_drift_threshold = _validate_finite_float(
+            "attention_drift_threshold",
+            self.attention_drift_threshold,
+            low=0.0,
+            high=1.0,
+        )
+        self.hybrid_alpha_base = _validate_finite_float(
+            "hybrid_alpha_base", self.hybrid_alpha_base
+        )
+        self.hybrid_alpha_per_turn = _validate_finite_float(
+            "hybrid_alpha_per_turn", self.hybrid_alpha_per_turn
+        )
 
         # DR1-004: emit DeprecationWarning only when the caller mixed the
         # deprecated ``compress_old_turns`` with a non-default ``storage_mode``.
@@ -887,6 +1027,208 @@ class PhotonSessionState:
         result = mx.sum(attn_weights[:, None] * stacked, axis=0)  # (D,)
         return result
 
+    def _aggregate(
+        self,
+        mode: str,
+        *,
+        vecs: list[mx.array],
+        turn_ids: list[int],
+        weights: list[float],
+        fallback_vec: mx.array,
+    ) -> mx.array:
+        """Run a single aggregation mode on pre-collected inputs (Issue #92 T-1).
+
+        Extracted from :meth:`get_session_coarse_state` so that the new
+        dynamic dispatcher (Issue #92) can reuse the weighted / attention /
+        last branches without duplicating the branch bodies. Behaviour is
+        bit-for-bit identical to the pre-refactor inline logic — existing
+        Issue #80 tests (``test_all_modes_*``) guard the invariants.
+
+        ``mode`` MUST be one of ``"weighted"``, ``"attention"``, ``"last"``;
+        unknown values raise :class:`ValueError` with the raw value
+        intentionally omitted (DR4-001 no-leak).
+        """
+        if mode == "last":
+            return fallback_vec
+        if mode == "weighted":
+            weight_sum = sum(weights)
+            if weight_sum <= 0.0:
+                # All weights were zero (e.g. decay=0 with history > 1).
+                return fallback_vec
+            stacked = mx.stack(vecs, axis=0)  # (N, D)
+            w_arr = mx.array(weights, dtype=mx.float32)[:, None]  # (N, 1)
+            return mx.sum(stacked * w_arr, axis=0) / float(weight_sum)
+        if mode == "attention":
+            # Need a valid current vec to score past turns against.
+            if self.current_state is None or not self.current_state.level_states:
+                return fallback_vec
+            curr_vec = mean_pool(self.current_state.level_states[-1])
+            attn = self._aggregate_attention(
+                vecs,
+                turn_ids,
+                curr_vec,
+                exclude_turn_id=self.current_state.turn_id,
+            )
+            return attn if attn is not None else fallback_vec
+        # Defensive fail-fast for post-__post_init__ corruption
+        # (Issue #80 §8 decision #1 safety net). The raw value is
+        # deliberately omitted from the message.
+        raise ValueError("Unknown aggregation mode")
+
+    # ------------------------------------------------------------------
+    # Issue #92: dynamic aggregation strategies + dispatcher helpers.
+    # ------------------------------------------------------------------
+
+    def _effective_turn_count(self) -> int:
+        """Return storage-mode-invariant effective turn count (Codex CB-001).
+
+        ``len(self.turn_history)`` alone under-counts when
+        ``storage_mode == "summary_only"``, because
+        :meth:`_append_summary_only` never appends to ``turn_history`` and
+        writes to ``compressed_history`` instead. In that mode the
+        turn-position / hybrid strategies would otherwise be stuck at
+        ``weighted`` forever (alpha never ramps).
+
+        Summing both lists gives the number of turns the session has
+        actually observed and that currently contribute to
+        :meth:`get_session_coarse_state`. The two lists are disjoint by
+        construction: ``_append_full`` only writes to ``turn_history`` (and
+        ``_compress_oldest_turn`` moves entries between them atomically),
+        while ``_append_summary_only`` only writes to
+        ``compressed_history`` — so no double-count is possible.
+        """
+        return len(self.turn_history) + len(self.compressed_history)
+
+    def _dynamic_turn_position(self) -> tuple[str, float | None]:
+        """Turn-position strategy: ``weighted`` early, ``attention`` later.
+
+        * ``effective_turn_count <= weighted_until_turn`` → ``("weighted", None)``
+        * otherwise                                      → ``("attention", None)``
+
+        Returns ``("weighted", None)`` when no turns exist yet (Turn 0) so
+        that dispatcher fallbacks always receive a valid mode. Uses
+        :meth:`_effective_turn_count` so the threshold fires correctly
+        under ``storage_mode="summary_only"`` where
+        ``turn_history`` stays empty (Codex CB-001).
+        """
+        cfg = self.working_memory_cfg
+        if self._effective_turn_count() <= cfg.weighted_until_turn:
+            return ("weighted", None)
+        return ("attention", None)
+
+    def _dynamic_drift_based(self) -> tuple[str, float | None]:
+        """Drift-based strategy: ``attention`` when drift spikes.
+
+        * ``drift_history == []``                        → ``("weighted", None)``
+        * ``drift.latent_cosine_drift_top > threshold``  → ``("attention", None)``
+        * otherwise                                      → ``("weighted", None)``
+
+        Off-by-one note (issue body §3.8): because prune_evidence runs
+        before session_forward, ``latest_drift()`` returns Turn N-1's drift
+        at the start of Turn N. Turn 1 has ``drift_history == []`` and
+        fails closed to ``weighted``.
+        """
+        cfg = self.working_memory_cfg
+        drift = self.latest_drift()
+        if drift is None:
+            return ("weighted", None)
+        if drift.latent_cosine_drift_top > cfg.attention_drift_threshold:
+            return ("attention", None)
+        return ("weighted", None)
+
+    def _dynamic_hybrid_select(self) -> tuple[str, float]:
+        """Hybrid strategy: compute alpha and defer mixing to dispatcher.
+
+        ``alpha = clamp(base + per_turn * max(0, turn_count - until), 0, 1)``
+
+        ``turn_count`` here is the :meth:`_effective_turn_count` so alpha
+        ramps up correctly under ``storage_mode="summary_only"`` where
+        ``turn_history`` stays empty (Codex CB-001).
+
+        The actual ``w*weighted + alpha*attention`` mixing happens in
+        :meth:`_aggregate_hybrid` — this helper only picks the mode tag
+        (``"hybrid"``) and the clamped alpha so the dispatcher can thread
+        the two through a uniform signature (DR1-002 tuple return).
+        """
+        cfg = self.working_memory_cfg
+        turn_count = self._effective_turn_count()
+        ramp_steps = max(0, turn_count - cfg.weighted_until_turn)
+        raw_alpha = cfg.hybrid_alpha_base + cfg.hybrid_alpha_per_turn * ramp_steps
+        alpha = max(0.0, min(1.0, float(raw_alpha)))
+        return ("hybrid", alpha)
+
+    def _aggregate_hybrid(
+        self,
+        *,
+        alpha: float,
+        vecs: list[mx.array],
+        turn_ids: list[int],
+        weights: list[float],
+        fallback_vec: mx.array,
+    ) -> mx.array:
+        """Mix weighted + attention aggregations by ``alpha`` (Issue #92 T-4).
+
+        The two branches reuse :meth:`_aggregate` so numerical behaviour
+        matches the static modes exactly. Both branches always return a
+        concrete vector (``fallback_vec`` when their own fallback path
+        fires), but we still guard with ``None`` checks to satisfy the
+        Issue #92 §3 contract should ``_aggregate`` evolve to return
+        ``None`` for new corner cases.
+
+        Output: ``(1 - alpha) * w_vec + alpha * a_vec``, clamped by the
+        caller-supplied ``alpha`` which the dispatcher has already held to
+        ``[0, 1]``.
+        """
+        w_vec = self._aggregate(
+            "weighted",
+            vecs=vecs,
+            turn_ids=turn_ids,
+            weights=weights,
+            fallback_vec=fallback_vec,
+        )
+        a_vec = self._aggregate(
+            "attention",
+            vecs=vecs,
+            turn_ids=turn_ids,
+            weights=weights,
+            fallback_vec=fallback_vec,
+        )
+        # Defensive ``None`` handling per Issue body L79-82. In practice
+        # ``_aggregate`` returns a concrete vec for weighted/attention
+        # because ``fallback_vec`` is always populated at this call site.
+        if a_vec is None:
+            return w_vec
+        if w_vec is None:
+            return a_vec
+        alpha_f = float(alpha)
+        return (1.0 - alpha_f) * w_vec + alpha_f * a_vec
+
+    # Class-level dict-based dispatch (design §3 judgement #3b). OCP:
+    # adding a new strategy only needs a single dict entry and a helper
+    # method — the dispatcher body stays untouched.
+    _DYNAMIC_STRATEGY_DISPATCH: ClassVar[
+        dict[str, Callable[["PhotonSessionState"], tuple[str, float | None]]]
+    ] = {
+        "turn_position": lambda self: self._dynamic_turn_position(),
+        "drift_based": lambda self: self._dynamic_drift_based(),
+        "hybrid": lambda self: self._dynamic_hybrid_select(),
+    }
+
+    def _record_selected_mode(self, mode: str, *, alpha: float | None) -> None:
+        """Write the selected mode/alpha onto the latest DriftMetrics.
+
+        No-op when ``drift_history`` is empty (Turn 0 / post-reset, per
+        DR2-005). When non-empty, both fields are written unconditionally
+        so the schema-level ``None`` default is replaced in a single
+        step. Downstream bench/report consumers read these through
+        :meth:`DriftMetrics.as_dict`.
+        """
+        if not self.drift_history:
+            return
+        latest = self.drift_history[-1]
+        latest.selected_aggregation_mode = mode
+        latest.selected_aggregation_alpha = alpha
+
     def get_session_coarse_state(self) -> mx.array | None:
         """Return a ``(D,)`` coarse session vector aggregated across turns.
 
@@ -951,40 +1293,58 @@ class PhotonSessionState:
             return None
 
         # DRY: the shared fallback is always the most-recent valid vec
-        # (DR1-004). Bound once and reused by last / weighted / attention.
+        # (DR1-004). Bound once and reused by last / weighted / attention
+        # / hybrid.
         fallback_vec = vecs[-1]
 
-        mode = self.working_memory_cfg.aggregation
-        if mode == "last":
-            result = fallback_vec
-        elif mode == "weighted":
-            weight_sum = sum(weights)
-            if weight_sum <= 0.0:
-                # All weights were zero (e.g. decay=0 with history > 1).
-                result = fallback_vec
-            else:
-                stacked = mx.stack(vecs, axis=0)  # (N, D)
-                w_arr = mx.array(weights, dtype=mx.float32)[:, None]  # (N, 1)
-                result = mx.sum(stacked * w_arr, axis=0) / float(weight_sum)
-        elif mode == "attention":
-            # Need a valid current vec to score past turns against.
-            if self.current_state is None or not self.current_state.level_states:
-                result = fallback_vec
-            else:
-                curr_vec = mean_pool(self.current_state.level_states[-1])
-                attn = self._aggregate_attention(
-                    vecs,
-                    turn_ids,
-                    curr_vec,
-                    exclude_turn_id=self.current_state.turn_id,
-                )
-                result = attn if attn is not None else fallback_vec
-        else:
-            # Defensive fail-fast for post-__post_init__ corruption
-            # (Issue #80 §8 decision #1 / judgement #1 safety net). The raw
-            # value is deliberately omitted from the message.
-            raise ValueError("Unknown aggregation mode")
+        agg = self.working_memory_cfg.aggregation
+        if agg != "dynamic":
+            # Static modes (Issue #80 behaviour). Record the chosen mode
+            # on the latest DriftMetrics so per-turn telemetry is
+            # consistent whether or not dynamic is in use.
+            result = self._aggregate(
+                agg,
+                vecs=vecs,
+                turn_ids=turn_ids,
+                weights=weights,
+                fallback_vec=fallback_vec,
+            )
+            self._record_selected_mode(agg, alpha=None)
+            mx.eval(result)
+            return result
 
+        # Issue #92 dynamic dispatch (DR1-003 dict-based, DR1-002 uniform
+        # tuple return signature). Codex CB-002: guard the dict lookup so
+        # post-__post_init__ corruption of ``dynamic_strategy`` raises a
+        # sanitized ``ValueError`` (matching the static path's
+        # "Unknown aggregation mode" style) rather than a raw
+        # ``KeyError('<payload>')`` that would leak the attacker-controlled
+        # value into logs / tracebacks (DR4-001 no-leak).
+        strategy = self.working_memory_cfg.dynamic_strategy
+        handler = self._DYNAMIC_STRATEGY_DISPATCH.get(strategy)
+        if handler is None:
+            raise ValueError("Unknown dynamic_strategy")
+        mode, alpha = handler(self)
+
+        if mode == "hybrid":
+            assert alpha is not None  # hybrid helper always returns a float
+            result = self._aggregate_hybrid(
+                alpha=alpha,
+                vecs=vecs,
+                turn_ids=turn_ids,
+                weights=weights,
+                fallback_vec=fallback_vec,
+            )
+        else:
+            result = self._aggregate(
+                mode,
+                vecs=vecs,
+                turn_ids=turn_ids,
+                weights=weights,
+                fallback_vec=fallback_vec,
+            )
+
+        self._record_selected_mode(mode, alpha=alpha)
         mx.eval(result)
         return result
 

--- a/photon_mlx/session.py
+++ b/photon_mlx/session.py
@@ -364,6 +364,22 @@ class WorkingMemoryConfig:
     exceeds ``weighted_until_turn``. The dispatcher clamps to ``[0.0,
     1.0]`` (Issue #92 §4)."""
 
+    # --- Issue #103: past-turn pinning (opt-in until eval gate passes). ---
+    past_turn_pinning_enabled: bool = False
+    """When ``True``, ``PhotonRAGPipeline`` calls
+    :meth:`PhotonSessionState.find_relevant_past_turn` after each turn and
+    pins the matched turn's ``cited_chunk_ids`` into the next turn's
+    evidence pack via ``additional_pinned_ids`` (design §4-3, §8 Step 5).
+    Default ``False`` keeps existing pipelines unchanged until the 2-run
+    MT eval gate flips defaults (design §8 Step 9)."""
+
+    max_pinned_chunks: int = 3
+    """Upper bound on the number of cited chunks promoted from the matched
+    past turn into the next turn's pin set. ``< 1`` raises ``ValueError``
+    (range error, DR1-001 / DR2-005, mirrors ``max_turns < 1``). Values
+    ``> 16`` only ``warnings.warn`` because ``evidence_pack.max_chunks`` /
+    ``max_tokens`` provide the hard cap (design §4-1)."""
+
     def __post_init__(self) -> None:
         if not isinstance(self.enabled, bool):
             raise TypeError(f"enabled must be bool, got {type(self.enabled).__name__}")
@@ -492,6 +508,51 @@ class WorkingMemoryConfig:
         self.hybrid_alpha_per_turn = _validate_finite_float(
             "hybrid_alpha_per_turn", self.hybrid_alpha_per_turn
         )
+
+        # --- Issue #103: past-turn pinning fields (design §4-1). ---
+        if not isinstance(self.past_turn_pinning_enabled, bool):
+            raise TypeError(
+                "past_turn_pinning_enabled must be bool, got "
+                f"{type(self.past_turn_pinning_enabled).__name__}"
+            )
+        if isinstance(self.max_pinned_chunks, bool) or not isinstance(
+            self.max_pinned_chunks, int
+        ):
+            raise TypeError(
+                "max_pinned_chunks must be int, got "
+                f"{type(self.max_pinned_chunks).__name__}"
+            )
+        if self.max_pinned_chunks < 1:
+            # DR1-001 / DR2-005: range errors map to ``ValueError`` (mirrors
+            # ``max_turns < 1`` and ``weighted_until_turn < 0``); type errors
+            # already mapped to ``TypeError`` above. ``_resolve_working_memory_cfg``
+            # downgrades both classes to a warning + fail-closed disable.
+            raise ValueError(
+                f"max_pinned_chunks must be >= 1, got {self.max_pinned_chunks}"
+            )
+        if self.max_pinned_chunks > 16:
+            warnings.warn(
+                f"max_pinned_chunks={self.max_pinned_chunks} exceeds soft cap "
+                "16; evidence pack max_chunks / max_tokens may be exceeded",
+                stacklevel=2,
+            )
+
+        # Codex CB-002 fix: ``summary_only`` storage mode never populates
+        # ``turn_history`` (see :meth:`PhotonSessionState._append_summary_only`),
+        # so :meth:`PhotonSessionState.find_relevant_past_turn` always returns
+        # ``None``. Combining it with ``past_turn_pinning_enabled=True`` would
+        # silently no-op the entire pinning feature. Emit an actionable
+        # ``UserWarning`` (not ``raise``) since this is a soft configuration
+        # mismatch, matching the existing ``warnings.warn`` pattern used by
+        # ``max_pinned_chunks > 16`` and ``weighted_until_turn > max_turns``.
+        if self.past_turn_pinning_enabled and self.storage_mode == "summary_only":
+            warnings.warn(
+                "past_turn_pinning_enabled=True is a no-op when "
+                "storage_mode='summary_only' because turn_history is never "
+                "populated; set storage_mode='full' to enable past-turn "
+                "pinning",
+                stacklevel=2,
+            )
 
         # DR1-004: emit DeprecationWarning only when the caller mixed the
         # deprecated ``compress_old_turns`` with a non-default ``storage_mode``.

--- a/photon_mlx/tests/test_session.py
+++ b/photon_mlx/tests/test_session.py
@@ -3283,3 +3283,77 @@ class TestCompressedHistoryRejectsZeroLengthSummaries:
             )
         )
         assert session.get_session_coarse_state() is None
+
+
+# ---------------------------------------------------------------------------
+# Issue #103: WorkingMemoryConfig past-turn pinning fields validation.
+# ---------------------------------------------------------------------------
+
+
+class TestWorkingMemoryConfigPastTurnPinning:
+    """Issue #103: ``past_turn_pinning_enabled`` / ``max_pinned_chunks`` fields.
+
+    Validation contract (design §4-1, DR1-001 / DR2-005):
+
+    * ``past_turn_pinning_enabled`` defaults to ``False`` (opt-in only).
+    * ``max_pinned_chunks`` defaults to ``3``.
+    * ``past_turn_pinning_enabled`` non-bool → ``TypeError``.
+    * ``max_pinned_chunks`` ``bool`` or non-int → ``TypeError``.
+    * ``max_pinned_chunks`` ``< 1`` → ``ValueError`` (range error,
+      consistent with existing ``max_turns < 1`` pattern).
+    * ``max_pinned_chunks`` ``> 16`` → ``warnings.warn`` only (soft cap).
+    """
+
+    def test_past_turn_pinning_enabled_default_false(self) -> None:
+        """Default must be ``False`` so the feature is opt-in."""
+        cfg = WorkingMemoryConfig()
+        assert cfg.past_turn_pinning_enabled is False
+
+    def test_max_pinned_chunks_default_3(self) -> None:
+        """Default must be ``3`` per design §4-1."""
+        cfg = WorkingMemoryConfig()
+        assert cfg.max_pinned_chunks == 3
+
+    def test_max_pinned_chunks_rejects_bool(self) -> None:
+        """``bool`` payloads must be rejected (Python's ``bool`` ⊂ ``int``)."""
+        with pytest.raises(TypeError):
+            WorkingMemoryConfig(max_pinned_chunks=True)  # type: ignore[arg-type]
+        with pytest.raises(TypeError):
+            WorkingMemoryConfig(max_pinned_chunks=False)  # type: ignore[arg-type]
+
+    def test_max_pinned_chunks_rejects_zero(self) -> None:
+        """``< 1`` is a *range* error → ``ValueError`` (DR1-001)."""
+        with pytest.raises(ValueError):
+            WorkingMemoryConfig(max_pinned_chunks=0)
+        with pytest.raises(ValueError):
+            WorkingMemoryConfig(max_pinned_chunks=-1)
+
+    def test_max_pinned_chunks_warns_above_cap(self) -> None:
+        """``> 16`` emits ``warnings.warn`` but still constructs."""
+        import warnings as _warnings
+
+        with _warnings.catch_warnings(record=True) as records:
+            _warnings.simplefilter("always")
+            cfg = WorkingMemoryConfig(max_pinned_chunks=17)
+        assert cfg.max_pinned_chunks == 17
+        # Ensure at least one warning surfaced about the soft cap.
+        assert any("max_pinned_chunks" in str(r.message) for r in records), (
+            f"expected soft-cap warning, got: {[str(r.message) for r in records]}"
+        )
+
+    def test_summary_only_with_pinning_warns(self) -> None:
+        """Issue #103 / CB-002 regression: combining
+        ``storage_mode='summary_only'`` with ``past_turn_pinning_enabled=True``
+        must emit a ``warnings.warn`` (not raise).
+
+        ``summary_only`` never populates ``turn_history``, so
+        :meth:`PhotonSessionState.find_relevant_past_turn` always returns
+        ``None`` — the pinning feature would silently no-op. The fix
+        emits an actionable ``UserWarning`` so operators see that the
+        pinning is disabled and that ``storage_mode='full'`` is required.
+        """
+        with pytest.warns(UserWarning, match="past_turn_pinning_enabled"):
+            WorkingMemoryConfig(
+                storage_mode="summary_only",
+                past_turn_pinning_enabled=True,
+            )

--- a/photon_mlx/tests/test_session.py
+++ b/photon_mlx/tests/test_session.py
@@ -270,8 +270,17 @@ class TestSessionState:
         assert drift.topic_shift_score < 1e-5
 
     def test_drift_metrics_as_dict_superset(self) -> None:
-        """DriftMetrics.as_dict() superset contract (DR3-002): legacy keys
-        stay present, three new keys are added."""
+        """DriftMetrics.as_dict() superset contract (DR3-002 + Issue #92 T-3):
+
+        * Legacy keys stay present (numeric drift fields — finite-checked).
+        * Three per-level keys added in Issue #63 stay present.
+        * Two new Issue #92 keys are present with their default values
+          (``selected_aggregation_mode`` / ``selected_aggregation_alpha``).
+        * Finite-check for the numeric drift fields is separate from the
+          type check for the mode/alpha fields (Issue body (g)).
+        """
+        import math as _math
+
         session = PhotonSessionState("s1", "repo", "abc123")
         s1 = HierarchicalState(
             level_states=[mx.ones((1, 4, 64)), mx.ones((1, 1, 64))],
@@ -284,7 +293,7 @@ class TestSessionState:
         )
         drift = session.update(s2)
         d = drift.as_dict()
-        # Legacy keys preserved.
+        # Legacy numeric keys preserved — all must be finite.
         for key in (
             "turn_id",
             "latent_cosine_drift",
@@ -300,8 +309,49 @@ class TestSessionState:
             "latent_cosine_drift_token",
         ):
             assert key in d
+        # Finite-check (separated from mode/alpha in Issue #92 T-3).
+        numeric_keys = (
+            "latent_cosine_drift",
+            "latent_cosine_drift_top",
+            "latent_cosine_drift_mid",
+            "latent_cosine_drift_token",
+            "token_agreement",
+            "logit_kl",
+            "topic_shift_score",
+        )
+        for key in numeric_keys:
+            assert _math.isfinite(d[key]), f"{key} must be finite"
         # Alias still returns top.
         assert d["latent_cosine_drift"] == d["latent_cosine_drift_top"]
+
+        # Issue #92: new telemetry fields present by default as ``None``.
+        assert "selected_aggregation_mode" in d
+        assert "selected_aggregation_alpha" in d
+        assert d["selected_aggregation_mode"] is None
+        assert d["selected_aggregation_alpha"] is None
+
+    def test_drift_metrics_as_dict_mode_alpha_types(self) -> None:
+        """Issue #92 T-3 (g): mode/alpha fields carry correct types when set.
+
+        Separated from the legacy numeric ``as_dict`` test so that the
+        type-check for mode (str) and alpha (float) does NOT run through
+        the numeric finite-check path.
+        """
+        m = DriftMetrics(turn_id=2)
+        m.selected_aggregation_mode = "hybrid"
+        m.selected_aggregation_alpha = 0.375
+        d = m.as_dict()
+        assert d["selected_aggregation_mode"] == "hybrid"
+        assert isinstance(d["selected_aggregation_mode"], str)
+        assert d["selected_aggregation_alpha"] == pytest.approx(0.375)
+        assert isinstance(d["selected_aggregation_alpha"], float)
+
+        # When only mode is set (weighted/attention/last), alpha stays None.
+        m2 = DriftMetrics(turn_id=3)
+        m2.selected_aggregation_mode = "weighted"
+        d2 = m2.as_dict()
+        assert d2["selected_aggregation_mode"] == "weighted"
+        assert d2["selected_aggregation_alpha"] is None
 
     def test_custom_drift_level_weights(self) -> None:
         """Custom weights propagate into topic_shift_score."""
@@ -1276,9 +1326,21 @@ class TestWorkingMemorySecurityRegression:
         assert out["token_agreement"] == 0.0
         assert out["logit_kl"] == 0.0
         assert abs(out["topic_shift_score"] - 0.25) < 1e-9
-        # JSON-safety: no NaN / Inf tokens in the dict.
-        for v in out.values():
-            assert _math.isfinite(v)
+        # JSON-safety: no NaN / Inf tokens in the NUMERIC fields. Issue #92
+        # adds mode/alpha fields of types str | None and float | None so we
+        # finite-check only the drift numeric keys here.
+        numeric_keys = {
+            "turn_id",
+            "latent_cosine_drift",
+            "latent_cosine_drift_top",
+            "latent_cosine_drift_mid",
+            "latent_cosine_drift_token",
+            "token_agreement",
+            "logit_kl",
+            "topic_shift_score",
+        }
+        for key in numeric_keys:
+            assert _math.isfinite(out[key])
         # A warning was surfaced for each non-finite coercion. The alias
         # ``latent_cosine_drift`` and the authoritative ``_top`` field both
         # resolve to NaN, so at minimum the 4 coercions (drift + alias +
@@ -1416,8 +1478,12 @@ class TestWorkingMemoryConfigAggregation:
         assert cfg.aggregation == "weighted"
 
     def test_working_memory_config_aggregation_accepts_valid_values(self) -> None:
-        """All three documented modes must construct successfully."""
-        for mode in ("weighted", "attention", "last"):
+        """All four documented modes must construct successfully.
+
+        Issue #92 adds ``"dynamic"`` to the closed-enum. The three legacy
+        modes (weighted/attention/last) continue to construct unchanged.
+        """
+        for mode in ("weighted", "attention", "last", "dynamic"):
             cfg = WorkingMemoryConfig(aggregation=mode)
             assert cfg.aggregation == mode
 
@@ -1505,27 +1571,189 @@ class TestWorkingMemoryConfigAggregation:
             WorkingMemoryConfig(aggregation="")
 
 
+class TestDynamicStrategyConfigValidation:
+    """Issue #92 T-2: validation rules for the five new dynamic fields.
+
+    Closed-enum and finite-float invariants follow the existing DR4-001
+    no-leak pattern — raw attacker-controlled values must never surface in
+    the error messages.
+    """
+
+    # ---- dynamic_strategy (closed enum) ----
+    @pytest.mark.parametrize("strategy", ["turn_position", "drift_based", "hybrid"])
+    def test_dynamic_strategy_accepts_valid_values(self, strategy: str) -> None:
+        cfg = WorkingMemoryConfig(aggregation="dynamic", dynamic_strategy=strategy)
+        assert cfg.dynamic_strategy == strategy
+
+    def test_dynamic_strategy_default_is_turn_position(self) -> None:
+        cfg = WorkingMemoryConfig()
+        assert cfg.dynamic_strategy == "turn_position"
+
+    def test_dynamic_strategy_rejects_non_str(self) -> None:
+        for bad in (1, 1.5, ["hybrid"], None):
+            with pytest.raises(TypeError) as excinfo:
+                WorkingMemoryConfig(dynamic_strategy=bad)  # type: ignore[arg-type]
+            # Type name is surfaced; raw repr of the payload is not
+            # (except when ``None`` where ``repr(None)="None"`` is a
+            # substring of ``NoneType`` — we skip that assert for None).
+            assert type(bad).__name__ in str(excinfo.value)
+            if bad is not None:
+                assert repr(bad) not in str(excinfo.value)
+
+    def test_dynamic_strategy_rejects_unknown_value_no_leak(self) -> None:
+        SENSITIVE = "<ATTACK-DYN-STRATEGY-SENTINEL>"
+        with pytest.raises(ValueError) as excinfo:
+            WorkingMemoryConfig(dynamic_strategy=SENSITIVE)
+        assert SENSITIVE not in str(excinfo.value)
+
+        for bad in ("turnposition", "hybrid_plus", "TURN_POSITION"):
+            with pytest.raises(ValueError) as excinfo:
+                WorkingMemoryConfig(dynamic_strategy=bad)
+            assert bad not in str(excinfo.value)
+
+    # ---- weighted_until_turn ----
+    def test_weighted_until_turn_default_is_three(self) -> None:
+        cfg = WorkingMemoryConfig()
+        assert cfg.weighted_until_turn == 3
+
+    @pytest.mark.parametrize("value", [0, 1, 3, 8])
+    def test_weighted_until_turn_accepts_non_negative(self, value: int) -> None:
+        cfg = WorkingMemoryConfig(weighted_until_turn=value)
+        assert cfg.weighted_until_turn == value
+
+    def test_weighted_until_turn_rejects_negative(self) -> None:
+        with pytest.raises(ValueError, match="weighted_until_turn"):
+            WorkingMemoryConfig(weighted_until_turn=-1)
+
+    def test_weighted_until_turn_rejects_non_int(self) -> None:
+        for bad in (1.5, "3", True):
+            with pytest.raises(TypeError):
+                WorkingMemoryConfig(weighted_until_turn=bad)  # type: ignore[arg-type]
+
+    def test_weighted_until_turn_warns_when_above_max_turns(self) -> None:
+        import warnings as _warnings
+
+        with _warnings.catch_warnings(record=True) as captured:
+            _warnings.simplefilter("always")
+            cfg = WorkingMemoryConfig(max_turns=3, weighted_until_turn=10)
+        assert cfg.weighted_until_turn == 10  # stored even though above cap
+        assert any("weighted_until_turn" in str(w.message) for w in captured)
+
+    # ---- attention_drift_threshold (finite float in [0, 1]) ----
+    def test_attention_drift_threshold_default(self) -> None:
+        cfg = WorkingMemoryConfig()
+        assert cfg.attention_drift_threshold == 0.5
+
+    @pytest.mark.parametrize("value", [0.0, 0.25, 0.5, 0.75, 1.0])
+    def test_attention_drift_threshold_accepts_in_range(self, value: float) -> None:
+        cfg = WorkingMemoryConfig(attention_drift_threshold=value)
+        assert cfg.attention_drift_threshold == value
+
+    def test_attention_drift_threshold_rejects_out_of_range(self) -> None:
+        import math as _math
+
+        for bad in (-0.1, 1.1, 2.0, _math.nan, _math.inf, -_math.inf):
+            with pytest.raises(ValueError, match="attention_drift_threshold"):
+                WorkingMemoryConfig(attention_drift_threshold=bad)
+
+    def test_attention_drift_threshold_rejects_non_float(self) -> None:
+        for bad in ("0.5", [0.5], None, True):
+            with pytest.raises(TypeError):
+                WorkingMemoryConfig(attention_drift_threshold=bad)  # type: ignore[arg-type]
+
+    # ---- hybrid_alpha_base ----
+    def test_hybrid_alpha_base_default(self) -> None:
+        cfg = WorkingMemoryConfig()
+        assert cfg.hybrid_alpha_base == 0.5
+
+    @pytest.mark.parametrize("value", [-5.0, 0.0, 0.25, 1.0, 10.0])
+    def test_hybrid_alpha_base_accepts_finite(self, value: float) -> None:
+        # Finite floats are accepted; clamp happens at dispatch time.
+        cfg = WorkingMemoryConfig(hybrid_alpha_base=value)
+        assert cfg.hybrid_alpha_base == value
+
+    def test_hybrid_alpha_base_rejects_non_finite(self) -> None:
+        import math as _math
+
+        for bad in (_math.nan, _math.inf, -_math.inf):
+            with pytest.raises(ValueError, match="hybrid_alpha_base"):
+                WorkingMemoryConfig(hybrid_alpha_base=bad)
+
+    def test_hybrid_alpha_base_rejects_non_float(self) -> None:
+        for bad in ("0.5", [0.5], None, True):
+            with pytest.raises(TypeError):
+                WorkingMemoryConfig(hybrid_alpha_base=bad)  # type: ignore[arg-type]
+
+    # ---- hybrid_alpha_per_turn ----
+    def test_hybrid_alpha_per_turn_default(self) -> None:
+        cfg = WorkingMemoryConfig()
+        assert cfg.hybrid_alpha_per_turn == 0.1
+
+    @pytest.mark.parametrize("value", [-1.0, 0.0, 0.1, 5.0])
+    def test_hybrid_alpha_per_turn_accepts_finite(self, value: float) -> None:
+        cfg = WorkingMemoryConfig(hybrid_alpha_per_turn=value)
+        assert cfg.hybrid_alpha_per_turn == value
+
+    def test_hybrid_alpha_per_turn_rejects_non_finite(self) -> None:
+        import math as _math
+
+        for bad in (_math.nan, _math.inf, -_math.inf):
+            with pytest.raises(ValueError, match="hybrid_alpha_per_turn"):
+                WorkingMemoryConfig(hybrid_alpha_per_turn=bad)
+
+
+def _mk_mode_cfg(aggregation_param: str, **kwargs: object) -> WorkingMemoryConfig:
+    """Build a :class:`WorkingMemoryConfig` for parametrized mode tests.
+
+    Accepts either a static mode (``"weighted"``/``"attention"``/``"last"``)
+    or a ``"dynamic-<strategy>"`` tag (Issue #92 T-6). This collapses the
+    Issue #80 3-mode matrix and the Issue #92 3-strategy matrix into a
+    single 6-value parametrize for the (a) common-contract tests.
+    """
+    if aggregation_param.startswith("dynamic-"):
+        strategy = aggregation_param.split("-", 1)[1]
+        return WorkingMemoryConfig(
+            aggregation="dynamic",
+            dynamic_strategy=strategy,
+            **kwargs,  # type: ignore[arg-type]
+        )
+    return WorkingMemoryConfig(aggregation=aggregation_param, **kwargs)  # type: ignore[arg-type]
+
+
+# Parametrize ids used by TestGetSessionCoarseStateModes (a) common
+# contract: legacy 3 static + 3 dynamic strategies (Issue #92 T-6 (b)).
+_MODE_IDS_ALL: tuple[str, ...] = (
+    "weighted",
+    "attention",
+    "last",
+    "dynamic-turn_position",
+    "dynamic-drift_based",
+    "dynamic-hybrid",
+)
+
+
 class TestGetSessionCoarseStateModes:
-    """Issue #80: 3-mode dispatch for ``get_session_coarse_state()``.
+    """Issue #80 + #92: mode dispatch for ``get_session_coarse_state()``.
 
     Four categories (design §8 DR1-009):
     - (a) common contract across modes (shape, dtype, None)
     - (b) mode-specific edge cases
     - (c) validation / defensive raise
     - (d) prune parity (covered in TestPruneParityAcrossAggregationModes)
+
+    Issue #92 T-6 (b) extends the (a) common-contract parametrize to also
+    cover the 3 new dynamic strategies.
     """
 
     # ---- (a) common contract across modes ----
-    @pytest.mark.parametrize("aggregation", ["weighted", "attention", "last"])
+    @pytest.mark.parametrize("aggregation", list(_MODE_IDS_ALL))
     def test_all_modes_shape_dtype(self, aggregation: str) -> None:
-        """3 modes must return (D,) float32 vectors."""
+        """All modes (static 3 + dynamic 3) must return (D,) float32 vectors."""
         session = PhotonSessionState(
             "s1",
             "repo",
             "abc",
-            working_memory_cfg=WorkingMemoryConfig(
-                enabled=True, max_turns=4, aggregation=aggregation
-            ),
+            working_memory_cfg=_mk_mode_cfg(aggregation, max_turns=4),
         )
         session.update(_mk_state(1.0))
         session.update(_mk_state(2.0))
@@ -1535,46 +1763,40 @@ class TestGetSessionCoarseStateModes:
         assert coarse.shape == (4,)
         assert coarse.dtype == mx.float32
 
-    @pytest.mark.parametrize("aggregation", ["weighted", "attention", "last"])
+    @pytest.mark.parametrize("aggregation", list(_MODE_IDS_ALL))
     def test_all_modes_empty_turn_history_returns_none(self, aggregation: str) -> None:
-        """All 3 modes return None on empty turn_history."""
+        """All modes return None on empty turn_history."""
         session = PhotonSessionState(
             "s1",
             "repo",
             "abc",
-            working_memory_cfg=WorkingMemoryConfig(
-                enabled=True, aggregation=aggregation
-            ),
+            working_memory_cfg=_mk_mode_cfg(aggregation),
         )
         assert session.get_session_coarse_state() is None
 
-    @pytest.mark.parametrize("aggregation", ["weighted", "attention", "last"])
+    @pytest.mark.parametrize("aggregation", list(_MODE_IDS_ALL))
     def test_all_modes_disabled_returns_none(self, aggregation: str) -> None:
-        """All 3 modes return None when working memory is disabled."""
+        """All modes return None when working memory is disabled."""
         # Even if aggregation is set, enabled=False short-circuits.
         session = PhotonSessionState(
             "s1",
             "repo",
             "abc",
-            working_memory_cfg=WorkingMemoryConfig(
-                enabled=False, aggregation=aggregation
-            ),
+            working_memory_cfg=_mk_mode_cfg(aggregation, enabled=False),
         )
         session.update(_mk_state(1.0))
         assert session.get_session_coarse_state() is None
 
-    @pytest.mark.parametrize("aggregation", ["weighted", "attention", "last"])
+    @pytest.mark.parametrize("aggregation", list(_MODE_IDS_ALL))
     def test_all_modes_all_empty_level_states_returns_none(
         self, aggregation: str
     ) -> None:
-        """All 3 modes return None when every turn has empty level_states."""
+        """All modes return None when every turn has empty level_states."""
         session = PhotonSessionState(
             "s1",
             "repo",
             "abc",
-            working_memory_cfg=WorkingMemoryConfig(
-                enabled=True, aggregation=aggregation
-            ),
+            working_memory_cfg=_mk_mode_cfg(aggregation),
         )
         # Inject a turn whose hierarchical_state has empty level_states
         # (simulating the skip invariant).
@@ -1582,16 +1804,14 @@ class TestGetSessionCoarseStateModes:
         session.update(HierarchicalState(level_states=[]))
         assert session.get_session_coarse_state() is None
 
-    @pytest.mark.parametrize("aggregation", ["weighted", "attention", "last"])
+    @pytest.mark.parametrize("aggregation", list(_MODE_IDS_ALL))
     def test_all_modes_single_turn_equivalent(self, aggregation: str) -> None:
-        """Single-turn history: 3 modes must produce the same coarse vec."""
+        """Single-turn history: all modes must produce the same coarse vec."""
         session = PhotonSessionState(
             "s1",
             "repo",
             "abc",
-            working_memory_cfg=WorkingMemoryConfig(
-                enabled=True, aggregation=aggregation
-            ),
+            working_memory_cfg=_mk_mode_cfg(aggregation),
         )
         session.update(_mk_state(2.5))
         coarse = session.get_session_coarse_state()
@@ -1834,7 +2054,20 @@ class TestPruneParityAcrossAggregationModes:
     scores (ε=1e-5).
     """
 
-    @pytest.mark.parametrize("aggregation", ["weighted", "attention", "last"])
+    @pytest.mark.parametrize(
+        "aggregation",
+        [
+            "weighted",
+            "attention",
+            "last",
+            # Issue #92 T-6 (c): dynamic 3 strategies with storage_mode="full"
+            # — scope-bounded per plan (no 3x3 matrix, that lives in
+            # TestDynamicAggregationStorageModeMatrix).
+            "dynamic-turn_position",
+            "dynamic-drift_based",
+            "dynamic-hybrid",
+        ],
+    )
     def test_single_turn_prune_scores_match_across_modes(
         self, stub_tokenizer_for_cfg, aggregation: str
     ) -> None:
@@ -1846,9 +2079,7 @@ class TestPruneParityAcrossAggregationModes:
             model,
             cfg,
             tokenizer,
-            working_memory_cfg=WorkingMemoryConfig(
-                enabled=True, aggregation=aggregation
-            ),
+            working_memory_cfg=_mk_mode_cfg(aggregation, storage_mode="full"),
         )
         ids = mx.random.randint(0, 256, (1, 16))
         engine.session_forward(ids, "s1", "repo", "abc")
@@ -1906,6 +2137,430 @@ class TestPruneParityAcrossAggregationModes:
                     f"prune score mismatch at idx {i}: "
                     f"weighted={a} {mode}={b} delta={abs(a - b)}"
                 )
+
+
+class TestDynamicAggregation:
+    """Issue #92 T-4/T-5/T-7: dynamic aggregation strategies + dispatcher.
+
+    Exercises the three strategy helpers, the hybrid aggregator, and the
+    dispatcher in :meth:`PhotonSessionState.get_session_coarse_state`,
+    plus the per-turn mode recording on :class:`DriftMetrics`.
+    """
+
+    # ---------- (T-4) _dynamic_turn_position ----------
+    def test_turn_position_weighted_at_threshold(self) -> None:
+        """turn_count == weighted_until_turn → 'weighted' (inclusive)."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True,
+                max_turns=8,
+                aggregation="dynamic",
+                dynamic_strategy="turn_position",
+                weighted_until_turn=3,
+            ),
+        )
+        for i in range(3):
+            session.update(_mk_state(float(i + 1)))
+        mode, alpha = session._dynamic_turn_position()
+        assert mode == "weighted"
+        assert alpha is None
+
+    def test_turn_position_attention_above_threshold(self) -> None:
+        """turn_count > weighted_until_turn → 'attention'."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True,
+                max_turns=8,
+                aggregation="dynamic",
+                dynamic_strategy="turn_position",
+                weighted_until_turn=2,
+            ),
+        )
+        for i in range(4):
+            session.update(_mk_state(float(i + 1)))
+        mode, alpha = session._dynamic_turn_position()
+        assert mode == "attention"
+        assert alpha is None
+
+    def test_turn_position_weighted_zero_turns(self) -> None:
+        """turn_count == 0 → 'weighted' (no turns yet)."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True,
+                aggregation="dynamic",
+                dynamic_strategy="turn_position",
+                weighted_until_turn=3,
+            ),
+        )
+        mode, alpha = session._dynamic_turn_position()
+        assert mode == "weighted"
+        assert alpha is None
+
+    # ---------- (T-4) _dynamic_drift_based ----------
+    def test_drift_based_empty_drift_history_returns_weighted(self) -> None:
+        """drift_history empty (Turn 0 / reset) → ('weighted', None)."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True,
+                aggregation="dynamic",
+                dynamic_strategy="drift_based",
+                attention_drift_threshold=0.5,
+            ),
+        )
+        assert session.drift_history == []
+        mode, alpha = session._dynamic_drift_based()
+        assert mode == "weighted"
+        assert alpha is None
+
+    def test_drift_based_below_threshold_weighted(self) -> None:
+        """drift <= threshold → 'weighted'."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True,
+                aggregation="dynamic",
+                dynamic_strategy="drift_based",
+                attention_drift_threshold=0.5,
+            ),
+        )
+        session.update(_mk_state(1.0))
+        session.update(_mk_state(1.0))  # identical → drift ~ 0
+        mode, alpha = session._dynamic_drift_based()
+        assert mode == "weighted"
+        assert alpha is None
+
+    def test_drift_based_above_threshold_attention(self) -> None:
+        """drift > threshold → 'attention'."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True,
+                aggregation="dynamic",
+                dynamic_strategy="drift_based",
+                attention_drift_threshold=0.5,
+            ),
+        )
+        # Force a drift above threshold by mutating the latest DriftMetrics.
+        session.update(_mk_state(1.0))
+        session.update(_mk_state(1.0))
+        session.drift_history[-1].latent_cosine_drift_top = 0.9
+        mode, alpha = session._dynamic_drift_based()
+        assert mode == "attention"
+        assert alpha is None
+
+    def test_drift_based_at_threshold_boundary(self) -> None:
+        """drift == threshold → 'weighted' (strict '>' per design)."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True,
+                aggregation="dynamic",
+                dynamic_strategy="drift_based",
+                attention_drift_threshold=0.5,
+            ),
+        )
+        session.update(_mk_state(1.0))
+        session.update(_mk_state(1.0))
+        session.drift_history[-1].latent_cosine_drift_top = 0.5  # == threshold
+        mode, _alpha = session._dynamic_drift_based()
+        assert mode == "weighted"
+
+    # ---------- (T-4) _dynamic_hybrid_select ----------
+    def test_hybrid_select_alpha_before_ramp(self) -> None:
+        """turn_count <= weighted_until_turn → alpha = base (clamped)."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True,
+                max_turns=8,
+                aggregation="dynamic",
+                dynamic_strategy="hybrid",
+                weighted_until_turn=3,
+                hybrid_alpha_base=0.5,
+                hybrid_alpha_per_turn=0.1,
+            ),
+        )
+        for i in range(3):
+            session.update(_mk_state(float(i + 1)))
+        mode, alpha = session._dynamic_hybrid_select()
+        assert mode == "hybrid"
+        assert alpha == pytest.approx(0.5)
+
+    def test_hybrid_select_alpha_after_ramp(self) -> None:
+        """alpha = clamp(base + per_turn * (turn_count - until), 0, 1)."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True,
+                max_turns=8,
+                aggregation="dynamic",
+                dynamic_strategy="hybrid",
+                weighted_until_turn=3,
+                hybrid_alpha_base=0.5,
+                hybrid_alpha_per_turn=0.1,
+            ),
+        )
+        for i in range(5):  # turn_count = 5 → alpha = 0.5 + 0.1*2 = 0.7
+            session.update(_mk_state(float(i + 1)))
+        mode, alpha = session._dynamic_hybrid_select()
+        assert mode == "hybrid"
+        assert alpha == pytest.approx(0.7)
+
+    def test_hybrid_select_alpha_clamped_above_one(self) -> None:
+        """Huge ramp → alpha clamped to 1.0."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True,
+                max_turns=8,
+                aggregation="dynamic",
+                dynamic_strategy="hybrid",
+                weighted_until_turn=0,
+                hybrid_alpha_base=10.0,
+                hybrid_alpha_per_turn=5.0,
+            ),
+        )
+        session.update(_mk_state(1.0))
+        _mode, alpha = session._dynamic_hybrid_select()
+        assert alpha == pytest.approx(1.0)
+
+    def test_hybrid_select_alpha_clamped_below_zero(self) -> None:
+        """Negative base → alpha clamped to 0.0."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True,
+                max_turns=8,
+                aggregation="dynamic",
+                dynamic_strategy="hybrid",
+                weighted_until_turn=3,
+                hybrid_alpha_base=-5.0,
+                hybrid_alpha_per_turn=0.1,
+            ),
+        )
+        session.update(_mk_state(1.0))
+        _mode, alpha = session._dynamic_hybrid_select()
+        assert alpha == pytest.approx(0.0)
+
+    # ---------- (T-5) get_session_coarse_state dispatcher ----------
+    @pytest.mark.parametrize("strategy", ["turn_position", "drift_based", "hybrid"])
+    def test_dispatcher_returns_shape_d_dtype_float32(self, strategy: str) -> None:
+        """dynamic dispatcher: all 3 strategies produce (D,) float32 vec."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True,
+                max_turns=4,
+                aggregation="dynamic",
+                dynamic_strategy=strategy,
+            ),
+        )
+        session.update(_mk_state(1.0))
+        session.update(_mk_state(2.0))
+        coarse = session.get_session_coarse_state()
+        assert coarse is not None
+        assert coarse.shape == (4,)
+        assert coarse.dtype == mx.float32
+
+    @pytest.mark.parametrize("strategy", ["turn_position", "drift_based", "hybrid"])
+    def test_dispatcher_empty_turn_history_returns_none(self, strategy: str) -> None:
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True,
+                aggregation="dynamic",
+                dynamic_strategy=strategy,
+            ),
+        )
+        assert session.get_session_coarse_state() is None
+
+    def test_selected_mode_recorded_per_turn_weighted(self) -> None:
+        """static ``weighted`` mode is recorded on the latest DriftMetrics."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True, max_turns=4, aggregation="weighted"
+            ),
+        )
+        session.update(_mk_state(1.0))
+        session.update(_mk_state(2.0))
+        session.get_session_coarse_state()
+        assert session.drift_history[-1].selected_aggregation_mode == "weighted"
+        assert session.drift_history[-1].selected_aggregation_alpha is None
+
+    def test_selected_mode_recorded_per_turn_dynamic_hybrid(self) -> None:
+        """hybrid: mode='hybrid' AND alpha is a float on DriftMetrics."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True,
+                max_turns=4,
+                aggregation="dynamic",
+                dynamic_strategy="hybrid",
+                weighted_until_turn=0,
+                hybrid_alpha_base=0.5,
+                hybrid_alpha_per_turn=0.1,
+            ),
+        )
+        session.update(_mk_state(1.0))
+        session.update(_mk_state(2.0))
+        session.get_session_coarse_state()
+        last = session.drift_history[-1]
+        assert last.selected_aggregation_mode == "hybrid"
+        assert isinstance(last.selected_aggregation_alpha, float)
+
+    def test_selected_mode_recorded_per_turn_dynamic_turn_position(self) -> None:
+        """turn_position records 'weighted' or 'attention' with alpha=None."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True,
+                max_turns=8,
+                aggregation="dynamic",
+                dynamic_strategy="turn_position",
+                weighted_until_turn=1,
+            ),
+        )
+        # Turn 1 → mode=weighted (turn_count=1 <= until=1).
+        session.update(_mk_state(1.0))
+        session.get_session_coarse_state()
+        assert session.drift_history[-1].selected_aggregation_mode == "weighted"
+        assert session.drift_history[-1].selected_aggregation_alpha is None
+
+        # Turn 3 → mode=attention (turn_count=3 > until=1).
+        session.update(_mk_state(2.0))
+        session.update(_mk_state(3.0))
+        session.get_session_coarse_state()
+        assert session.drift_history[-1].selected_aggregation_mode == "attention"
+        assert session.drift_history[-1].selected_aggregation_alpha is None
+
+    def test_record_selected_mode_noop_when_drift_history_empty(self) -> None:
+        """Empty drift_history → _record_selected_mode is a no-op (no raise)."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True,
+                aggregation="dynamic",
+                dynamic_strategy="turn_position",
+            ),
+        )
+        # With no turn_history, get_session_coarse_state short-circuits to
+        # None. _record_selected_mode is not reached — but a direct call
+        # must also be a no-op.
+        session._record_selected_mode("weighted", alpha=None)
+        assert session.drift_history == []
+
+    def test_hybrid_aggregate_combines_weighted_and_attention(self) -> None:
+        """_aggregate_hybrid mixes weighted and attention results."""
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True,
+                max_turns=4,
+                aggregation="dynamic",
+                dynamic_strategy="hybrid",
+                weighted_until_turn=0,
+                hybrid_alpha_base=0.5,
+                hybrid_alpha_per_turn=0.0,  # keep alpha at 0.5
+            ),
+        )
+        session.update(_mk_state(1.0))
+        session.update(_mk_state(-1.0))
+        session.update(_mk_state(1.0))  # current similar to turn 1
+        coarse = session.get_session_coarse_state()
+        assert coarse is not None
+        mx.eval(coarse)
+        import math as _math
+
+        for v in coarse.tolist():
+            assert _math.isfinite(v)
+
+
+class TestDynamicAggregationStorageModeMatrix:
+    """Issue #92 T-7 (f): storage_mode × dynamic_strategy 3×3 = 9 combos."""
+
+    @pytest.mark.parametrize("storage_mode", ["full", "top_level_only", "summary_only"])
+    @pytest.mark.parametrize("strategy", ["turn_position", "drift_based", "hybrid"])
+    def test_shape_dtype_across_storage_modes(
+        self, storage_mode: str, strategy: str
+    ) -> None:
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True,
+                max_turns=3,
+                storage_mode=storage_mode,
+                aggregation="dynamic",
+                dynamic_strategy=strategy,
+            ),
+        )
+        for v in (1.0, 2.0):
+            session.update(_mk_state(v))
+        coarse = session.get_session_coarse_state()
+        assert coarse is not None
+        assert coarse.shape == (4,)
+        assert coarse.dtype == mx.float32
+
+    @pytest.mark.parametrize("storage_mode", ["full", "top_level_only", "summary_only"])
+    @pytest.mark.parametrize("strategy", ["turn_position", "drift_based", "hybrid"])
+    def test_empty_returns_none_across_storage_modes(
+        self, storage_mode: str, strategy: str
+    ) -> None:
+        session = PhotonSessionState(
+            "s1",
+            "repo",
+            "abc",
+            working_memory_cfg=WorkingMemoryConfig(
+                enabled=True,
+                max_turns=3,
+                storage_mode=storage_mode,
+                aggregation="dynamic",
+                dynamic_strategy=strategy,
+            ),
+        )
+        assert session.get_session_coarse_state() is None
 
 
 class TestCodexCB004WorkingMemoryMaxTurnsHardCap:

--- a/scripts/_grid_search_core.py
+++ b/scripts/_grid_search_core.py
@@ -1,0 +1,504 @@
+"""Pure-function core of the retrieval grid-search tool (Issue #88).
+
+This module is deliberately MLX-free so it can be imported from unit
+tests on a CI runner that has no MLX installed. It provides:
+
+- ``ConfigParams`` / ``ConfigResult`` dataclasses
+- ``generate_phase1_grid`` / ``generate_phase2_grid`` (grid construction)
+- ``is_invalid_combo`` (4-condition filter per design §5)
+- ``aggregate_metrics`` (pinned against ``ci_eval_check.check_static``)
+- ``validate_override`` (fail-fast key typo guard)
+- ``atomic_write_json`` / ``write_markdown_report`` (IO helpers)
+
+The CLI-facing ``scripts/retrieval_grid_search.py`` is the only place
+that imports MLX-backed pipeline code.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+import statistics
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from baseline_reporag.config import Config
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ConfigParams:
+    """Sweep-target parameters. Immutable + hashable."""
+
+    lexical_top_k: int
+    embedding_top_k: int
+    fused_top_k: int
+    rerank_top_k: int
+    weights_lexical: float
+    weights_embedding: float
+
+    def to_override_dict(self) -> dict[str, Any]:
+        return {
+            "lexical_top_k": self.lexical_top_k,
+            "embedding_top_k": self.embedding_top_k,
+            "fused_top_k": self.fused_top_k,
+            "rerank_top_k": self.rerank_top_k,
+            "weights": {
+                "lexical": self.weights_lexical,
+                "embedding": self.weights_embedding,
+            },
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> ConfigParams:
+        weights = d.get("weights", {})
+        return cls(
+            lexical_top_k=int(d["lexical_top_k"]),
+            embedding_top_k=int(d["embedding_top_k"]),
+            fused_top_k=int(d["fused_top_k"]),
+            rerank_top_k=int(d["rerank_top_k"]),
+            weights_lexical=float(
+                weights.get("lexical", d.get("weights_lexical", 0.0))
+            ),
+            weights_embedding=float(
+                weights.get("embedding", d.get("weights_embedding", 0.0))
+            ),
+        )
+
+
+@dataclass
+class ConfigResult:
+    """Per-config aggregated result. Serialized to JSON with _ms suffix."""
+
+    config_idx: int
+    params: ConfigParams
+    raw_no_citation_rate: float
+    true_nc_rate: float
+    wrong_citation_count: int
+    latency_p50_ms: float
+    latency_p95_ms: float
+    n_questions: int
+    n_no_citation: int
+    duration_seconds: float
+    started_at: str
+    completed_at: str
+    memory_peak_mb: float | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def to_json(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "config_idx": self.config_idx,
+            "params": self.params.to_override_dict(),
+            "raw_no_citation_rate": self.raw_no_citation_rate,
+            "true_nc_rate": self.true_nc_rate,
+            "wrong_citation_count": self.wrong_citation_count,
+            "latency_p50_ms": self.latency_p50_ms,
+            "latency_p95_ms": self.latency_p95_ms,
+            "n_questions": self.n_questions,
+            "n_no_citation": self.n_no_citation,
+            "duration_seconds": self.duration_seconds,
+            "started_at": self.started_at,
+            "completed_at": self.completed_at,
+        }
+        if self.memory_peak_mb is not None:
+            out["memory_peak_mb"] = self.memory_peak_mb
+        if self.extra:
+            out["extra"] = self.extra
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Invalid combo filter (design §5)
+# ---------------------------------------------------------------------------
+
+
+_WEIGHTS_SUM_MAX = 0.90
+_WEIGHTS_SUM_EPS = 1e-9
+
+
+def is_invalid_combo(p: ConfigParams) -> bool:
+    """Return True when ``p`` violates at least one of the 4 sanity rules.
+
+    See design §5 for the full rationale of each condition.
+    """
+    if p.rerank_top_k > p.fused_top_k:
+        return True
+    if p.lexical_top_k <= 0 or p.embedding_top_k <= 0 or p.fused_top_k <= 0:
+        return True
+    if (p.weights_lexical + p.weights_embedding) > _WEIGHTS_SUM_MAX + _WEIGHTS_SUM_EPS:
+        return True
+    if p.lexical_top_k <= 15 and p.embedding_top_k <= 15 and p.fused_top_k >= 20:
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Grid generators
+# ---------------------------------------------------------------------------
+
+
+_PHASE1_LEX_EMB: tuple[tuple[int, int], ...] = ((15, 15), (20, 20), (25, 25))
+_PHASE1_FUSED_RERANK: tuple[tuple[int, int], ...] = ((10, 8), (16, 12), (20, 16))
+_PHASE1_WEIGHTS: tuple[tuple[float, float], ...] = (
+    (0.55, 0.35),
+    (0.45, 0.45),
+    (0.35, 0.55),
+)
+
+
+def generate_phase1_grid() -> list[ConfigParams]:
+    """Return the 24 valid Phase 1 configs (27 candidates minus 3 invalid)."""
+    valid: list[ConfigParams] = []
+    for lex, emb in _PHASE1_LEX_EMB:
+        for fused, rerank in _PHASE1_FUSED_RERANK:
+            for w_lex, w_emb in _PHASE1_WEIGHTS:
+                params = ConfigParams(
+                    lexical_top_k=lex,
+                    embedding_top_k=emb,
+                    fused_top_k=fused,
+                    rerank_top_k=rerank,
+                    weights_lexical=w_lex,
+                    weights_embedding=w_emb,
+                )
+                if is_invalid_combo(params):
+                    continue
+                valid.append(params)
+    return valid
+
+
+def _key(params: ConfigParams) -> str:
+    return json.dumps(params.to_override_dict(), sort_keys=True)
+
+
+def generate_phase2_grid(
+    seeds: list[ConfigParams],
+    *,
+    topk_delta: int = 5,
+    topk_step: int = 5,
+    weight_delta: float = 0.05,
+    weight_step: float = 0.05,
+) -> list[ConfigParams]:
+    """Generate Phase 2 neighborhood around each seed.
+
+    For every seed we walk ``top_k ± topk_delta`` in ``topk_step`` increments
+    on each of the four ``*_top_k`` axes, and ``weights ± weight_delta`` in
+    ``weight_step`` increments on the two weight axes. Invalid combos are
+    filtered out and duplicates (including the seed itself) are dropped.
+    """
+    if not seeds:
+        return []
+
+    seed_keys = {_key(s) for s in seeds}
+    seen: set[str] = set(seed_keys)
+    result: list[ConfigParams] = []
+
+    topk_offsets = _range_int(-topk_delta, topk_delta, topk_step)
+    weight_offsets = _range_float(-weight_delta, weight_delta, weight_step)
+
+    for seed in seeds:
+        for d_lex in topk_offsets:
+            for d_emb in topk_offsets:
+                for d_fused in topk_offsets:
+                    for d_rerank in topk_offsets:
+                        for d_wl in weight_offsets:
+                            for d_we in weight_offsets:
+                                cand = ConfigParams(
+                                    lexical_top_k=seed.lexical_top_k + d_lex,
+                                    embedding_top_k=seed.embedding_top_k + d_emb,
+                                    fused_top_k=seed.fused_top_k + d_fused,
+                                    rerank_top_k=seed.rerank_top_k + d_rerank,
+                                    weights_lexical=round(
+                                        seed.weights_lexical + d_wl, 4
+                                    ),
+                                    weights_embedding=round(
+                                        seed.weights_embedding + d_we, 4
+                                    ),
+                                )
+                                if is_invalid_combo(cand):
+                                    continue
+                                k = _key(cand)
+                                if k in seen:
+                                    continue
+                                seen.add(k)
+                                result.append(cand)
+    return result
+
+
+def _range_int(lo: int, hi: int, step: int) -> list[int]:
+    if step <= 0:
+        return [0]
+    out: list[int] = []
+    n = lo
+    while n <= hi + 0:
+        out.append(n)
+        n += step
+    return out
+
+
+def _range_float(lo: float, hi: float, step: float) -> list[float]:
+    if step <= 0:
+        return [0.0]
+    out: list[float] = []
+    # Use integer math to avoid floating-point drift.
+    n_steps = int(round((hi - lo) / step))
+    for i in range(n_steps + 1):
+        out.append(round(lo + i * step, 6))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# aggregate_metrics (pinned against ci_eval_check.check_static)
+# ---------------------------------------------------------------------------
+
+
+def aggregate_metrics(
+    records: list[dict[str, Any]],
+    unanswerable_ids: set[str],
+) -> dict[str, Any]:
+    """Compute the same metrics as ``ci_eval_check.check_static``.
+
+    Returned keys match that function's dict (no ``_ms`` suffix on latency).
+    ``true_nc_rate`` is only present when ``unanswerable_ids`` is non-empty,
+    matching the reference implementation.
+    """
+    total = len(records)
+    if total == 0:
+        return {"total": 0, "error": "no records found"}
+
+    no_cite = sum(1 for r in records if r.get("no_citation"))
+    wrong_cite = sum(1 for r in records if r.get("wrong_citation_indices"))
+    latencies = [lat for r in records if (lat := _extract_latency(r)) is not None]
+
+    answerable_records = [r for r in records if _eval_id(r) not in unanswerable_ids]
+    answerable_total = len(answerable_records)
+    answerable_no_cite = sum(1 for r in answerable_records if r.get("no_citation"))
+    correct_abstains = sum(
+        1 for r in records if _eval_id(r) in unanswerable_ids and r.get("no_citation")
+    )
+
+    result: dict[str, Any] = {
+        "total": total,
+        "no_citation_rate": no_cite / total,
+        "wrong_citation_count": wrong_cite,
+        "latency_p50": statistics.median(latencies) if latencies else 0,
+        "latency_p95": _percentile(latencies, 0.95) if latencies else 0,
+        "n_questions": total,
+        "n_no_citation": no_cite,
+    }
+
+    if unanswerable_ids:
+        result["unanswerable_count"] = len(unanswerable_ids)
+        result["correct_abstains"] = correct_abstains
+        result["answerable_total"] = answerable_total
+        result["answerable_no_cite"] = answerable_no_cite
+        result["true_nc_rate"] = (
+            answerable_no_cite / answerable_total if answerable_total else 0
+        )
+
+    return result
+
+
+def _extract_latency(record: dict[str, Any]) -> float | None:
+    if "latency" in record and isinstance(record["latency"], dict):
+        return record["latency"].get("total_ms")
+    return record.get("latency_ms")
+
+
+def _eval_id(record: dict[str, Any]) -> str:
+    qid = record.get("eval_id", "") or record.get("id", "")
+    if not qid:
+        sid = record.get("session_id", "")
+        qid = sid.replace("eval-", "", 1) if sid.startswith("eval-") else sid
+    return qid
+
+
+def _percentile(values: list[float], q: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    # nearest-rank method: ceil(q * N) - 1, clipped to [0, N-1].
+    idx = max(0, min(len(ordered) - 1, math.ceil(q * len(ordered)) - 1))
+    return ordered[idx]
+
+
+# ---------------------------------------------------------------------------
+# validate_override (O8: fail-fast before 16h run)
+# ---------------------------------------------------------------------------
+
+
+def validate_override(base_cfg: Config, params: ConfigParams) -> None:
+    """Raise ValueError if ``params`` contains a key absent from ``base_cfg.retrieval``.
+
+    Catches typos (e.g. ``lexcial_top_k``) before they silently collapse to
+    the base config value during a 16h sweep.
+    """
+    retrieval_cfg = getattr(base_cfg, "retrieval", None)
+    if retrieval_cfg is None:
+        raise ValueError("base_cfg has no .retrieval section")
+
+    base_keys = set(_cfg_to_dict(retrieval_cfg).keys())
+    override = params.to_override_dict()
+    for key, value in override.items():
+        if key not in base_keys:
+            raise ValueError(
+                f"Unknown retrieval key: {key!r} (not in base_cfg.retrieval)"
+            )
+        if key == "weights" and isinstance(value, dict):
+            weights_base = _cfg_to_dict(getattr(retrieval_cfg, "weights", {}))
+            for wk in value:
+                if wk not in weights_base:
+                    raise ValueError(f"Unknown retrieval key: weights.{wk}")
+
+
+def _cfg_to_dict(cfg_or_dict: Any) -> dict[str, Any]:
+    if hasattr(cfg_or_dict, "to_dict"):
+        return cfg_or_dict.to_dict()
+    if isinstance(cfg_or_dict, dict):
+        return cfg_or_dict
+    return dict(vars(cfg_or_dict))
+
+
+# ---------------------------------------------------------------------------
+# Atomic JSON write
+# ---------------------------------------------------------------------------
+
+
+def atomic_write_json(path: str | Path, payload: dict[str, Any]) -> None:
+    """Atomically replace ``path`` with a JSON dump of ``payload``.
+
+    The tmp file is created in the same directory (same filesystem) so
+    ``os.replace`` is atomic on POSIX. Permissions are restricted to the
+    owner and ``fsync`` is called before the rename so a power loss after
+    rename still yields a durable, valid file.
+    """
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    tmp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=target.parent,
+            prefix=target.stem + ".",
+            suffix=".tmp",
+            delete=False,
+        ) as tmp:
+            tmp_path = Path(tmp.name)
+            os.chmod(tmp.name, 0o600)
+            json.dump(payload, tmp, indent=2, ensure_ascii=False)
+            tmp.flush()
+            os.fsync(tmp.fileno())
+        tmp_path.replace(target)
+        tmp_path = None
+    finally:
+        if tmp_path is not None and tmp_path.exists():
+            try:
+                tmp_path.unlink()
+            except OSError:
+                logger.warning("Failed to clean up tmp file %s", tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Markdown report
+# ---------------------------------------------------------------------------
+
+
+def write_markdown_report(
+    state: dict[str, Any],
+    best: ConfigResult,
+    out_path: str | Path,
+) -> None:
+    """Render a Markdown summary of all configs with best highlighted."""
+    target = Path(out_path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    lines: list[str] = []
+    lines.append("# Retrieval Grid Search Report")
+    lines.append("")
+    lines.append(f"- Base config: `{state.get('base_config_path', '')}`")
+    lines.append(f"- Phase: `{state.get('phase', '')}`")
+    lines.append(
+        f"- Max questions per config: {state.get('max_questions_per_config', '')}"
+    )
+    lines.append(f"- Started at: {state.get('started_at', '')}")
+    lines.append(f"- Completed at: {state.get('completed_at', '')}")
+    lines.append(f"- Total configs: {len(state.get('configs', []))}")
+    lines.append("")
+
+    lines.append("## Best Config")
+    lines.append("")
+    lines.append(
+        f"- **config_idx**: {best.config_idx}  "
+        f"(lexical_top_k={best.params.lexical_top_k}, "
+        f"embedding_top_k={best.params.embedding_top_k}, "
+        f"fused_top_k={best.params.fused_top_k}, "
+        f"rerank_top_k={best.params.rerank_top_k}, "
+        f"weights_lexical={best.params.weights_lexical}, "
+        f"weights_embedding={best.params.weights_embedding})"
+    )
+    lines.append(
+        f"- **raw no_citation_rate**: {best.raw_no_citation_rate:.2%} "
+        f"({best.n_no_citation}/{best.n_questions})"
+    )
+    lines.append(f"- **true_nc_rate**: {best.true_nc_rate:.2%}")
+    lines.append(f"- **wrong_citation_count**: {best.wrong_citation_count}")
+    lines.append(f"- **latency_p50_ms**: {best.latency_p50_ms:.0f}")
+    lines.append(f"- **latency_p95_ms**: {best.latency_p95_ms:.0f}")
+    lines.append(f"- **duration_seconds**: {best.duration_seconds:.1f}")
+    lines.append("")
+
+    lines.append("## All Configs")
+    lines.append("")
+    lines.append(
+        "| idx | lex | emb | fused | rerank | w_lex | w_emb | "
+        "raw NC | true NC | p50 ms | p95 ms | wrong |"
+    )
+    lines.append(
+        "|-----|-----|-----|-------|--------|-------|-------|"
+        "--------|---------|--------|--------|-------|"
+    )
+    for entry in state.get("configs", []):
+        params = entry.get("params", {})
+        weights = params.get("weights", {})
+        lines.append(
+            "| {idx} | {lex} | {emb} | {fused} | {rerank} | "
+            "{wl:.2f} | {we:.2f} | {raw:.2%} | {true_nc} | "
+            "{p50:.0f} | {p95:.0f} | {wrong} |".format(
+                idx=entry.get("config_idx", ""),
+                lex=params.get("lexical_top_k", ""),
+                emb=params.get("embedding_top_k", ""),
+                fused=params.get("fused_top_k", ""),
+                rerank=params.get("rerank_top_k", ""),
+                wl=float(weights.get("lexical", 0.0)),
+                we=float(weights.get("embedding", 0.0)),
+                raw=entry.get("raw_no_citation_rate", 0.0),
+                true_nc=_format_pct_or_dash(entry.get("true_nc_rate")),
+                p50=entry.get("latency_p50_ms", 0.0),
+                p95=entry.get("latency_p95_ms", 0.0),
+                wrong=entry.get("wrong_citation_count", 0),
+            )
+        )
+
+    lines.append("")
+    target.write_text("\n".join(lines), encoding="utf-8")
+
+
+def _format_pct_or_dash(value: Any) -> str:
+    if value is None:
+        return "-"
+    try:
+        return f"{float(value):.2%}"
+    except (TypeError, ValueError):
+        return "-"

--- a/scripts/retrieval_grid_search.py
+++ b/scripts/retrieval_grid_search.py
@@ -1,0 +1,523 @@
+"""Retrieval parameter grid-search driver (Issue #88).
+
+Sweeps ``configs/baseline.yaml`` ``retrieval.*`` parameters in a single
+process, reusing one loaded pipeline across all configs. Writes per-config
+progress to ``reports/retrieval_grid_search.json`` atomically and renders
+``reports/retrieval_grid_search.md`` at the end.
+
+See ``workspace/design/issue-88-retrieval-grid-search-design-policy.md``
+for the full design rationale. The pure-function helpers live in
+``scripts/_grid_search_core`` and are unit-tested without MLX.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import signal
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from types import FrameType
+from typing import TYPE_CHECKING, Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts._grid_search_core import (  # noqa: E402
+    ConfigParams,
+    ConfigResult,
+    aggregate_metrics,
+    atomic_write_json,
+    generate_phase1_grid,
+    generate_phase2_grid,
+    validate_override,
+    write_markdown_report,
+)
+
+if TYPE_CHECKING:
+    from baseline_reporag.config import Config
+    from baseline_reporag.pipeline import RepoRAGPipeline
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# CLI parsing + path validation
+# ---------------------------------------------------------------------------
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Retrieval parameter grid search (Issue #88)."
+    )
+    parser.add_argument("--config", default="configs/baseline.yaml")
+    parser.add_argument("--eval-set", default="data/eval_sets/static_eval.jsonl")
+    parser.add_argument("--phase", choices=["1", "2", "both"], default="both")
+    parser.add_argument("--max-questions", type=int, default=40)
+    parser.add_argument("--output-dir", default="reports")
+    parser.add_argument("--logs-dir", default="logs")
+    parser.add_argument("--resume", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--top-n-for-phase2", type=int, default=5)
+    parser.add_argument("--phase2-topk-delta", type=int, default=5)
+    parser.add_argument("--phase2-weight-delta", type=float, default=0.05)
+    return parser.parse_args(argv)
+
+
+def _repo_relative(p: str | Path) -> Path:
+    """Resolve ``p`` and assert it stays under ``REPO_ROOT``.
+
+    Rejects absolute paths, ``..`` traversal, and symlink escapes. The
+    grid-search tool is trusted-operator-only; this guard exists to keep
+    an accidental ``--config /etc/shadow`` from reaching ``pickle.load``.
+    """
+    raw = Path(p)
+    if raw.is_absolute():
+        raise SystemExit(f"error: path must be repo-relative, got absolute: {p!r}")
+    resolved = (REPO_ROOT / raw).resolve()
+    try:
+        resolved.relative_to(REPO_ROOT.resolve())
+    except ValueError as exc:
+        raise SystemExit(f"error: path escapes repo root: {p!r}") from exc
+    return resolved
+
+
+def _validate_paths(args: argparse.Namespace) -> None:
+    _repo_relative(args.config)
+    _repo_relative(args.eval_set)
+    _repo_relative(args.output_dir)
+    _repo_relative(args.logs_dir)
+
+
+# ---------------------------------------------------------------------------
+# Pipeline build + eval helpers
+# ---------------------------------------------------------------------------
+
+
+def build_pipeline_for_sweep(
+    base_cfg: Config,
+    scratch_log_root: Path,
+) -> "RepoRAGPipeline":
+    """Load a single pipeline instance, pointing scratch logs to *scratch_log_root*."""
+    from baseline_reporag.pipeline_factory import build_pipeline
+
+    scratch_log_root.mkdir(parents=True, exist_ok=True)
+    sweep_cfg = base_cfg.merge_override({"paths": {"log_root": str(scratch_log_root)}})
+    return build_pipeline(sweep_cfg)  # type: ignore[return-value]
+
+
+def load_questions(path: Path, max_questions: int) -> list[dict[str, Any]]:
+    questions: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            questions.append(json.loads(line))
+    if max_questions > 0:
+        questions = questions[:max_questions]
+    return questions
+
+
+def unanswerable_ids_from(questions: list[dict[str, Any]]) -> set[str]:
+    return {q["id"] for q in questions if q.get("answerable") is False}
+
+
+def run_eval_inproc(
+    pipeline: "RepoRAGPipeline",
+    questions: list[dict[str, Any]],
+    *,
+    config_idx: int,
+    repo_id: str,
+) -> list[dict[str, Any]]:
+    """Run ``pipeline.query`` once per question, collect citation records.
+
+    Each question uses ``session_id = f"grid-{config_idx}-{q['id']}"`` to
+    keep session history from leaking across configs.
+    """
+    records: list[dict[str, Any]] = []
+    for q in questions:
+        result = pipeline.query(
+            question=q["question"],
+            session_id=f"grid-{config_idx}-{q['id']}",
+            repo_id=repo_id,
+        )
+        latency_ms = float(getattr(result.latency, "total_ms", 0.0))
+        memory_peak = float(getattr(result.memory, "peak_mb", 0.0))
+        records.append(
+            {
+                "eval_id": q["id"],
+                "no_citation": bool(result.no_citation),
+                "wrong_citation_indices": list(result.wrong_citation_indices or []),
+                "latency_ms": latency_ms,
+                "memory_peak_mb": memory_peak,
+            }
+        )
+    return records
+
+
+# ---------------------------------------------------------------------------
+# Sweep loop + resume + atomic write
+# ---------------------------------------------------------------------------
+
+
+def _params_key(params: ConfigParams) -> str:
+    return json.dumps(params.to_override_dict(), sort_keys=True)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).astimezone().isoformat()
+
+
+def _load_state(state_path: Path) -> dict[str, Any] | None:
+    if not state_path.exists():
+        return None
+    try:
+        return json.loads(state_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        logger.warning("Could not read existing state at %s", state_path)
+        return None
+
+
+def _build_config_result(
+    config_idx: int,
+    params: ConfigParams,
+    records: list[dict[str, Any]],
+    metrics: dict[str, Any],
+    started_at: str,
+    completed_at: str,
+    duration_seconds: float,
+) -> ConfigResult:
+    memory_peaks = [
+        r.get("memory_peak_mb", 0.0)
+        for r in records
+        if r.get("memory_peak_mb") is not None
+    ]
+    peak = max(memory_peaks) if memory_peaks else None
+    return ConfigResult(
+        config_idx=config_idx,
+        params=params,
+        raw_no_citation_rate=float(metrics.get("no_citation_rate", 0.0)),
+        true_nc_rate=float(metrics.get("true_nc_rate", 0.0) or 0.0),
+        wrong_citation_count=int(metrics.get("wrong_citation_count", 0)),
+        latency_p50_ms=float(metrics.get("latency_p50", 0.0)),
+        latency_p95_ms=float(metrics.get("latency_p95", 0.0)),
+        n_questions=int(metrics.get("n_questions", len(records))),
+        n_no_citation=int(metrics.get("n_no_citation", 0)),
+        duration_seconds=duration_seconds,
+        started_at=started_at,
+        completed_at=completed_at,
+        memory_peak_mb=peak,
+    )
+
+
+class _InterruptedError(BaseException):
+    """Raised when a signal handler requests graceful shutdown."""
+
+
+def _install_signal_handlers(flag: dict[str, bool]) -> None:
+    def _handler(signum: int, _frame: FrameType | None) -> None:
+        logger.warning("Received signal %s, flushing and exiting.", signum)
+        flag["stop"] = True
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        try:
+            signal.signal(sig, _handler)
+        except (ValueError, OSError):
+            # SIGTERM not available on every platform / thread context.
+            pass
+
+
+def run_phase(
+    base_cfg: Config,
+    grid: list[ConfigParams],
+    *,
+    questions: list[dict[str, Any]],
+    unanswerable_ids: set[str],
+    pipeline: "RepoRAGPipeline",
+    state_path: Path,
+    resume: bool,
+    phase_name: str,
+    repo_id: str,
+    stop_flag: dict[str, bool],
+) -> list[ConfigResult]:
+    """Execute one phase of the sweep, atomically persisting per-config state."""
+    state: dict[str, Any]
+    existing = _load_state(state_path) if resume else None
+    if existing and resume:
+        state = existing
+    else:
+        state = {
+            "phase": phase_name,
+            "base_config_path": getattr(base_cfg, "_config_path", ""),
+            "max_questions_per_config": len(questions),
+            "started_at": _now_iso(),
+            "completed_at": "",
+            "configs": [],
+            "status": "running",
+        }
+
+    done_keys = {
+        json.dumps(c.get("params", {}), sort_keys=True)
+        for c in state.get("configs", [])
+    }
+
+    results: list[ConfigResult] = []
+    total = len(grid)
+    sweep_start = time.perf_counter()
+
+    for idx, params in enumerate(grid):
+        if stop_flag.get("stop"):
+            state["status"] = "interrupted"
+            state["interrupted_at"] = _now_iso()
+            atomic_write_json(state_path, state)
+            raise _InterruptedError("interrupted by signal")
+
+        key = _params_key(params)
+        if resume and key in done_keys:
+            logger.info(
+                "[%s] skipping already-completed config %d/%d",
+                phase_name,
+                idx + 1,
+                total,
+            )
+            continue
+
+        started_at = _now_iso()
+        t0 = time.perf_counter()
+        logger.info(
+            "[%s] [Config %d/%d] starting params=%s",
+            phase_name,
+            idx + 1,
+            total,
+            params.to_override_dict(),
+        )
+
+        cfg2 = base_cfg.merge_override({"retrieval": params.to_override_dict()})
+        pipeline.cfg = cfg2  # type: ignore[attr-defined]
+
+        try:
+            records = run_eval_inproc(
+                pipeline, questions, config_idx=idx, repo_id=repo_id
+            )
+        except KeyboardInterrupt:
+            state["status"] = "interrupted"
+            state["interrupted_at"] = _now_iso()
+            atomic_write_json(state_path, state)
+            raise
+
+        metrics = aggregate_metrics(records, unanswerable_ids)
+        duration = time.perf_counter() - t0
+        completed_at = _now_iso()
+        result = _build_config_result(
+            idx, params, records, metrics, started_at, completed_at, duration
+        )
+        results.append(result)
+
+        state["configs"].append(result.to_json())
+        state["completed_at"] = completed_at
+        done_keys.add(key)
+        atomic_write_json(state_path, state)
+
+        elapsed = time.perf_counter() - sweep_start
+        logger.info(
+            "[%s] [Config %d/%d] NC=%.1f%% (%d/%d) p50=%.0fms elapsed=%.1fs",
+            phase_name,
+            idx + 1,
+            total,
+            100.0 * result.raw_no_citation_rate,
+            result.n_no_citation,
+            result.n_questions,
+            result.latency_p50_ms,
+            elapsed,
+        )
+
+    state["status"] = f"{phase_name}_complete"
+    state["completed_at"] = _now_iso()
+    atomic_write_json(state_path, state)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Best config selection + phase 2 gating
+# ---------------------------------------------------------------------------
+
+
+def pick_best(results: list[ConfigResult]) -> ConfigResult | None:
+    if not results:
+        return None
+    return min(
+        results,
+        key=lambda r: (r.raw_no_citation_rate, r.latency_p50_ms),
+    )
+
+
+def top_n(results: list[ConfigResult], n: int) -> list[ConfigResult]:
+    return sorted(results, key=lambda r: (r.raw_no_citation_rate, r.latency_p50_ms))[:n]
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    args = _parse_args(argv)
+    _validate_paths(args)
+
+    config_path = _repo_relative(args.config)
+    eval_set_path = _repo_relative(args.eval_set)
+    output_dir = _repo_relative(args.output_dir)
+    logs_dir = _repo_relative(args.logs_dir)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    logs_dir.mkdir(parents=True, exist_ok=True)
+
+    from baseline_reporag.config import load_config
+
+    base_cfg = load_config(config_path)
+    repo_id = base_cfg.repo.repo_id
+
+    phase1_grid = generate_phase1_grid()
+    for params in phase1_grid:
+        validate_override(base_cfg, params)
+
+    logger.info("Phase 1 grid: %d configs", len(phase1_grid))
+
+    if args.dry_run:
+        _print_dry_run(phase1_grid)
+        return 0
+
+    questions = load_questions(eval_set_path, args.max_questions)
+    unanswerable = unanswerable_ids_from(questions)
+    logger.info(
+        "Loaded %d questions (unanswerable: %d)", len(questions), len(unanswerable)
+    )
+
+    scratch_root = logs_dir / "grid_search_scratch"
+    pipeline = build_pipeline_for_sweep(base_cfg, scratch_root)
+
+    state_path = output_dir / "retrieval_grid_search.json"
+    report_path = output_dir / "retrieval_grid_search.md"
+
+    stop_flag: dict[str, bool] = {"stop": False}
+    _install_signal_handlers(stop_flag)
+
+    all_results: list[ConfigResult] = []
+
+    try:
+        if args.phase in ("1", "both"):
+            phase1_results = run_phase(
+                base_cfg,
+                phase1_grid,
+                questions=questions,
+                unanswerable_ids=unanswerable,
+                pipeline=pipeline,
+                state_path=state_path,
+                resume=args.resume,
+                phase_name="phase1",
+                repo_id=repo_id,
+                stop_flag=stop_flag,
+            )
+            all_results.extend(phase1_results)
+
+        if args.phase in ("2", "both"):
+            seeds_source = all_results or _reload_results_from_state(state_path)
+            seeds = [r.params for r in top_n(seeds_source, args.top_n_for_phase2)]
+            if not seeds:
+                logger.warning("No Phase 1 seeds available; skipping Phase 2.")
+            else:
+                best_so_far = pick_best(seeds_source)
+                if (
+                    args.phase == "both"
+                    and best_so_far is not None
+                    and best_so_far.raw_no_citation_rate > 0.18
+                ):
+                    logger.warning(
+                        "Phase 1 best NC=%.1f%% > 18%%; skipping Phase 2.",
+                        100.0 * best_so_far.raw_no_citation_rate,
+                    )
+                else:
+                    phase2_grid = generate_phase2_grid(
+                        seeds,
+                        topk_delta=args.phase2_topk_delta,
+                        weight_delta=args.phase2_weight_delta,
+                    )
+                    logger.info(
+                        "Phase 2 grid: %d configs around top-%d seeds",
+                        len(phase2_grid),
+                        len(seeds),
+                    )
+                    phase2_results = run_phase(
+                        base_cfg,
+                        phase2_grid,
+                        questions=questions,
+                        unanswerable_ids=unanswerable,
+                        pipeline=pipeline,
+                        state_path=state_path,
+                        resume=args.resume,
+                        phase_name="phase2",
+                        repo_id=repo_id,
+                        stop_flag=stop_flag,
+                    )
+                    all_results.extend(phase2_results)
+    except _InterruptedError:
+        logger.warning("Sweep interrupted; partial state preserved in %s", state_path)
+        return 130
+
+    final_state = _load_state(state_path) or {}
+    all_config_results = _reload_results_from_state(state_path)
+    best = pick_best(all_config_results)
+    if best is not None:
+        write_markdown_report(final_state, best, report_path)
+        logger.info(
+            "Best config: idx=%d raw_nc=%.2f%% p50=%.0fms",
+            best.config_idx,
+            100.0 * best.raw_no_citation_rate,
+            best.latency_p50_ms,
+        )
+    else:
+        logger.warning("No results available; Markdown report not written.")
+    return 0
+
+
+def _reload_results_from_state(state_path: Path) -> list[ConfigResult]:
+    state = _load_state(state_path)
+    if not state:
+        return []
+    out: list[ConfigResult] = []
+    for entry in state.get("configs", []):
+        params = ConfigParams.from_dict(entry.get("params", {}))
+        out.append(
+            ConfigResult(
+                config_idx=int(entry.get("config_idx", 0)),
+                params=params,
+                raw_no_citation_rate=float(entry.get("raw_no_citation_rate", 0.0)),
+                true_nc_rate=float(entry.get("true_nc_rate", 0.0) or 0.0),
+                wrong_citation_count=int(entry.get("wrong_citation_count", 0)),
+                latency_p50_ms=float(entry.get("latency_p50_ms", 0.0)),
+                latency_p95_ms=float(entry.get("latency_p95_ms", 0.0)),
+                n_questions=int(entry.get("n_questions", 0)),
+                n_no_citation=int(entry.get("n_no_citation", 0)),
+                duration_seconds=float(entry.get("duration_seconds", 0.0)),
+                started_at=str(entry.get("started_at", "")),
+                completed_at=str(entry.get("completed_at", "")),
+                memory_peak_mb=entry.get("memory_peak_mb"),
+            )
+        )
+    return out
+
+
+def _print_dry_run(grid: list[ConfigParams]) -> None:
+    print(f"Phase 1 grid contains {len(grid)} configs:")
+    for idx, params in enumerate(grid):
+        print(f"  [{idx:2d}] {json.dumps(params.to_override_dict(), sort_keys=True)}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_retrieval_grid_search.py
+++ b/tests/test_retrieval_grid_search.py
@@ -1,0 +1,523 @@
+"""Unit tests for scripts/_grid_search_core (Issue #88).
+
+Covers the pure-function grid search core module per design §7.1:
+ConfigParams / ConfigResult, grid generation, invalid-combo filtering,
+metric aggregation pinned against ci_eval_check.check_static, and
+override validation.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts._grid_search_core import (  # noqa: E402
+    ConfigParams,
+    ConfigResult,
+    aggregate_metrics,
+    atomic_write_json,
+    generate_phase1_grid,
+    generate_phase2_grid,
+    is_invalid_combo,
+    validate_override,
+    write_markdown_report,
+)
+
+
+# ---------------------------------------------------------------------------
+# ConfigParams / ConfigResult
+# ---------------------------------------------------------------------------
+
+
+def _sample_params(**overrides: object) -> ConfigParams:
+    base = dict(
+        lexical_top_k=20,
+        embedding_top_k=20,
+        fused_top_k=16,
+        rerank_top_k=12,
+        weights_lexical=0.45,
+        weights_embedding=0.45,
+    )
+    base.update(overrides)
+    return ConfigParams(**base)  # type: ignore[arg-type]
+
+
+def test_config_params_to_override_dict() -> None:
+    params = _sample_params()
+    override = params.to_override_dict()
+
+    assert override["lexical_top_k"] == 20
+    assert override["embedding_top_k"] == 20
+    assert override["fused_top_k"] == 16
+    assert override["rerank_top_k"] == 12
+    assert override["weights"] == {"lexical": 0.45, "embedding": 0.45}
+
+
+def test_config_params_roundtrip() -> None:
+    original = _sample_params(weights_lexical=0.55, weights_embedding=0.35)
+    restored = ConfigParams.from_dict(original.to_override_dict())
+    assert restored == original
+
+
+def test_config_result_to_json_uses_ms_suffix() -> None:
+    params = _sample_params()
+    result = ConfigResult(
+        config_idx=3,
+        params=params,
+        raw_no_citation_rate=0.175,
+        true_nc_rate=0.16,
+        wrong_citation_count=1,
+        latency_p50_ms=19500.0,
+        latency_p95_ms=28000.0,
+        n_questions=40,
+        n_no_citation=7,
+        duration_seconds=780.5,
+        started_at="2026-04-22T10:01:00+09:00",
+        completed_at="2026-04-22T10:14:00+09:00",
+    )
+    j = result.to_json()
+    assert j["config_idx"] == 3
+    assert j["latency_p50_ms"] == 19500.0
+    assert j["latency_p95_ms"] == 28000.0
+    assert j["params"] == params.to_override_dict()
+
+
+# ---------------------------------------------------------------------------
+# is_invalid_combo
+# ---------------------------------------------------------------------------
+
+
+def test_is_invalid_combo_rerank_exceeds_fused() -> None:
+    p = _sample_params(fused_top_k=16, rerank_top_k=20)
+    assert is_invalid_combo(p) is True
+
+
+def test_is_invalid_combo_non_positive_topk() -> None:
+    p = _sample_params(lexical_top_k=0)
+    assert is_invalid_combo(p) is True
+
+
+def test_is_invalid_combo_weights_sum_overflow() -> None:
+    p = _sample_params(weights_lexical=0.55, weights_embedding=0.55)
+    assert is_invalid_combo(p) is True
+
+
+def test_is_invalid_combo_known_cases() -> None:
+    assert (
+        is_invalid_combo(
+            _sample_params(
+                lexical_top_k=15,
+                embedding_top_k=15,
+                fused_top_k=20,
+                rerank_top_k=16,
+            )
+        )
+        is True
+    )
+    assert is_invalid_combo(_sample_params()) is False
+
+
+def test_is_invalid_combo_weights_sum_exactly_0_90_is_valid() -> None:
+    p = _sample_params(weights_lexical=0.55, weights_embedding=0.35)
+    assert is_invalid_combo(p) is False
+
+
+# ---------------------------------------------------------------------------
+# generate_phase1_grid
+# ---------------------------------------------------------------------------
+
+
+def test_generate_phase1_grid_count() -> None:
+    grid = generate_phase1_grid()
+    assert len(grid) == 24
+
+
+def test_phase1_grid_no_invalid_combos() -> None:
+    for params in generate_phase1_grid():
+        assert not is_invalid_combo(params), params
+
+
+def test_phase1_grid_unique_configs() -> None:
+    grid = generate_phase1_grid()
+    seen = {json.dumps(p.to_override_dict(), sort_keys=True) for p in grid}
+    assert len(seen) == len(grid)
+
+
+# ---------------------------------------------------------------------------
+# generate_phase2_grid
+# ---------------------------------------------------------------------------
+
+
+def test_phase2_neighborhood_dedup() -> None:
+    seeds = [
+        _sample_params(),
+        _sample_params(),
+    ]
+    grid = generate_phase2_grid(seeds)
+    seen = {json.dumps(p.to_override_dict(), sort_keys=True) for p in grid}
+    assert len(seen) == len(grid)
+
+
+def test_phase2_no_invalid_combos() -> None:
+    seeds = [_sample_params()]
+    for p in generate_phase2_grid(seeds):
+        assert not is_invalid_combo(p), p
+
+
+def test_phase2_excludes_seed_itself() -> None:
+    seed = _sample_params()
+    grid = generate_phase2_grid([seed])
+    seed_key = json.dumps(seed.to_override_dict(), sort_keys=True)
+    keys = {json.dumps(p.to_override_dict(), sort_keys=True) for p in grid}
+    assert seed_key not in keys
+
+
+# ---------------------------------------------------------------------------
+# aggregate_metrics (pin against scripts.ci_eval_check.check_static)
+# ---------------------------------------------------------------------------
+
+
+def _sample_records() -> list[dict]:
+    return [
+        {
+            "eval_id": "SE-001",
+            "no_citation": False,
+            "wrong_citation_indices": [],
+            "latency_ms": 10_000.0,
+        },
+        {
+            "eval_id": "SE-002",
+            "no_citation": True,
+            "wrong_citation_indices": [],
+            "latency_ms": 20_000.0,
+        },
+        {
+            "eval_id": "SE-003",
+            "no_citation": False,
+            "wrong_citation_indices": [2],
+            "latency_ms": 30_000.0,
+        },
+        {
+            "eval_id": "SE-UA-001",
+            "no_citation": True,
+            "wrong_citation_indices": [],
+            "latency_ms": 5_000.0,
+        },
+    ]
+
+
+def test_aggregate_metrics_matches_ci_eval_check(tmp_path: Path) -> None:
+    from scripts.ci_eval_check import check_static
+
+    records = _sample_records()
+    unanswerable_ids = {"SE-UA-001"}
+
+    metrics = aggregate_metrics(records, unanswerable_ids)
+
+    log_path = tmp_path / "fake.jsonl"
+    with open(log_path, "w", encoding="utf-8") as f:
+        for r in records:
+            f.write(json.dumps(r) + "\n")
+    ref = check_static(str(log_path), unanswerable_ids=unanswerable_ids)
+
+    assert metrics["no_citation_rate"] == pytest.approx(ref["no_citation_rate"])
+    assert metrics["wrong_citation_count"] == ref["wrong_citation_count"]
+    assert metrics["latency_p50"] == pytest.approx(ref["latency_p50"])
+    assert metrics["true_nc_rate"] == pytest.approx(ref["true_nc_rate"])
+
+
+def test_aggregate_metrics_p50_calculation() -> None:
+    records = _sample_records()
+    metrics = aggregate_metrics(records, unanswerable_ids=set())
+    expected_p50 = statistics.median([r["latency_ms"] for r in records])
+    assert metrics["latency_p50"] == pytest.approx(expected_p50)
+
+
+def test_aggregate_metrics_no_true_nc_when_empty_unanswerable() -> None:
+    records = _sample_records()
+    metrics = aggregate_metrics(records, unanswerable_ids=set())
+    assert "true_nc_rate" not in metrics
+
+
+def test_aggregate_metrics_counts_wrong_citation_records() -> None:
+    records = _sample_records()
+    metrics = aggregate_metrics(records, unanswerable_ids=set())
+    # ci_eval_check counts records with non-empty wrong_citation_indices.
+    assert metrics["wrong_citation_count"] == 1
+
+
+def test_aggregate_metrics_latency_p95() -> None:
+    records = _sample_records()
+    metrics = aggregate_metrics(records, unanswerable_ids=set())
+    # p95 of 4 points = index min(len-1, ceil(.95 * len) - 1) = 3
+    assert metrics["latency_p95"] == pytest.approx(30_000.0)
+
+
+# ---------------------------------------------------------------------------
+# validate_override
+# ---------------------------------------------------------------------------
+
+
+def _load_base_cfg():  # type: ignore[no-untyped-def]
+    from baseline_reporag.config import load_config
+
+    return load_config(REPO_ROOT / "configs" / "baseline.yaml")
+
+
+def test_validate_override_rejects_unknown_key() -> None:
+    base_cfg = _load_base_cfg()
+    bad = _sample_params()
+    # Patch override dict to include a typo'd key by wrapping in a subclass
+    # that returns a custom dict. validate_override must inspect the dict.
+
+    class _BadParams(ConfigParams):
+        def to_override_dict(self) -> dict:  # type: ignore[override]
+            d = super().to_override_dict()
+            d["lexcial_top_k"] = 20  # intentional typo
+            return d
+
+    bad_typed = _BadParams(
+        lexical_top_k=bad.lexical_top_k,
+        embedding_top_k=bad.embedding_top_k,
+        fused_top_k=bad.fused_top_k,
+        rerank_top_k=bad.rerank_top_k,
+        weights_lexical=bad.weights_lexical,
+        weights_embedding=bad.weights_embedding,
+    )
+    with pytest.raises(ValueError, match="Unknown retrieval key"):
+        validate_override(base_cfg, bad_typed)
+
+
+def test_validate_override_passes_valid_params() -> None:
+    base_cfg = _load_base_cfg()
+    params = _sample_params()
+    validate_override(base_cfg, params)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# merge_override preserves sibling keys (D2-a / D3 pin)
+# ---------------------------------------------------------------------------
+
+
+def test_merge_override_preserves_reranker() -> None:
+    base_cfg = _load_base_cfg()
+    params = _sample_params()
+    cfg2 = base_cfg.merge_override({"retrieval": params.to_override_dict()})
+    assert cfg2.retrieval.reranker.enabled is True
+
+
+def test_merge_override_preserves_graph_weight() -> None:
+    base_cfg = _load_base_cfg()
+    params = _sample_params()
+    cfg2 = base_cfg.merge_override({"retrieval": params.to_override_dict()})
+    assert cfg2.retrieval.weights.graph == pytest.approx(0.10)
+
+
+# ---------------------------------------------------------------------------
+# atomic_write_json
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_json_writes_content(tmp_path: Path) -> None:
+    target = tmp_path / "state.json"
+    payload = {"configs": [{"config_idx": 0}], "phase": "phase1"}
+    atomic_write_json(target, payload)
+    assert target.exists()
+    assert json.loads(target.read_text(encoding="utf-8")) == payload
+
+
+def test_atomic_write_json_replaces_existing(tmp_path: Path) -> None:
+    target = tmp_path / "state.json"
+    target.write_text('{"stale": true}', encoding="utf-8")
+    payload = {"fresh": True}
+    atomic_write_json(target, payload)
+    assert json.loads(target.read_text(encoding="utf-8")) == payload
+
+
+def test_atomic_write_json_no_tmp_leftover(tmp_path: Path) -> None:
+    target = tmp_path / "state.json"
+    atomic_write_json(target, {"ok": True})
+    leftovers = [p for p in tmp_path.iterdir() if p.name.endswith(".tmp")]
+    assert leftovers == []
+
+
+def test_atomic_write_json_chmod_owner_only(tmp_path: Path) -> None:
+    target = tmp_path / "state.json"
+    atomic_write_json(target, {"ok": True})
+    mode = target.stat().st_mode & 0o777
+    # Owner-only permissions: no group / world access.
+    assert mode & 0o077 == 0
+
+
+# ---------------------------------------------------------------------------
+# write_markdown_report
+# ---------------------------------------------------------------------------
+
+
+def test_write_markdown_report_renders_best_config(tmp_path: Path) -> None:
+    params = _sample_params()
+    best = ConfigResult(
+        config_idx=0,
+        params=params,
+        raw_no_citation_rate=0.125,
+        true_nc_rate=0.10,
+        wrong_citation_count=0,
+        latency_p50_ms=19000.0,
+        latency_p95_ms=27000.0,
+        n_questions=40,
+        n_no_citation=5,
+        duration_seconds=780.0,
+        started_at="2026-04-22T10:00:00+09:00",
+        completed_at="2026-04-22T10:13:00+09:00",
+    )
+    state = {
+        "phase": "both",
+        "base_config_path": "configs/baseline.yaml",
+        "max_questions_per_config": 40,
+        "started_at": "2026-04-22T10:00:00+09:00",
+        "completed_at": "2026-04-22T10:13:00+09:00",
+        "configs": [best.to_json()],
+    }
+    out = tmp_path / "report.md"
+    write_markdown_report(state, best, out)
+
+    text = out.read_text(encoding="utf-8")
+    assert "# Retrieval Grid Search" in text
+    assert "12.50%" in text  # raw NC as %
+    assert "lexical_top_k=20" in text or "lexical_top_k: 20" in text
+
+
+# ---------------------------------------------------------------------------
+# resume skip (state helper used by run_phase)
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_json_survives_partial_write(tmp_path: Path) -> None:
+    # Write once, verify, then overwrite and verify again. The tmp+replace
+    # pattern guarantees the reader either sees the old or the new file,
+    # never a truncated one. We can't simulate a real crash inside a unit
+    # test, but we can assert the contract's key property: after a
+    # successful call the file is always valid JSON.
+    target = tmp_path / "state.json"
+    atomic_write_json(target, {"n": 1})
+    assert json.loads(target.read_text(encoding="utf-8")) == {"n": 1}
+    atomic_write_json(target, {"n": 2, "nested": {"x": "y"}})
+    assert json.loads(target.read_text(encoding="utf-8")) == {
+        "n": 2,
+        "nested": {"x": "y"},
+    }
+    # No leftover temp files in the directory.
+    assert [p.name for p in tmp_path.iterdir()] == ["state.json"]
+
+
+# ---------------------------------------------------------------------------
+# Misc: atomic_write_json dir must exist
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_json_creates_parent(tmp_path: Path) -> None:
+    target = tmp_path / "sub" / "nested" / "state.json"
+    atomic_write_json(target, {"ok": True})
+    assert target.exists()
+
+
+# ---------------------------------------------------------------------------
+# Sanity: is_invalid_combo boundary fused_top_k == 15
+# ---------------------------------------------------------------------------
+
+
+def test_is_invalid_combo_fused_19_below_threshold() -> None:
+    # (15,15,19,?) is NOT filtered by condition (4); only fused>=20 triggers.
+    p = _sample_params(
+        lexical_top_k=15,
+        embedding_top_k=15,
+        fused_top_k=19,
+        rerank_top_k=12,
+    )
+    assert is_invalid_combo(p) is False
+
+
+# ---------------------------------------------------------------------------
+# Ensure tempfile clean-up survives a filesystem where dir is read-only.
+# (Guard: we only check non-hostile case; hostile case tested via exception.)
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_json_fsync_called(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[int] = []
+    real_fsync = os.fsync
+
+    def _fake_fsync(fd: int) -> None:
+        calls.append(fd)
+        real_fsync(fd)
+
+    monkeypatch.setattr(os, "fsync", _fake_fsync)
+    atomic_write_json(tmp_path / "x.json", {"ok": True})
+    assert calls, "os.fsync must be invoked before rename"
+
+
+# ---------------------------------------------------------------------------
+# Misc: atomic_write_json with pathlib.Path and str both accepted.
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_json_accepts_str_path(tmp_path: Path) -> None:
+    target = tmp_path / "x.json"
+    atomic_write_json(str(target), {"ok": True})  # type: ignore[arg-type]
+    assert json.loads(target.read_text(encoding="utf-8")) == {"ok": True}
+
+
+# ---------------------------------------------------------------------------
+# Regression: ConfigParams is hashable (used as dict key / set).
+# ---------------------------------------------------------------------------
+
+
+def test_config_params_is_hashable() -> None:
+    s = {_sample_params(), _sample_params(lexical_top_k=25)}
+    assert len(s) == 2
+
+
+# ---------------------------------------------------------------------------
+# Smoke: Phase 2 without any seeds returns empty grid.
+# ---------------------------------------------------------------------------
+
+
+def test_phase2_empty_seeds_returns_empty() -> None:
+    assert generate_phase2_grid([]) == []
+
+
+# ---------------------------------------------------------------------------
+# Smoke: tempfile is placed in target dir, not /tmp.
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_json_tmp_in_same_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    tmp_paths: list[str] = []
+
+    real_ntf = tempfile.NamedTemporaryFile
+
+    def _fake_ntf(*args: object, **kwargs: object):  # type: ignore[no-untyped-def]
+        f = real_ntf(*args, **kwargs)
+        tmp_paths.append(f.name)
+        return f
+
+    monkeypatch.setattr(tempfile, "NamedTemporaryFile", _fake_ntf)
+
+    target = tmp_path / "x.json"
+    atomic_write_json(target, {"ok": True})
+    assert tmp_paths, "atomic_write_json must use NamedTemporaryFile"
+    assert Path(tmp_paths[0]).parent == target.parent

--- a/tests/test_retrieval_grid_search_smoke.py
+++ b/tests/test_retrieval_grid_search_smoke.py
@@ -1,0 +1,367 @@
+"""Smoke integration test for scripts/retrieval_grid_search (Issue #88).
+
+Patches ``build_pipeline`` with a ``MagicMock`` so the sweep loop runs
+without loading MLX / Qwen / sentence-transformers. Verifies:
+
+- ``run_eval_inproc`` feeds ``session_id = grid-<idx>-<qid>`` correctly
+- ``run_phase`` writes per-config results atomically
+- ``--resume`` skips already-completed configs
+- ``--dry-run`` prints the 24 Phase 1 configs and exits clean
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts._grid_search_core import (  # noqa: E402
+    ConfigParams,
+    aggregate_metrics,
+)
+from scripts.retrieval_grid_search import (  # noqa: E402
+    _params_key,
+    main,
+    run_eval_inproc,
+    run_phase,
+)
+
+
+# ---------------------------------------------------------------------------
+# Minimal fakes mirroring the bits of QueryResult the loop reads.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeLatency:
+    total_ms: float = 12_000.0
+
+
+@dataclass
+class _FakeMemory:
+    peak_mb: float = 4200.0
+
+
+@dataclass
+class _FakeQueryResult:
+    answer: str
+    no_citation: bool
+    wrong_citation_indices: list[int]
+    latency: _FakeLatency
+    memory: _FakeMemory
+
+
+def _mk_result(
+    *, no_citation: bool, wrong: list[int] | None = None, latency: float = 12_000.0
+) -> _FakeQueryResult:
+    return _FakeQueryResult(
+        answer="dummy",
+        no_citation=no_citation,
+        wrong_citation_indices=wrong or [],
+        latency=_FakeLatency(total_ms=latency),
+        memory=_FakeMemory(),
+    )
+
+
+def _load_base_cfg():  # type: ignore[no-untyped-def]
+    from baseline_reporag.config import load_config
+
+    return load_config(REPO_ROOT / "configs" / "baseline.yaml")
+
+
+# ---------------------------------------------------------------------------
+# run_eval_inproc
+# ---------------------------------------------------------------------------
+
+
+def test_smoke_run_eval_inproc_uses_session_id_scope() -> None:
+    mock_pipeline = MagicMock()
+    mock_pipeline.query.side_effect = [
+        _mk_result(no_citation=False, latency=10_000.0),
+        _mk_result(no_citation=True, latency=20_000.0),
+        _mk_result(no_citation=False, wrong=[2], latency=30_000.0),
+    ]
+    questions = [
+        {"id": "q1", "question": "Q1"},
+        {"id": "q2", "question": "Q2"},
+        {"id": "q3", "question": "Q3"},
+    ]
+    records = run_eval_inproc(
+        mock_pipeline, questions, config_idx=7, repo_id="fastapi_fastapi"
+    )
+    assert len(records) == 3
+    assert records[0]["eval_id"] == "q1"
+    assert records[1]["no_citation"] is True
+    assert records[2]["wrong_citation_indices"] == [2]
+
+    calls = mock_pipeline.query.call_args_list
+    assert calls[0].kwargs["session_id"] == "grid-7-q1"
+    assert calls[1].kwargs["session_id"] == "grid-7-q2"
+    assert calls[2].kwargs["session_id"] == "grid-7-q3"
+
+    metrics = aggregate_metrics(records, unanswerable_ids=set())
+    assert metrics["no_citation_rate"] == pytest.approx(1 / 3)
+
+
+# ---------------------------------------------------------------------------
+# run_phase writes JSON state atomically and supports resume.
+# ---------------------------------------------------------------------------
+
+
+def _params(
+    lex: int = 20, emb: int = 20, fused: int = 16, rerank: int = 12
+) -> ConfigParams:
+    return ConfigParams(
+        lexical_top_k=lex,
+        embedding_top_k=emb,
+        fused_top_k=fused,
+        rerank_top_k=rerank,
+        weights_lexical=0.45,
+        weights_embedding=0.45,
+    )
+
+
+def test_run_phase_writes_state_per_config(tmp_path: Path) -> None:
+    base_cfg = _load_base_cfg()
+    mock_pipeline = MagicMock()
+    mock_pipeline.cfg = base_cfg
+    mock_pipeline.query.side_effect = [
+        _mk_result(no_citation=False),
+        _mk_result(no_citation=True),
+    ]
+    questions: list[dict[str, Any]] = [
+        {"id": "q1", "question": "?"},
+        {"id": "q2", "question": "?"},
+    ]
+    state_path = tmp_path / "state.json"
+
+    grid = [_params(lex=20)]
+    results = run_phase(
+        base_cfg,
+        grid,
+        questions=questions,
+        unanswerable_ids=set(),
+        pipeline=mock_pipeline,
+        state_path=state_path,
+        resume=False,
+        phase_name="phase1",
+        repo_id="fastapi_fastapi",
+        stop_flag={"stop": False},
+    )
+
+    assert len(results) == 1
+    assert state_path.exists()
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert state["status"] == "phase1_complete"
+    assert len(state["configs"]) == 1
+    assert state["configs"][0]["params"]["lexical_top_k"] == 20
+
+
+def test_run_phase_resume_skips_completed_configs(tmp_path: Path) -> None:
+    base_cfg = _load_base_cfg()
+    mock_pipeline = MagicMock()
+    mock_pipeline.cfg = base_cfg
+    state_path = tmp_path / "state.json"
+
+    grid = [_params(lex=20), _params(lex=25)]
+
+    # Run once with both configs...
+    mock_pipeline.query.side_effect = [
+        _mk_result(no_citation=False)
+        for _ in range(2)  # q1 for config1
+    ] + [
+        _mk_result(no_citation=True)
+        for _ in range(2)  # q1 for config2
+    ]
+    questions = [{"id": "q1", "question": "?"}]
+    # But actually we only pass 1 question per config so side_effect length = 2.
+    mock_pipeline.query.side_effect = [
+        _mk_result(no_citation=False),
+        _mk_result(no_citation=True),
+    ]
+    run_phase(
+        base_cfg,
+        grid,
+        questions=questions,
+        unanswerable_ids=set(),
+        pipeline=mock_pipeline,
+        state_path=state_path,
+        resume=False,
+        phase_name="phase1",
+        repo_id="fastapi_fastapi",
+        stop_flag={"stop": False},
+    )
+
+    # Now re-run with --resume; both configs are already in state so pipeline
+    # must not be invoked again.
+    call_count_before = mock_pipeline.query.call_count
+    run_phase(
+        base_cfg,
+        grid,
+        questions=questions,
+        unanswerable_ids=set(),
+        pipeline=mock_pipeline,
+        state_path=state_path,
+        resume=True,
+        phase_name="phase1",
+        repo_id="fastapi_fastapi",
+        stop_flag={"stop": False},
+    )
+    assert mock_pipeline.query.call_count == call_count_before
+
+
+def test_run_phase_resume_completes_missing_configs(tmp_path: Path) -> None:
+    base_cfg = _load_base_cfg()
+    mock_pipeline = MagicMock()
+    mock_pipeline.cfg = base_cfg
+    state_path = tmp_path / "state.json"
+
+    # Pre-populate state with config A only.
+    grid = [_params(lex=20), _params(lex=25)]
+    key_done = _params_key(grid[0])
+    state = {
+        "phase": "phase1",
+        "configs": [
+            {
+                "config_idx": 0,
+                "params": json.loads(key_done),
+                "raw_no_citation_rate": 0.1,
+                "true_nc_rate": 0.1,
+                "wrong_citation_count": 0,
+                "latency_p50_ms": 12_000.0,
+                "latency_p95_ms": 12_000.0,
+                "n_questions": 1,
+                "n_no_citation": 0,
+                "duration_seconds": 1.0,
+                "started_at": "x",
+                "completed_at": "y",
+            }
+        ],
+        "status": "running",
+    }
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    mock_pipeline.query.side_effect = [_mk_result(no_citation=True)]
+    questions = [{"id": "q1", "question": "?"}]
+    results = run_phase(
+        base_cfg,
+        grid,
+        questions=questions,
+        unanswerable_ids=set(),
+        pipeline=mock_pipeline,
+        state_path=state_path,
+        resume=True,
+        phase_name="phase1",
+        repo_id="fastapi_fastapi",
+        stop_flag={"stop": False},
+    )
+    # Only config B ran (config A skipped on resume).
+    assert mock_pipeline.query.call_count == 1
+    assert len(results) == 1
+    assert results[0].params.lexical_top_k == 25
+
+
+# ---------------------------------------------------------------------------
+# main --dry-run prints the 24 Phase 1 configs and exits clean.
+# ---------------------------------------------------------------------------
+
+
+def test_main_dry_run_prints_grid(capsys: pytest.CaptureFixture[str]) -> None:
+    with patch("scripts.retrieval_grid_search.build_pipeline_for_sweep") as mock_build:
+        exit_code = main(
+            [
+                "--config",
+                "configs/baseline.yaml",
+                "--dry-run",
+            ]
+        )
+    # Dry-run must NOT build a pipeline.
+    mock_build.assert_not_called()
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "Phase 1 grid contains 24 configs" in out
+
+
+def test_main_rejects_absolute_config_path() -> None:
+    with pytest.raises(SystemExit):
+        main(["--config", "/etc/passwd", "--dry-run"])
+
+
+def test_main_rejects_parent_traversal() -> None:
+    with pytest.raises(SystemExit):
+        main(["--config", "../../../etc/passwd", "--dry-run"])
+
+
+# ---------------------------------------------------------------------------
+# Sanity: pipeline.cfg is mutated in-place between configs.
+# ---------------------------------------------------------------------------
+
+
+def test_run_phase_mutates_pipeline_cfg_each_iteration(tmp_path: Path) -> None:
+    base_cfg = _load_base_cfg()
+    mock_pipeline = MagicMock()
+    mock_pipeline.cfg = base_cfg
+
+    seen_lex: list[int] = []
+
+    def _capture_cfg(**_kwargs: Any) -> _FakeQueryResult:
+        seen_lex.append(mock_pipeline.cfg.retrieval.lexical_top_k)
+        return _mk_result(no_citation=False)
+
+    mock_pipeline.query.side_effect = _capture_cfg
+    questions = [{"id": "q1", "question": "?"}]
+    grid = [_params(lex=20), _params(lex=25)]
+
+    run_phase(
+        base_cfg,
+        grid,
+        questions=questions,
+        unanswerable_ids=set(),
+        pipeline=mock_pipeline,
+        state_path=tmp_path / "state.json",
+        resume=False,
+        phase_name="phase1",
+        repo_id="fastapi_fastapi",
+        stop_flag={"stop": False},
+    )
+    assert seen_lex == [20, 25]
+
+
+# ---------------------------------------------------------------------------
+# Sanity: stop_flag aborts before running the next config.
+# ---------------------------------------------------------------------------
+
+
+def test_run_phase_honors_stop_flag(tmp_path: Path) -> None:
+    from scripts.retrieval_grid_search import _InterruptedError
+
+    base_cfg = _load_base_cfg()
+    mock_pipeline = MagicMock()
+    mock_pipeline.cfg = base_cfg
+    stop_flag = {"stop": True}
+    grid = [_params(lex=20), _params(lex=25)]
+
+    with pytest.raises(_InterruptedError):
+        run_phase(
+            base_cfg,
+            grid,
+            questions=[{"id": "q1", "question": "?"}],
+            unanswerable_ids=set(),
+            pipeline=mock_pipeline,
+            state_path=tmp_path / "state.json",
+            resume=False,
+            phase_name="phase1",
+            repo_id="fastapi_fastapi",
+            stop_flag=stop_flag,
+        )
+    state = json.loads((tmp_path / "state.json").read_text(encoding="utf-8"))
+    assert state["status"] == "interrupted"


### PR DESCRIPTION
## Summary

Wave 6 全 revert 後の再着手 3 Issue の成果を main に同期。

### Included Commits

- `a72775e` feat(photon): dynamic aggregation mode (#101, Issue #92)
- `5c461a6` feat(retrieval): grid search harness (#102, Issue #88)
- `dfc228f` feat(photon): find_relevant_past_turn pipeline integration (#105, Issue #103)

### Eval Results（develop tip）

| metric | 値 | 判定 |
|--------|-----|------|
| Static NC | 17.5% | Wave 5 baseline 維持 |
| MT NC (weighted default) | 7-8% | Wave 5 range 維持 |
| Turn 5-6 NC | 0% | PHOTON working memory 健在 |

### 実測で確定した opt-in features

| feature | default | 推奨 |
|---------|---------|------|
| `aggregation: dynamic` / `hybrid` | weighted 維持 | 特定 workload のみ |
| `past_turn_pinning_enabled` | false 維持 | Turn 1 focused シナリオのみ |

## Test plan

- [x] develop での 2-run MT eval 通過（Wave 5 range 維持）
- [x] 全 Issue 個別 pre-merge eval-gate 通過
- [x] Issue #89 (bge-reranker) は data-driven で abort、main へ含めず

## 関連

- Issue #93 Wave 6 Epic（本 PR で実質完結）
- Issue #89, #103, #104 は empirical eval で closed
- reports/issue_92/103/104 レポート一式追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)