### PR TITLE
chore: sync develop → main (#82 Streamlit + MVP docs refresh)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ logs/
 # Reports (generated artifacts — committed manually after review)
 reports/benchmark_runs/
 
+# Issue #82: eval job outputs (streamlit app)
+reports/eval_runs/
+logs/eval/
+
 # macOS
 .DS_Store
 

--- a/app/components/__init__.py
+++ b/app/components/__init__.py
@@ -1,0 +1,11 @@
+"""Streamlit-free pure-Python components for ``app/photon_app.py``.
+
+Modules under this package MUST NOT import :mod:`streamlit`. Keeping them
+framework-free lets the unit tests in ``tests/test_photon_app_components.py``
+exercise the helpers without spinning up a Streamlit runtime.
+
+The invariant is pinned by ``T-C-streamlit-absent`` which imports every
+module in this package and asserts that ``"streamlit" not in sys.modules``
+afterwards (via a fresh subprocess so the test runner's own imports do
+not pollute the check).
+"""

--- a/app/components/drift_panel.py
+++ b/app/components/drift_panel.py
@@ -1,0 +1,105 @@
+"""Drift-metrics panel helpers for the Streamlit chat UI (Issue #82 Wave 3).
+
+This module is intentionally streamlit-free (see
+``app/components/__init__.py``) so the formatting logic can be unit-tested
+without a Streamlit runtime. The rendering side (``st.expander`` /
+``st.metric``) lives in ``app/photon_app.page_chat`` and consumes the
+plain ``dict`` returned by :func:`format_drift_panel`.
+
+Design reference: `workspace/design/issue-82-app-photon-features-design-policy.md`
+§6.2 drift_panel.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+DriftLevel = Literal["ok", "warn", "alert"]
+
+# Map UI indicator names to ``DriftMetrics.as_dict()`` keys.
+# Source: ``photon_mlx/session.py:113-170`` (Issue #63 three-level metrics).
+# The ordering below is load-bearing: the chat UI renders rows in this
+# sequence so operators always see the same top-to-bottom layout.
+DRIFT_METRIC_KEYS: dict[str, str] = {
+    "token_level": "latent_cosine_drift_token",
+    "mid_level": "latent_cosine_drift_mid",
+    "top_level": "latent_cosine_drift_top",
+    "topic_shift": "topic_shift_score",
+}
+
+
+def classify_drift(value: float | None, threshold: float | None) -> DriftLevel:
+    """Classify a drift value against its threshold.
+
+    Rules:
+        * ``value is None`` or ``threshold is None`` → ``"ok"``
+          (no data or no configured threshold).
+        * ``value > threshold``              → ``"alert"``.
+        * ``value > threshold * 0.8``        → ``"warn"``.
+        * otherwise                          → ``"ok"``.
+    """
+    if value is None or threshold is None:
+        return "ok"
+    if value > threshold:
+        return "alert"
+    if value > threshold * 0.8:
+        return "warn"
+    return "ok"
+
+
+def format_drift_panel(
+    drift_metrics: dict[str, Any] | None,
+    thresholds: dict[str, float | None],
+) -> dict[str, Any]:
+    """Render-ready summary of a single turn's drift metrics.
+
+    Args:
+        drift_metrics: Output of ``DriftMetrics.as_dict()`` (or ``None``
+            for baseline_rag / first-turn cases where no metric exists).
+        thresholds: Map keyed by the UI indicator name
+            (``token_level`` / ``mid_level`` / ``top_level`` /
+            ``topic_shift``) to either a numeric threshold or ``None``.
+
+    Returns:
+        A dict with keys ``available`` (bool), ``reason`` (str),
+        ``rows`` (list of per-indicator dicts) and ``safe_recgen_fired``
+        (bool). When ``drift_metrics`` is empty/None, ``available=False``
+        and ``reason="N/A (baseline_rag or first turn)"``; otherwise four
+        rows are returned in :data:`DRIFT_METRIC_KEYS` order.
+    """
+    if not drift_metrics:
+        return {
+            "available": False,
+            "reason": "N/A (baseline_rag or first turn)",
+            "rows": [],
+            "safe_recgen_fired": False,
+        }
+
+    badge_map: dict[DriftLevel, str] = {"alert": "⚠", "warn": "!", "ok": ""}
+    rows: list[dict[str, Any]] = []
+    for ui_name, dm_key in DRIFT_METRIC_KEYS.items():
+        raw = drift_metrics.get(dm_key)
+        if isinstance(raw, (int, float)) and not isinstance(raw, bool):
+            val_f: float | None = float(raw)
+            value_str = f"{val_f:.2f}"
+        else:
+            val_f = None
+            value_str = "—"
+        th = thresholds.get(ui_name)
+        level = classify_drift(val_f, th)
+        rows.append(
+            {
+                "name": ui_name,
+                "value": val_f,
+                "value_str": value_str,
+                "level": level,
+                "badge": badge_map[level],
+            }
+        )
+
+    return {
+        "available": True,
+        "reason": "",
+        "rows": rows,
+        "safe_recgen_fired": bool(drift_metrics.get("safe_recgen_fired", False)),
+    }

--- a/app/components/eval_panel.py
+++ b/app/components/eval_panel.py
@@ -1,0 +1,307 @@
+"""Eval-runner helpers for the Streamlit app (Issue #82 Wave 2 / 4).
+
+This module is intentionally streamlit-free (see ``app/components/__init__.py``)
+so the pure-Python path helpers can be unit-tested without a Streamlit
+runtime.  Wave 2 provided the path / id sanitization primitives; Wave 4
+adds the subprocess orchestration (``build_eval_job_cmd``,
+``start_eval_job``, ``parse_eval_progress``, ``tail_log_bytes``) and leaves
+the state-reconciliation (``_sync_eval_job``) in ``app/photon_app.py`` so
+that the sync loop can import lazily without adding a Streamlit dep here.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+from typing import Any
+
+# --- D4-002 constants ---------------------------------------------------
+# Only these two sub-trees of PROJECT_ROOT are allowed to receive eval
+# artifacts. Both ``make_eval_paths`` and (in Wave 4) ``sync_eval_job``
+# re-validate every path on entry so a tampered state file cannot trick
+# the app into reading/writing outside these directories.
+ALLOWED_EVAL_RESULTS_DIR_NAME = "reports/eval_runs"
+ALLOWED_EVAL_LOG_DIR_NAME = "logs/eval"
+
+# --- D4-003 constants ---------------------------------------------------
+# Resource caps for the async eval runner. Wave 4 wires these into the UI;
+# they are exported from Wave 2 so the wizard / state-load code can share
+# them without a cross-wave import cycle.
+MAX_CONCURRENT_EVAL = 1
+EVAL_WALL_CLOCK_TIMEOUT_SEC = 3600
+
+# --- D2-002 mapping -----------------------------------------------------
+# Supported ``eval_type`` → ``scripts.*`` module name. ``baseline_compare``
+# is a UI-level virtual type implemented as two sequential ``static`` runs,
+# so it is deliberately absent from this mapping.
+EVAL_SCRIPT_MAP = {
+    "static": "scripts.run_baseline_eval",
+    "multi_turn": "scripts.run_multi_turn_eval",
+}
+
+# Hex-only job ids (as produced by ``uuid.uuid4().hex``). We accept the
+# slightly broader ``[A-Za-z0-9]+`` allowlist so that explicit ids passed
+# in tests / debugging can also be validated without loosening to allow
+# path metacharacters.
+_SAFE_JOB_ID_RE = re.compile(r"^[A-Za-z0-9]+$")
+
+
+def sanitize_job_id(raw: str | None = None) -> str:
+    """Return a safe job id (hex characters only).
+
+    If ``raw`` is :data:`None`, a fresh ``uuid.uuid4().hex`` is returned
+    (32 lowercase hex chars). Otherwise ``raw`` is validated against
+    :data:`_SAFE_JOB_ID_RE` — any input containing path separators,
+    traversal (``..``), whitespace, or other metacharacters raises
+    :class:`ValueError`.
+    """
+
+    if raw is None:
+        return uuid.uuid4().hex
+    if not isinstance(raw, str) or not _SAFE_JOB_ID_RE.match(raw):
+        raise ValueError(f"Invalid job_id: {raw!r}. Only [A-Za-z0-9]+ is allowed.")
+    return raw
+
+
+def make_eval_paths(
+    job_id: str,
+    project_root: Path,
+) -> tuple[Path, Path, Path]:
+    """Return ``(result_json, log_file, marker_file)`` for an eval run.
+
+    All three paths are composed under ``project_root`` in the two allowed
+    sub-directories (see :data:`ALLOWED_EVAL_RESULTS_DIR_NAME` and
+    :data:`ALLOWED_EVAL_LOG_DIR_NAME`).  As defense-in-depth the computed
+    paths are then ``.resolve()``-checked to confirm they stay strictly
+    inside ``project_root`` — any attempt to escape (e.g. via a crafted
+    ``job_id``) raises :class:`ValueError`.
+
+    Args:
+        job_id: The sanitized job id. Callers SHOULD pass the return value
+            of :func:`sanitize_job_id`; as a safety net this function
+            re-validates via :func:`sanitize_job_id`.
+        project_root: The absolute repository root.
+
+    Returns:
+        A 3-tuple ``(result_json, log_file, marker_file)``:
+            * ``result_json``  → ``<root>/reports/eval_runs/<id>.json``
+            * ``log_file``     → ``<root>/logs/eval/<id>.log``
+            * ``marker_file``  → ``<root>/reports/eval_runs/<id>.done``
+
+    Raises:
+        ValueError: if ``job_id`` fails sanitization or any computed path
+            escapes ``project_root``.
+    """
+
+    # Defense-in-depth: re-validate the job_id even though callers are
+    # expected to have already done so.
+    job_id = sanitize_job_id(job_id)
+
+    root = Path(project_root).resolve()
+    results_dir = (root / ALLOWED_EVAL_RESULTS_DIR_NAME).resolve()
+    log_dir = (root / ALLOWED_EVAL_LOG_DIR_NAME).resolve()
+
+    result_json = (results_dir / f"{job_id}.json").resolve()
+    log_file = (log_dir / f"{job_id}.log").resolve()
+    marker_file = (results_dir / f"{job_id}.done").resolve()
+
+    for label, path, parent in (
+        ("result_json", result_json, results_dir),
+        ("log_file", log_file, log_dir),
+        ("marker_file", marker_file, results_dir),
+    ):
+        if not path.is_relative_to(parent):
+            raise ValueError(
+                f"eval {label} escaped allowed dir: {path} not under {parent}"
+            )
+        if not path.is_relative_to(root):
+            raise ValueError(
+                f"eval {label} escaped project_root: {path} not under {root}"
+            )
+
+    return result_json, log_file, marker_file
+
+
+# --- W4-T1: subprocess orchestration ------------------------------------
+
+# Reuse ``_SAFE_ID_RE``-style allowlist for project_name / repo_id values
+# that flow into argv. This mirrors ``photon_app._safe_id`` but stays
+# streamlit-free (and local, to avoid an app→components circular import).
+_SAFE_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def build_eval_job_cmd(
+    eval_type: str,
+    project_name: str,
+    repo_id: str,
+    config_path: str,
+    output_json: Path,
+    marker_file: Path,
+    python_exec: str | None = None,
+) -> list[str]:
+    """Build an argv list suitable for ``subprocess.Popen(..., shell=False)``.
+
+    Args:
+        eval_type: ``"static"`` or ``"multi_turn"`` (keys of
+            :data:`EVAL_SCRIPT_MAP`).  ``baseline_compare`` is a UI-level
+            virtual type and is not accepted here.
+        project_name: For provenance only — validated with the same
+            ``[A-Za-z0-9_-]+`` allowlist so the value is safe to log.
+        repo_id: Passed as ``--repo-id``.  Same allowlist as
+            ``project_name``.
+        config_path: Passed as ``--config``.  Not added to the allowlist
+            because it is an internal path composed by the UI.
+        output_json: Passed as ``--output``.  Should be a path produced by
+            :func:`make_eval_paths`.
+        marker_file: Passed as ``--marker-file``.  The subprocess writes
+            a sentinel file here on successful completion; the main app's
+            ``_sync_eval_job`` polls for its existence to detect success.
+        python_exec: Path to the Python executable; defaults to
+            ``sys.executable``.
+
+    Returns:
+        An argv list starting with ``python_exec, "-u", "-m",
+        "<script_module>"`` followed by CLI flags.
+
+    Raises:
+        ValueError: for unknown ``eval_type`` / malformed ``project_name``
+            or ``repo_id``.
+    """
+
+    if eval_type not in EVAL_SCRIPT_MAP:
+        raise ValueError(
+            f"Unknown eval_type: {eval_type!r}. "
+            f"Expected one of {sorted(EVAL_SCRIPT_MAP)}."
+        )
+    if not isinstance(project_name, str) or not _SAFE_ID_RE.match(project_name):
+        raise ValueError(
+            f"Invalid project_name: {project_name!r}. Only [A-Za-z0-9_-]+ is allowed."
+        )
+    if not isinstance(repo_id, str) or not _SAFE_ID_RE.match(repo_id):
+        raise ValueError(
+            f"Invalid repo_id: {repo_id!r}. Only [A-Za-z0-9_-]+ is allowed."
+        )
+
+    script_mod = EVAL_SCRIPT_MAP[eval_type]
+    exe = python_exec or sys.executable
+    return [
+        exe,
+        "-u",
+        "-m",
+        script_mod,
+        "--config",
+        str(config_path),
+        "--repo-id",
+        repo_id,
+        "--output",
+        str(output_json),
+        "--marker-file",
+        str(marker_file),
+    ]
+
+
+def start_eval_job(
+    cmd: list[str],
+    log_file: Path,
+    env_overrides: dict[str, str] | None = None,
+) -> subprocess.Popen:
+    """Spawn an eval subprocess with ``shell=False``.
+
+    ``stdout`` and ``stderr`` are redirected (merged) into ``log_file``;
+    the file is opened in append mode so a caller can safely re-use the
+    same log between phases / restarts.  ``TRANSFORMERS_VERBOSITY=error``
+    and ``TOKENIZERS_PARALLELISM=false`` are injected into the child env
+    unless the caller supplies explicit overrides.
+
+    .. warning::
+
+       This function MUST NOT use ``shell=True``.  The
+       ``TestPageIndexNoShellTrue`` guardrail in
+       ``tests/test_photon_app_helpers.py`` scans this module with an
+       AST walker and will fail CI if a regression introduces it.
+    """
+
+    log_file.parent.mkdir(parents=True, exist_ok=True)
+    env = os.environ.copy()
+    env.setdefault("TRANSFORMERS_VERBOSITY", "error")
+    env.setdefault("TOKENIZERS_PARALLELISM", "false")
+    if env_overrides:
+        env.update(env_overrides)
+    # Append mode so a re-spawn (e.g. on UI restart) does not truncate
+    # the previous phase's output.  The file handle stays open for the
+    # lifetime of the child process; the OS closes it on exit.
+    log_fh = open(log_file, "a", encoding="utf-8")  # noqa: SIM115
+    proc = subprocess.Popen(
+        cmd,
+        shell=False,
+        stdout=log_fh,
+        stderr=subprocess.STDOUT,
+        env=env,
+    )
+    return proc
+
+
+def parse_eval_progress(log_file: Path) -> dict[str, Any]:
+    """Tail ``log_file`` for ``PROGRESS …`` lines and return the latest.
+
+    The eval scripts emit machine-readable progress lines of the form::
+
+        PROGRESS done=15 total=120 p50_ms=19300 nc=0.183
+
+    The most recent such line wins.  Non-PROGRESS log content is ignored.
+
+    Returns:
+        ``{"done_q", "total_q", "p50_latency_ms", "nc_rate"}`` on success,
+        or an empty dict when the file is missing or contains no PROGRESS
+        lines.
+    """
+
+    try:
+        if not log_file.exists():
+            return {}
+        text = log_file.read_text(encoding="utf-8", errors="replace")
+        progress_lines = [ln for ln in text.splitlines() if ln.startswith("PROGRESS ")]
+        if not progress_lines:
+            return {}
+        last = progress_lines[-1]
+        kv: dict[str, str] = {}
+        for part in last[len("PROGRESS ") :].split():
+            if "=" in part:
+                key, value = part.split("=", 1)
+                kv[key] = value
+        return {
+            "done_q": int(kv.get("done", 0)),
+            "total_q": int(kv.get("total", 0)),
+            "p50_latency_ms": float(kv.get("p50_ms", 0.0)),
+            "nc_rate": float(kv.get("nc", 0.0)),
+        }
+    except (OSError, ValueError):
+        return {}
+
+
+def tail_log_bytes(log_file: Path, max_bytes: int = 2048) -> str:
+    """Return the trailing ``max_bytes`` of ``log_file`` as decoded text.
+
+    Intended for populating ``EvalJob.error_message`` when a subprocess
+    dies without writing the marker file — we want the last few KB of
+    stderr/stdout so the UI can surface the crash reason without having
+    to read the full log.
+
+    Empty string is returned when the file is missing or unreadable.
+    """
+
+    try:
+        if not log_file.exists():
+            return ""
+        size = log_file.stat().st_size
+        with open(log_file, "rb") as f:
+            if size > max_bytes:
+                f.seek(size - max_bytes)
+            data = f.read()
+        return data.decode("utf-8", errors="replace")
+    except OSError:
+        return ""

--- a/app/components/turn_history_panel.py
+++ b/app/components/turn_history_panel.py
@@ -1,0 +1,105 @@
+"""Turn-history panel helpers for the Streamlit chat UI (Issue #82 Wave 3).
+
+This module is intentionally streamlit-free. The rendering side lives in
+``app/photon_app.page_chat`` and consumes the dict returned by
+:func:`format_turn_history_panel`.
+
+Design reference: `workspace/design/issue-82-app-photon-features-design-policy.md`
+§6.3 turn_history_panel.
+
+The panel joins two state sources by ``turn_id`` (int):
+
+* ``photon_turn_history`` — entries of ``PhotonSessionState.turn_history``
+  (``photon_mlx/session.py``). Each entry has ``turn_id``, ``question_text``
+  and ``timestamp`` attributes.
+* ``session_manager_turns`` — ``SessionState.turns`` from
+  ``baseline_reporag/memory/session.py``. Each entry has ``turn_id`` and
+  ``cited_chunk_ids``.
+
+Missing matches on the SessionManager side resolve to an empty cited list;
+this keeps the UI resilient when the two stores briefly drift across
+fail-closed paths (see design §3-1, DR2-004 in photon_pipeline.py).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class TurnRow:
+    """One rendered row: everything needed for a single table entry."""
+
+    turn_id: int
+    question_text: str
+    timestamp: str
+    cited_chunk_ids: list[str]
+
+
+def format_turn_history_panel(
+    photon_turn_history: list[Any] | None,
+    session_manager_turns: list[Any] | None,
+    working_memory_enabled: bool,
+    max_turns: int,
+) -> dict[str, Any]:
+    """Build a render-ready payload for the turn-history panel.
+
+    Args:
+        photon_turn_history: Entries from
+            :attr:`PhotonSessionState.turn_history` (ordered oldest→newest).
+            ``None`` indicates a baseline_rag project (no PHOTON session).
+        session_manager_turns: Entries from :attr:`SessionState.turns` used
+            to look up ``cited_chunk_ids`` by ``turn_id``.
+        working_memory_enabled: ``True`` iff
+            ``cfg.session_memory.working_memory.enabled`` is set.
+        max_turns: Maximum number of entries to retain in ``rows`` (keeps
+            the last N after slicing).
+
+    Returns:
+        ``{"available": bool, "reason": str, "rows": list[TurnRow]}``.
+        ``available=False`` with a ``reason`` string is returned for the
+        three N/A paths (working_memory disabled, baseline_rag, or
+        photon_turn_history is literally ``None``).
+    """
+    if not working_memory_enabled:
+        return {
+            "available": False,
+            "reason": "N/A (working_memory disabled)",
+            "rows": [],
+        }
+    if photon_turn_history is None:
+        return {
+            "available": False,
+            "reason": "N/A (baseline_rag)",
+            "rows": [],
+        }
+    if not photon_turn_history:
+        return {"available": True, "reason": "", "rows": []}
+
+    cited_by_tid: dict[int, list[str]] = {}
+    if session_manager_turns:
+        for t in session_manager_turns:
+            try:
+                tid = int(getattr(t, "turn_id", -1))
+            except (TypeError, ValueError):
+                continue
+            cited = list(getattr(t, "cited_chunk_ids", []) or [])
+            cited_by_tid[tid] = cited
+
+    recent = list(photon_turn_history)[-max_turns:]
+    rows: list[TurnRow] = []
+    for ph in recent:
+        try:
+            tid = int(getattr(ph, "turn_id", -1))
+        except (TypeError, ValueError):
+            tid = -1
+        rows.append(
+            TurnRow(
+                turn_id=tid,
+                question_text=str(getattr(ph, "question_text", "")),
+                timestamp=str(getattr(ph, "timestamp", "")),
+                cited_chunk_ids=cited_by_tid.get(tid, []),
+            )
+        )
+    return {"available": True, "reason": "", "rows": rows}

--- a/app/components/wizard.py
+++ b/app/components/wizard.py
@@ -1,0 +1,287 @@
+"""Project-wizard helpers for the Streamlit app (Issue #82 Wave 2 / 5).
+
+Never uses :func:`yaml.load`; only :func:`yaml.safe_load` is permitted
+(D4-005). This module is streamlit-free — the wizard *UI* lives in
+``app/photon_app.py`` and only depends on the pure helpers exported here.
+
+Wave 2 provides the YAML safety allowlist (:func:`_assert_safe_yaml`).
+Wave 5 adds :func:`apply_best_practice` (5-key merge) and
+:func:`generate_yaml_from_wizard` (toggle → YAML).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml  # PyYAML — safe_load-only, see module docstring
+
+# Only these scalar / container types are permitted in a loaded YAML tree
+# (D4-005 reflected). Anything else — including custom Python objects
+# produced by ``!!python/object`` tags — causes ``_assert_safe_yaml`` to
+# raise :class:`ValueError`.
+ALLOWED_YAML_TYPES: tuple[type, ...] = (
+    str,
+    int,
+    float,
+    bool,
+    type(None),
+    list,
+    dict,
+)
+
+
+# Issue #82 Wave 5 (W5-T1): the 5 best-practice keys we merge into a
+# profile YAML when the user opts in to ``[Apply best-practice]``.  The
+# key is a tuple path into the nested YAML dict; the value is the target
+# state expected by the current operational guidance (design §7.3).
+BEST_PRACTICE_KEYS: dict[tuple[str, ...], Any] = {
+    ("safe_recgen", "enabled"): True,
+    ("generation", "evidence_pruning_enabled"): True,
+    ("session_memory", "working_memory", "enabled"): True,
+    ("inference", "photon_generation_enabled"): False,
+    ("retrieval", "two_pass_search", "enabled"): False,
+}
+
+
+# Allowlist for ``inference.generation_fallback_policy`` — the wizard
+# rejects any other value early so the saved YAML can never reference an
+# unsupported policy string.
+ALLOWED_FALLBACK_POLICIES: tuple[str, ...] = ("qwen", "abort")
+
+
+# Profiles where a pre-existing non-best-practice value is *intentional*
+# (e.g. ``photon_tiny_recgen`` ships RecGen ON for experiments, and
+# ``photon_tiny`` / ``photon_600m_paper`` omit working_memory on purpose).
+# For these profiles we still apply the best-practice override when the
+# user asks, but we surface a warning so the operator notices the drift.
+_INTENTIONAL_CONFLICT_PROFILES: frozenset[str] = frozenset(
+    {"photon_tiny_recgen", "photon_tiny", "photon_600m_paper"}
+)
+
+
+def _assert_safe_yaml(obj: Any, path: str = "<root>") -> None:
+    """Recursively verify ``obj`` contains only :data:`ALLOWED_YAML_TYPES`.
+
+    ``yaml.safe_load`` already rejects most dangerous tags (e.g.
+    ``!!python/object/apply:os.system``) with a
+    :class:`yaml.constructor.ConstructorError`, so in practice this
+    function is the second line of defense for values that *do* load
+    cleanly but whose types still fall outside our allowlist (e.g. a
+    :class:`tuple` sneaking in via some custom loader variant).
+
+    Args:
+        obj: The parsed YAML tree (or any nested value).
+        path: Dotted path used for error messages, e.g. ``"<root>.foo[2]"``.
+
+    Raises:
+        ValueError: on first encountered non-allowlisted type, mentioning
+            the offending type and its dotted path.
+    """
+
+    # ``bool`` is a subclass of ``int`` in Python; isinstance handles it
+    # correctly because ``bool`` is listed explicitly.
+    if not isinstance(obj, ALLOWED_YAML_TYPES):
+        raise ValueError(f"Unsafe YAML type {type(obj).__name__!r} at {path}")
+
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            # Keys must also be primitives (never a custom object).
+            if not isinstance(k, (str, int, float, bool, type(None))):
+                raise ValueError(f"Unsafe YAML key type {type(k).__name__!r} at {path}")
+            _assert_safe_yaml(v, f"{path}.{k}")
+    elif isinstance(obj, list):
+        for i, v in enumerate(obj):
+            _assert_safe_yaml(v, f"{path}[{i}]")
+
+
+def _deep_get(d: dict, path: tuple[str, ...]) -> Any:
+    """Return ``d[path[0]][path[1]]…`` or raise :class:`KeyError`.
+
+    Raises:
+        KeyError: if any intermediate key is missing or a non-mapping
+            node is encountered on the traversal.
+    """
+
+    cur: Any = d
+    for k in path:
+        if not isinstance(cur, dict) or k not in cur:
+            raise KeyError(path)
+        cur = cur[k]
+    return cur
+
+
+def _deep_set(d: dict, path: tuple[str, ...], value: Any) -> None:
+    """Create nested dicts as needed, then set ``d[path[0]]…[path[-1]] = value``.
+
+    Any non-dict node encountered along ``path[:-1]`` is overwritten with
+    an empty dict — the caller is expected to have validated ``d`` via
+    :func:`_assert_safe_yaml` before invoking this helper.
+    """
+
+    cur = d
+    for k in path[:-1]:
+        if k not in cur or not isinstance(cur[k], dict):
+            cur[k] = {}
+        cur = cur[k]
+    cur[path[-1]] = value
+
+
+def apply_best_practice(
+    yaml_text: str,
+    profile: str,
+    overrides: dict[tuple[str, ...], Any] | None = None,
+) -> tuple[str, list[str]]:
+    """Merge best-practice keys into a YAML document (Issue #82 Wave 5).
+
+    Loads ``yaml_text`` with :func:`yaml.safe_load` only, validates it
+    with :func:`_assert_safe_yaml`, then for each ``(path, value)`` in
+    ``overrides``:
+
+    - if ``path`` is missing entirely → create the nested keys and add a
+      warning ``"Added new path … to profile …"``;
+    - if the existing value differs from the target AND ``profile`` is one
+      of :data:`_INTENTIONAL_CONFLICT_PROFILES` → add a warning noting the
+      profile's intentional setting; in all differ cases the override is
+      still applied;
+    - if the existing value equals the target → no-op, no warning.
+
+    Then dump back with ``yaml.safe_dump(sort_keys=False, allow_unicode=True)``
+    so the resulting text keeps key ordering stable across round-trips.
+
+    Args:
+        yaml_text: Source YAML document (typically a profile file).
+        profile: Profile name (e.g. ``"photon_small"``) used in warnings
+            and to decide whether conflicts are intentional.
+        overrides: Optional custom override mapping; defaults to
+            :data:`BEST_PRACTICE_KEYS`.
+
+    Returns:
+        Tuple of ``(new_yaml_text, warnings)``.
+
+    Raises:
+        ValueError: if ``yaml_text`` contains non-allowlisted YAML types
+            (see :func:`_assert_safe_yaml`), or the top-level node is not
+            a mapping.
+    """
+
+    if overrides is None:
+        overrides = BEST_PRACTICE_KEYS
+    doc = yaml.safe_load(yaml_text) or {}
+    if not isinstance(doc, dict):
+        raise ValueError("Top-level YAML must be a mapping")
+    _assert_safe_yaml(doc)
+
+    warnings: list[str] = []
+    for path, target in overrides.items():
+        try:
+            current = _deep_get(doc, path)
+        except KeyError:
+            _deep_set(doc, path, target)
+            warnings.append(
+                f"Added new path {'.'.join(path)} = {target} to profile {profile}"
+            )
+            continue
+
+        if current == target:
+            continue
+
+        if profile in _INTENTIONAL_CONFLICT_PROFILES:
+            warnings.append(
+                f"Overriding {'.'.join(path)}: {current} -> {target} "
+                f"(profile {profile} has intentional setting)"
+            )
+        _deep_set(doc, path, target)
+
+    new_text = yaml.safe_dump(doc, sort_keys=False, allow_unicode=True)
+    return new_text, warnings
+
+
+# Wizard-form toggle key → nested YAML dotted path.  Centralised so the
+# UI layer can iterate ``user_toggles`` without duplicating the mapping.
+_WIZARD_TOGGLE_MAPPING: dict[str, tuple[str, ...]] = {
+    "recgen_enabled": ("inference", "photon_generation_enabled"),
+    "fallback_policy": ("inference", "generation_fallback_policy"),
+    "two_pass_search_enabled": ("retrieval", "two_pass_search", "enabled"),
+    "two_pass_pass1_top_k": ("retrieval", "two_pass_search", "pass1_top_k"),
+    "two_pass_pass2_top_k": ("retrieval", "two_pass_search", "pass2_top_k"),
+    "working_memory_enabled": ("session_memory", "working_memory", "enabled"),
+    "working_memory_max_turns": ("session_memory", "working_memory", "max_turns"),
+    "working_memory_aggregation": ("session_memory", "working_memory", "aggregation"),
+    "working_memory_storage_mode": ("session_memory", "working_memory", "storage_mode"),
+    "past_turn_pinning_enabled": (
+        "session_memory",
+        "working_memory",
+        "past_turn_pinning_enabled",
+    ),
+}
+
+
+def generate_yaml_from_wizard(
+    base_profile: str,
+    user_toggles: dict[str, Any],
+    base_yaml_text: str | None = None,
+) -> str:
+    """Generate a YAML document from a base profile + wizard form toggles.
+
+    ``user_toggles`` supports the following keys (extra keys are
+    silently ignored so the UI can feed in opaque form-state dicts):
+
+    - ``recgen_enabled`` (bool) → ``inference.photon_generation_enabled``
+    - ``fallback_policy`` (``"qwen"`` | ``"abort"``) →
+      ``inference.generation_fallback_policy``
+    - ``two_pass_search_enabled`` (bool) →
+      ``retrieval.two_pass_search.enabled``
+    - ``two_pass_pass1_top_k`` (int) → ``retrieval.two_pass_search.pass1_top_k``
+    - ``two_pass_pass2_top_k`` (int) → ``retrieval.two_pass_search.pass2_top_k``
+    - ``working_memory_enabled`` (bool) →
+      ``session_memory.working_memory.enabled``
+    - ``working_memory_max_turns`` (int) →
+      ``session_memory.working_memory.max_turns``
+    - ``working_memory_aggregation``
+      (``"weighted"`` | ``"attention"`` | ``"last"``) →
+      ``session_memory.working_memory.aggregation``
+    - ``working_memory_storage_mode`` (``"full"`` | ``"top_level_only"``) →
+      ``session_memory.working_memory.storage_mode``
+    - ``past_turn_pinning_enabled`` (bool) →
+      ``session_memory.working_memory.past_turn_pinning_enabled``
+
+    Args:
+        base_profile: Name of the profile to start from (e.g.
+            ``"photon_small"``).  When ``base_yaml_text`` is ``None``,
+            the file ``configs/<base_profile>.yaml`` is read from disk.
+        user_toggles: Mapping of wizard form values (see above).
+        base_yaml_text: Optional pre-loaded profile YAML (used by tests
+            to avoid filesystem dependencies).
+
+    Returns:
+        YAML text with the toggles applied.
+
+    Raises:
+        ValueError: on an invalid ``fallback_policy`` value or an unsafe
+            base YAML document.
+    """
+
+    fp = user_toggles.get("fallback_policy")
+    if fp is not None and fp not in ALLOWED_FALLBACK_POLICIES:
+        raise ValueError(
+            f"Invalid fallback_policy: {fp!r} "
+            f"(must be one of {ALLOWED_FALLBACK_POLICIES})"
+        )
+
+    if base_yaml_text is None:
+        cfg_path = (
+            Path(__file__).resolve().parents[2] / "configs" / f"{base_profile}.yaml"
+        )
+        base_yaml_text = cfg_path.read_text(encoding="utf-8")
+
+    doc = yaml.safe_load(base_yaml_text) or {}
+    if not isinstance(doc, dict):
+        raise ValueError("Top-level YAML must be a mapping")
+    _assert_safe_yaml(doc)
+
+    for toggle_key, path in _WIZARD_TOGGLE_MAPPING.items():
+        if toggle_key in user_toggles:
+            _deep_set(doc, path, user_toggles[toggle_key])
+
+    return yaml.safe_dump(doc, sort_keys=False, allow_unicode=True)

--- a/app/photon_app.py
+++ b/app/photon_app.py
@@ -22,6 +22,43 @@ from typing import Any
 import streamlit as st
 
 PROJECT_ROOT = Path(__file__).parent.parent
+# Ensure baseline_reporag is importable when this module is launched via
+# ``streamlit run app/photon_app.py`` (cwd may be the project root, but the
+# app directory itself is not on sys.path by default).
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from baseline_reporag.config import load_config  # noqa: E402
+from baseline_reporag.pipeline_factory import build_pipeline  # noqa: E402
+
+
+# Issue #82 Wave 3: drift + turn-history panels (streamlit-free helpers).
+# The ``app`` directory has no ``__init__.py`` (see design note on the
+# MySwiftAgent ``app/`` namespace collision in
+# ``tests/test_photon_app_components.py``) so we load each component by
+# absolute file path. Mirrors the loader pattern used by the unit tests.
+def _load_component(mod_name: str):
+    import importlib.util
+
+    full_name = f"_photon_app_component_{mod_name}"
+    if full_name in sys.modules:
+        return sys.modules[full_name]
+    path = PROJECT_ROOT / "app" / "components" / f"{mod_name}.py"
+    spec = importlib.util.spec_from_file_location(full_name, path)
+    assert spec and spec.loader, f"cannot spec component {mod_name} at {path}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[full_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_drift_panel = _load_component("drift_panel")
+_turn_history_panel = _load_component("turn_history_panel")
+# Issue #82 Wave 4: eval_panel orchestration helpers (streamlit-free).
+_eval_panel = _load_component("eval_panel")
+# Issue #82 Wave 5: project wizard helpers (YAML safe_load + best-practice merge).
+_wizard = _load_component("wizard")
+
 STATE_FILE = PROJECT_ROOT / ".cache" / "photon_app_state.json"
 
 SYNC_INTERVAL_SECONDS = 30
@@ -180,6 +217,32 @@ class IndexJob:
 
 
 @dataclass
+class EvalJob:
+    """Evaluation job record persisted in AppState (Issue #82 Wave 1)."""
+
+    job_id: str = ""
+    project_name: str = ""
+    eval_type: str = ""  # "static" | "multi_turn" | "baseline_compare"
+    status: str = "pending"  # "pending" | "running" | "succeeded" | "failed"
+    started_at: str = ""
+    started_at_epoch: float = 0.0
+    finished_at: str = ""
+    pid: int | None = None
+    log_file: str = ""
+    result_json: str = ""
+    marker_file: str = ""
+    done_q: int = 0
+    total_q: int = 0
+    p50_latency_ms: float = 0.0
+    nc_rate: float = 0.0
+    error_message: str = ""
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.status in ("succeeded", "failed")
+
+
+@dataclass
 class Project:
     name: str
     repo_id: str
@@ -197,6 +260,7 @@ class AppState:
     index_jobs: dict[str, IndexJob] = field(default_factory=dict)
     projects: dict[str, Project] = field(default_factory=dict)
     chat_histories: dict[str, list[dict]] = field(default_factory=dict)
+    eval_jobs: dict[str, EvalJob] = field(default_factory=dict)
 
 
 # ================================================================
@@ -218,6 +282,54 @@ def _load_state() -> AppState:
             for k, v in data.get("projects", {}).items():
                 state.projects[k] = Project(**_filter_known_fields(Project, v))
             state.chat_histories = data.get("chat_histories", {})
+            for k, v in data.get("eval_jobs", {}).items():
+                state.eval_jobs[k] = EvalJob(**_filter_known_fields(EvalJob, v))
+            # Issue #82 Wave 2 (W2-T4, D4-004): validate integrity of every
+            # eval_job entry loaded from disk. A tampered state file could
+            # otherwise feed arbitrary pid types, paths outside PROJECT_ROOT
+            # or unknown status values into the sync/UI layer.
+            _allowed_eval_status = {"pending", "running", "succeeded", "failed"}
+            _project_root_abs = PROJECT_ROOT.resolve()
+            for _k, _job in list(state.eval_jobs.items()):
+                # Normalize pid: must be ``int`` or ``None``. Anything else
+                # (e.g. a string via JSON tampering) is coerced to ``None``
+                # so ``os.kill(pid, 0)`` can never see garbage.
+                if not (_job.pid is None or isinstance(_job.pid, int)):
+                    _logger.warning(
+                        "eval_job %s has non-int pid %r; resetting to None",
+                        _k,
+                        _job.pid,
+                    )
+                    _job.pid = None
+                # Validate path-like fields: they must resolve inside
+                # PROJECT_ROOT when non-empty. Empty strings are allowed
+                # (they indicate "not yet assigned").
+                for _attr in ("log_file", "result_json", "marker_file"):
+                    _value = getattr(_job, _attr, "")
+                    if not _value:
+                        continue
+                    try:
+                        _p = Path(_value).resolve()
+                        _p.relative_to(_project_root_abs)
+                    except (ValueError, OSError):
+                        _job.status = "failed"
+                        _job.error_message = "state tampering detected"
+                        _logger.warning(
+                            "eval_job %s has tampered %s: %r",
+                            _k,
+                            _attr,
+                            _value,
+                        )
+                        break
+                # Constrain status to the documented set; anything unknown
+                # is funnelled into ``failed`` so the UI stops polling it.
+                if _job.status not in _allowed_eval_status:
+                    _logger.warning(
+                        "eval_job %s has unknown status %r; forcing to failed",
+                        _k,
+                        _job.status,
+                    )
+                    _job.status = "failed"
             return state
         except Exception as exc:
             _logger.warning("Failed to load app state: %s", exc)
@@ -230,6 +342,7 @@ def _save_state(state: AppState) -> None:
         "index_jobs": {k: asdict(v) for k, v in state.index_jobs.items()},
         "projects": {k: asdict(v) for k, v in state.projects.items()},
         "chat_histories": state.chat_histories,
+        "eval_jobs": {k: asdict(v) for k, v in state.eval_jobs.items()},
     }
     _atomic_write_text(STATE_FILE, json.dumps(data, ensure_ascii=False, indent=2))
 
@@ -397,8 +510,92 @@ def _sync_index_job(job: IndexJob) -> bool:
     return changed
 
 
+def _sync_eval_job(job: EvalJob, now_epoch: float | None = None) -> bool:
+    """Reconcile an eval job against live process state / marker / logs.
+
+    Issue #82 Wave 4 (W4-T2, D3-004 / D4-003):
+
+    * ``marker_file`` exists → ``status="succeeded"``; progress fields are
+      pulled from ``result_json`` (falling back to the current values if
+      the JSON is missing or malformed).
+    * ``started_at_epoch`` is older than ``EVAL_WALL_CLOCK_TIMEOUT_SEC`` →
+      ``status="failed"``, ``error_message="wall-clock timeout"``.
+    * PID not alive AND no marker → ``status="failed"``, ``error_message``
+      is the trailing 2KB of the log so the UI can surface crash context.
+    * PID alive AND running: refresh progress from the log's latest
+      ``PROGRESS`` line; only mutate if ``done_q`` advanced.
+
+    Terminal jobs (``succeeded``/``failed``) are skipped — this keeps
+    ``_sync_all_jobs`` cheap when the state file already reflects the
+    final outcome.
+
+    Returns ``True`` iff any field on ``job`` was mutated.
+    """
+
+    if job.is_terminal:
+        return False
+
+    now = now_epoch if now_epoch is not None else time.time()
+
+    marker_path = Path(job.marker_file) if job.marker_file else None
+    if marker_path is not None and marker_path.exists():
+        # D3-004: marker_file is the authoritative success signal.
+        result: dict[str, Any] = {}
+        if job.result_json:
+            try:
+                result = json.loads(Path(job.result_json).read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                result = {}
+        job.done_q = int(result.get("done_q", job.done_q))
+        job.total_q = int(result.get("total_q", job.total_q))
+        job.p50_latency_ms = float(result.get("p50_latency_ms", job.p50_latency_ms))
+        job.nc_rate = float(result.get("nc_rate", job.nc_rate))
+        job.status = "succeeded"
+        job.finished_at = datetime.now().isoformat(timespec="seconds")
+        return True
+
+    started = job.started_at_epoch or now
+    elapsed = now - started
+    if elapsed > _eval_panel.EVAL_WALL_CLOCK_TIMEOUT_SEC:
+        job.status = "failed"
+        job.error_message = "wall-clock timeout"
+        job.finished_at = datetime.now().isoformat(timespec="seconds")
+        return True
+
+    pid_alive = _is_process_running(job.pid)
+    if pid_alive:
+        changed = False
+        if job.log_file:
+            progress = _eval_panel.parse_eval_progress(Path(job.log_file))
+            if progress:
+                new_done = int(progress.get("done_q", job.done_q))
+                new_total = int(progress.get("total_q", job.total_q))
+                new_p50 = float(progress.get("p50_latency_ms", job.p50_latency_ms))
+                new_nc = float(progress.get("nc_rate", job.nc_rate))
+                if (
+                    new_done != job.done_q
+                    or new_total != job.total_q
+                    or new_p50 != job.p50_latency_ms
+                    or new_nc != job.nc_rate
+                ):
+                    job.done_q = new_done
+                    job.total_q = new_total
+                    job.p50_latency_ms = new_p50
+                    job.nc_rate = new_nc
+                    changed = True
+        return changed
+
+    # PID not alive AND no marker file → the child exited without
+    # signalling success. Mark as failed and surface the log tail.
+    job.status = "failed"
+    tail = _eval_panel.tail_log_bytes(Path(job.log_file), 2048) if job.log_file else ""
+    job.error_message = tail or "process died without marker"
+    job.finished_at = datetime.now().isoformat(timespec="seconds")
+    return True
+
+
 def _sync_all_jobs(state: AppState) -> bool:
-    """Reconcile every training/index job in `state`. Returns True if mutated."""
+    """Reconcile every training/index/eval job in `state`. Returns True if mutated."""
     changed = False
     progress = _read_training_progress(str(PROJECT_ROOT / "logs" / "train_log.jsonl"))
     for job in state.training_jobs.values():
@@ -406,6 +603,10 @@ def _sync_all_jobs(state: AppState) -> bool:
             changed = True
     for job in state.index_jobs.values():
         if _sync_index_job(job):
+            changed = True
+    # Issue #82 Wave 4 (W4-T2): daemon thread also reconciles eval jobs.
+    for eval_job in state.eval_jobs.values():
+        if _sync_eval_job(eval_job):
             changed = True
     return changed
 
@@ -653,6 +854,149 @@ def page_training():
             st.text(f"Config: {job.config_path}")
             st.text(f"リポジトリ: {job.repo_dir}")
 
+            # Issue #82 Wave 4 (W4-T3): eval runner section per training job.
+            _render_eval_runner_section(state, job_id, job)
+
+
+def _render_eval_runner_section(state: AppState, job_id: str, job: TrainingJob) -> None:
+    """Render the [Run Static Eval] / [Run Multi-Turn Eval] controls + status.
+
+    Issue #82 Wave 4 (W4-T3): async eval runner in the training page.
+    ``MAX_CONCURRENT_EVAL=1`` is enforced by disabling both buttons when
+    any eval job is currently in the ``running`` state (D4-003).
+    """
+
+    st.markdown("---")
+    st.caption("評価ジョブ (Issue #82 Wave 4)")
+
+    # Build a project selector: eval needs ``repo_id`` + ``config_path`` and
+    # both live on ``Project``, not ``TrainingJob``.
+    if not state.projects:
+        st.info("先にプロジェクトを登録すると評価を実行できます。")
+        return
+
+    project_name = st.selectbox(
+        "評価対象プロジェクト",
+        options=list(state.projects.keys()),
+        key=f"eval_proj_{job_id}",
+    )
+    proj = state.projects[project_name]
+
+    running_evals = [ej for ej in state.eval_jobs.values() if ej.status == "running"]
+    disable_buttons = len(running_evals) >= _eval_panel.MAX_CONCURRENT_EVAL
+    if disable_buttons:
+        st.caption("⏳ 他の評価ジョブが実行中のため新規実行は無効です。")
+
+    col_s, col_m = st.columns(2)
+    with col_s:
+        static_clicked = st.button(
+            "Run Static Eval",
+            key=f"run_static_{job_id}",
+            disabled=disable_buttons,
+        )
+    with col_m:
+        mt_clicked = st.button(
+            "Run Multi-Turn Eval",
+            key=f"run_mt_{job_id}",
+            disabled=disable_buttons,
+        )
+
+    if static_clicked:
+        _launch_eval_job(state, proj, eval_type="static")
+        st.rerun()
+    if mt_clicked:
+        _launch_eval_job(state, proj, eval_type="multi_turn")
+        st.rerun()
+
+    # Running / recent eval jobs for this project.
+    related = [ej for ej in state.eval_jobs.values() if ej.project_name == proj.name]
+    if not related:
+        return
+    for ej in sorted(related, key=lambda e: e.started_at, reverse=True)[:5]:
+        icon = {
+            "pending": "⏳",
+            "running": "🔄",
+            "succeeded": "✅",
+            "failed": "❌",
+        }.get(ej.status, "?")
+        st.markdown(
+            f"**{icon} {ej.eval_type}** · `{ej.job_id[:8]}…` · "
+            f"{ej.status} · started {ej.started_at[:19]}"
+        )
+        if ej.total_q > 0:
+            pct = min(ej.done_q / ej.total_q, 1.0)
+            st.progress(
+                pct,
+                text=(
+                    f"{ej.done_q}/{ej.total_q} Q · "
+                    f"p50 {ej.p50_latency_ms:.0f}ms · "
+                    f"NC {ej.nc_rate:.1%}"
+                ),
+            )
+        if ej.status == "succeeded":
+            st.caption(
+                f"result: {ej.result_json}" if ej.result_json else "(no result_json)"
+            )
+        if ej.status == "failed" and ej.error_message:
+            # Keep the error short in the UI; full tail lives on disk.
+            snippet = ej.error_message.strip().splitlines()[-1][:200]
+            st.warning(f"失敗: {snippet}")
+
+
+def _launch_eval_job(
+    state: AppState,
+    proj: Project,
+    eval_type: str,
+) -> None:
+    """Spawn an eval subprocess + persist a new EvalJob in ``state``.
+
+    Issue #82 Wave 4 (W4-T3).  Path composition goes through
+    ``eval_panel.make_eval_paths`` so result_json/log_file/marker_file are
+    all confined to ``reports/eval_runs/`` and ``logs/eval/``.  The
+    config is taken from ``proj.photon_config_path`` when the project is
+    PHOTON-enabled, else from ``proj.config_path``.
+    """
+
+    job_id = _eval_panel.sanitize_job_id()
+    result_json, log_file, marker_file = _eval_panel.make_eval_paths(
+        job_id, PROJECT_ROOT
+    )
+    config_path = proj.photon_config_path or proj.config_path
+    try:
+        cmd = _eval_panel.build_eval_job_cmd(
+            eval_type=eval_type,
+            project_name=proj.name,
+            repo_id=proj.repo_id,
+            config_path=config_path,
+            output_json=result_json,
+            marker_file=marker_file,
+        )
+    except ValueError as exc:
+        st.error(f"評価コマンドの構築に失敗: {exc}")
+        return
+    try:
+        proc = _eval_panel.start_eval_job(cmd, log_file)
+    except OSError as exc:
+        st.error(f"評価プロセスの起動に失敗: {exc}")
+        return
+
+    started_epoch = time.time()
+    job = EvalJob(
+        job_id=job_id,
+        project_name=proj.name,
+        eval_type=eval_type,
+        status="running",
+        started_at=datetime.now().isoformat(timespec="seconds"),
+        started_at_epoch=started_epoch,
+        pid=proc.pid,
+        log_file=str(log_file),
+        result_json=str(result_json),
+        marker_file=str(marker_file),
+    )
+    state.eval_jobs[job_id] = job
+    save()
+    st.success(f"評価開始 (PID: {proc.pid}, job_id: {job_id[:8]}…)")
+
 
 def _generate_photon_config(
     path: str,
@@ -870,24 +1214,189 @@ def page_projects():
     )
     config_path = st.selectbox("Config ファイル", options=available_configs)
 
+    # Issue #82 Wave 5 (W5-T2): opt-in PHOTON wizard. The expander keeps
+    # the default UX minimal — users who only care about config_path /
+    # checkpoint leave the panel collapsed and the wizard is a no-op.
+    # When the user opens the expander AND PHOTON is enabled, submit
+    # writes ``projects/<safe_id(name)>/photon.yaml`` via
+    # ``wizard.generate_yaml_from_wizard`` (+ optional best-practice
+    # merge) and overrides ``photon_config_path`` accordingly.
+    with st.expander("PHOTON settings (Wave 2-4 toggles)", expanded=False):
+        use_wizard = st.checkbox(
+            "この form で PHOTON YAML を生成して保存",
+            value=False,
+            key="wizard_enable",
+            help=(
+                "オンにすると下記トグルから projects/<name>/photon.yaml を "
+                "生成し、photon_config_path に自動設定します。"
+            ),
+        )
+        wiz_base_profile = st.selectbox(
+            "Config template",
+            options=["photon_small", "photon_tiny", "photon_long_context"],
+            key="wizard_base_profile",
+        )
+        wiz_recgen = st.checkbox(
+            "RecGen enabled (inference.photon_generation_enabled)",
+            value=False,
+            key="wizard_recgen",
+        )
+        wiz_fallback: str | None = None
+        if wiz_recgen:
+            wiz_fallback = st.radio(
+                "Fallback policy (inference.generation_fallback_policy)",
+                options=list(_wizard.ALLOWED_FALLBACK_POLICIES),
+                index=0,
+                key="wizard_fallback",
+                horizontal=True,
+            )
+        wiz_two_pass = st.checkbox(
+            "2-pass search enabled (retrieval.two_pass_search.enabled)",
+            value=False,
+            key="wizard_two_pass",
+        )
+        wiz_pass1 = st.number_input(
+            "pass1_top_k",
+            min_value=1,
+            value=64,
+            step=1,
+            key="wizard_pass1_top_k",
+            disabled=not wiz_two_pass,
+        )
+        wiz_pass2 = st.number_input(
+            "pass2_top_k",
+            min_value=1,
+            value=16,
+            step=1,
+            key="wizard_pass2_top_k",
+            disabled=not wiz_two_pass,
+        )
+        wiz_wm = st.checkbox(
+            "Working memory enabled (session_memory.working_memory.enabled)",
+            value=True,
+            key="wizard_wm",
+        )
+        wiz_wm_max_turns = st.number_input(
+            "max_turns",
+            min_value=1,
+            value=8,
+            step=1,
+            key="wizard_wm_max_turns",
+            disabled=not wiz_wm,
+        )
+        wiz_wm_agg = st.selectbox(
+            "aggregation",
+            options=["weighted", "attention", "last"],
+            index=0,
+            key="wizard_wm_agg",
+            disabled=not wiz_wm,
+        )
+        wiz_wm_storage = st.selectbox(
+            "storage_mode",
+            options=["full", "top_level_only"],
+            index=0,
+            key="wizard_wm_storage",
+            disabled=not wiz_wm,
+        )
+        wiz_pinning = st.checkbox(
+            "past_turn_pinning_enabled",
+            value=False,
+            key="wizard_pinning",
+            disabled=not wiz_wm,
+        )
+        wiz_apply_best = st.checkbox(
+            "Apply best-practice when saving",
+            value=False,
+            key="wizard_apply_best",
+            help=(
+                "5 キー（safe_recgen / evidence_pruning / working_memory / "
+                "photon_generation=false / two_pass_search=false）を選択 "
+                "template にマージします。intentional conflict の profile "
+                "では警告として表示されます。"
+            ),
+        )
+
     if st.button(
         "登録",
         type="primary",
         disabled=not (name and repo_id and repo_id != "(なし — 先にDB作成)"),
     ):
+        # Issue #82 Wave 2 (W2-T1): validate project_name before any path
+        # composition. Reject metacharacters / traversal via _safe_id.
+        try:
+            safe_name = _safe_id(name, label="project_name")
+        except ValueError as exc:
+            st.error(f"プロジェクト名が不正です: {exc}")
+            return
+        # Path-containment assertion for defense-in-depth: the project dir
+        # (when saved) MUST resolve inside PROJECT_ROOT / "projects".
+        projects_root = (PROJECT_ROOT / "projects").resolve()
+        save_dir = (PROJECT_ROOT / "projects" / safe_name).resolve()
+        assert save_dir.is_relative_to(projects_root), (
+            f"project save dir escaped projects root: {save_dir}"
+        )
+
+        # Issue #82 Wave 5 (W5-T2): if the wizard panel opted in AND the
+        # selected checkpoint enables PHOTON, generate a fresh YAML from
+        # the chosen template + wizard toggles and (optionally) merge
+        # best-practice keys. The resulting file lives inside the
+        # validated ``save_dir`` so photon_config_path is contained.
+        photon_config_for_project = config_path if use_photon else ""
+        if use_photon and use_wizard:
+            user_toggles: dict[str, Any] = {
+                "recgen_enabled": bool(wiz_recgen),
+                "two_pass_search_enabled": bool(wiz_two_pass),
+                "two_pass_pass1_top_k": int(wiz_pass1),
+                "two_pass_pass2_top_k": int(wiz_pass2),
+                "working_memory_enabled": bool(wiz_wm),
+                "working_memory_max_turns": int(wiz_wm_max_turns),
+                "working_memory_aggregation": str(wiz_wm_agg),
+                "working_memory_storage_mode": str(wiz_wm_storage),
+                "past_turn_pinning_enabled": bool(wiz_pinning),
+            }
+            if wiz_recgen and wiz_fallback is not None:
+                user_toggles["fallback_policy"] = wiz_fallback
+
+            try:
+                generated_yaml = _wizard.generate_yaml_from_wizard(
+                    wiz_base_profile,
+                    user_toggles,
+                )
+                if wiz_apply_best:
+                    generated_yaml, warnings = _wizard.apply_best_practice(
+                        generated_yaml,
+                        wiz_base_profile,
+                    )
+                    for w in warnings:
+                        st.warning(w)
+            except ValueError as exc:
+                st.error(f"wizard YAML 生成に失敗しました: {exc}")
+                return
+
+            save_dir.mkdir(parents=True, exist_ok=True)
+            photon_yaml_path = (save_dir / "photon.yaml").resolve()
+            # Defense-in-depth: ensure the final written path is still
+            # inside projects_root after resolve().
+            assert photon_yaml_path.is_relative_to(projects_root), (
+                f"photon.yaml escaped projects root: {photon_yaml_path}"
+            )
+            _atomic_write_text(photon_yaml_path, generated_yaml)
+            photon_config_for_project = str(photon_yaml_path)
+            st.success(f"wizard YAML を保存しました: {photon_yaml_path}")
+
         project = Project(
-            name=name,
+            name=safe_name,
             repo_id=repo_id,
             index_dir=str(idx_dir / repo_id),
             config_path=config_path,
-            photon_config_path=config_path if use_photon else "",
+            photon_config_path=photon_config_for_project,
             checkpoint_dir=checkpoint if use_photon else "",
             use_photon=use_photon,
             created_at=datetime.now().isoformat(),
         )
-        state.projects[name] = project
+        state.projects[safe_name] = project
         save()
-        st.success(f"プロジェクト '{name}' を登録しました")
+        st.success(f"プロジェクト '{safe_name}' を登録しました")
         st.rerun()
 
     # --- List ---
@@ -937,6 +1446,17 @@ def page_chat():
         f"config: {Path(proj.config_path).name}"
     )
 
+    # Issue #82 Wave 1 (W1-T1): block retries when MLX is unavailable for
+    # a photon-provider project. ``_run_query`` sets this flag on the first
+    # ImportError so we don't keep re-trying the heavy import every turn.
+    photon_unavailable_key = f"photon_unavailable_{project_name}"
+    photon_unavailable = st.session_state.get(photon_unavailable_key)
+    if photon_unavailable:
+        st.error(
+            "PHOTON パイプラインを初期化できません "
+            f"({photon_unavailable})。MLX がインストールされているか確認してください。"
+        )
+
     # Session management
     session_key = f"chat_{project_name}"
     if session_key not in state.chat_histories:
@@ -959,7 +1479,12 @@ def page_chat():
             placeholder="質問を入力して送信ボタンを押してください",
         )
     with col_btn:
-        send_clicked = st.button("送信", type="primary", key=f"send_{session_key}")
+        send_clicked = st.button(
+            "送信",
+            type="primary",
+            key=f"send_{session_key}",
+            disabled=bool(photon_unavailable),
+        )
 
     question = question_input if send_clicked and question_input else None
 
@@ -983,6 +1508,70 @@ def page_chat():
                     col2.metric("Citations", str(metadata.get("cited_count", 0)))
                     col3.metric("Chunks", str(metadata.get("pack_size", 0)))
 
+                # Issue #82 Wave 3: drift + turn_history panels.
+                # Isolated so rendering failures do not break chat flow.
+                try:
+                    cfg_for_panels = load_config(proj.config_path)
+                except Exception:
+                    cfg_for_panels = None
+
+                try:
+                    dm_raw = metadata.get("drift_metrics")
+                    dm_dict = None
+                    if dm_raw is not None:
+                        dm_dict = (
+                            dm_raw.as_dict() if hasattr(dm_raw, "as_dict") else dm_raw
+                        )
+                    thresholds = _build_drift_thresholds(cfg_for_panels)
+                    panel = _drift_panel.format_drift_panel(dm_dict, thresholds)
+                    with st.expander("Drift metrics"):
+                        if not panel["available"]:
+                            st.info(panel["reason"])
+                        else:
+                            for row in panel["rows"]:
+                                label = (
+                                    f"{row['badge']} {row['name']}".strip()
+                                    if row["badge"]
+                                    else row["name"]
+                                )
+                                st.metric(label, row["value_str"])
+                            fired = "Yes" if panel["safe_recgen_fired"] else "No"
+                            st.caption(f"Safe RecGen fired: {fired}")
+                except Exception as exc:
+                    st.warning(f"drift panel render failed: {exc}")
+
+                try:
+                    wm_enabled = _working_memory_enabled(cfg_for_panels)
+                    max_turns = 8
+                    if cfg_for_panels is not None:
+                        sm = getattr(cfg_for_panels, "session_memory", None)
+                        wm = getattr(sm, "working_memory", None) if sm else None
+                        max_turns = int(getattr(wm, "max_turns", 8) or 8) if wm else 8
+                    hist_panel = _turn_history_panel.format_turn_history_panel(
+                        metadata.get("photon_turn_history"),
+                        metadata.get("session_turns"),
+                        working_memory_enabled=wm_enabled,
+                        max_turns=max_turns,
+                    )
+                    with st.expander("Turn history"):
+                        if not hist_panel["available"]:
+                            st.info(hist_panel["reason"])
+                        elif not hist_panel["rows"]:
+                            st.caption("(no turns recorded yet)")
+                        else:
+                            for row in hist_panel["rows"]:
+                                st.markdown(
+                                    f"- **turn {row.turn_id}** · "
+                                    f"`{row.timestamp}` — "
+                                    f"{row.question_text}"
+                                )
+                                if row.cited_chunk_ids:
+                                    st.caption(
+                                        "cited: " + ", ".join(row.cited_chunk_ids)
+                                    )
+                except Exception as exc:
+                    st.warning(f"turn history render failed: {exc}")
+
         history.append({"role": "assistant", "content": answer})
         save()
 
@@ -994,76 +1583,160 @@ def page_chat():
 
 
 def _run_query(proj: Project, question: str, session_key: str) -> tuple[str, dict]:
-    """Run a query through the pipeline."""
+    """Run a query through the pipeline via ``build_pipeline(cfg)``.
+
+    Issue #82 Wave 1 (W1-T1): route through the provider-routing factory so
+    ``cfg.model.provider == "photon"`` reaches ``PhotonRAGPipeline`` and the
+    resulting ``QueryResult.drift_metrics`` / ``turn_id`` become available
+    to the UI. MLX import errors are caught and surfaced via the
+    ``photon_unavailable_{proj.name}`` session-state flag so the chat page
+    can block retries and display a clear error.
+    """
+    # Default metadata keeps the UI contract stable even on error paths.
+    metadata_default: dict[str, Any] = {
+        "latency_ms": 0,
+        "cited_count": 0,
+        "pack_size": 0,
+        "no_citation": False,
+        "drift_metrics": None,
+        "turn_id": 0,
+    }
+
+    pipeline_key = f"pipeline_{proj.name}"
+
     try:
-        import sys
+        cfg = load_config(proj.config_path)
+    except Exception as exc:
+        _logger.exception("Failed to load config for %s", proj.name)
+        return f"エラー: config load failed ({type(exc).__name__}: {exc})", dict(
+            metadata_default
+        )
 
-        sys.path.insert(0, str(PROJECT_ROOT))
-
-        from baseline_reporag.config import load_config
-        from baseline_reporag.generation.generator import Generator
-        from baseline_reporag.indexing.embedding import EmbeddingIndex
-        from baseline_reporag.indexing.lexical import LexicalIndex
-        from baseline_reporag.indexing.symbol_graph import SymbolGraph
-        from baseline_reporag.ingestion.store import ChunkStore
-        from baseline_reporag.logger import RunLogger
-        from baseline_reporag.memory.session import SessionManager
-        from baseline_reporag.pipeline import RepoRAGPipeline
-        from baseline_reporag.retrieval.reranker import CrossEncoderReranker
-
-        # Cache pipeline in session state
-        pipeline_key = f"pipeline_{proj.name}"
-        if pipeline_key not in st.session_state:
-            cfg = load_config(proj.config_path)
-            idx_dir = Path(cfg.paths.data_root) / "indexes" / proj.repo_id
-            run_id = f"app_{proj.repo_id}_{int(time.time())}"
-
-            reranker_cfg = cfg.retrieval.reranker
-            reranker = (
-                CrossEncoderReranker(
-                    model_id=reranker_cfg.get(
-                        "model_id", "cross-encoder/ms-marco-MiniLM-L-6-v2"
-                    )
-                )
-                if reranker_cfg.get("enabled", False)
-                else None
+    if pipeline_key not in st.session_state:
+        try:
+            pipeline = build_pipeline(cfg)
+        except (ImportError, ModuleNotFoundError) as exc:
+            st.session_state[f"photon_unavailable_{proj.name}"] = str(exc)
+            _logger.warning("PHOTON pipeline unavailable for %s: %s", proj.name, exc)
+            return (
+                f"エラー: PHOTON pipeline unavailable ({exc})",
+                dict(metadata_default),
             )
-
-            st.session_state[pipeline_key] = RepoRAGPipeline(
-                config=cfg,
-                store=ChunkStore(idx_dir / "chunks.db"),
-                lexical=LexicalIndex.load(idx_dir / "lexical.pkl"),
-                embedding=EmbeddingIndex.load(idx_dir / "embedding"),
-                graph=SymbolGraph.load(idx_dir / "symbol_graph.json"),
-                sessions=SessionManager(log_dir=Path(cfg.paths.log_root) / "sessions"),
-                generator=Generator(
-                    model_id=cfg.model.model_id,
-                    max_new_tokens=cfg.generation.max_new_tokens,
-                    temperature=cfg.generation.temperature,
-                    top_p=cfg.generation.top_p,
-                ),
-                logger=RunLogger(cfg.paths.log_root, run_id),
-                reranker=reranker,
+        except Exception as exc:
+            _logger.exception("Failed to build pipeline for %s", proj.name)
+            return (
+                f"エラー: pipeline build failed ({type(exc).__name__}: {exc})",
+                dict(metadata_default),
             )
+        st.session_state[pipeline_key] = pipeline
 
-        pipeline = st.session_state[pipeline_key]
+    pipeline = st.session_state[pipeline_key]
+
+    try:
         result = pipeline.query(
             question=question,
             session_id=session_key,
             repo_id=proj.repo_id,
         )
+    except Exception as exc:
+        # Keep traceback in logs; keep UI message short.
+        _logger.exception("pipeline.query failed for %s", proj.name)
+        return (
+            f"エラー: {type(exc).__name__}: {exc}",
+            dict(metadata_default),
+        )
 
-        metadata = {
-            "latency_ms": result.latency.total_ms,
-            "cited_count": len(result.cited_chunk_ids),
-            "pack_size": len(result.cited_chunk_ids),
-            "no_citation": result.no_citation,
+    metadata = {
+        "latency_ms": result.latency.total_ms,
+        "cited_count": len(result.cited_chunk_ids),
+        "pack_size": len(result.cited_chunk_ids),
+        "no_citation": result.no_citation,
+        "drift_metrics": getattr(result, "drift_metrics", None),
+        "turn_id": getattr(result, "turn_id", 0),
+    }
+
+    # Issue #82 Wave 3 (W3-T3): surface turn-history for the chat panel.
+    # PhotonRAGPipeline keeps PHOTON sessions in ``photon_inference._sessions``
+    # and the baseline SessionManager in ``baseline.sessions``. When the
+    # pipeline is a plain baseline_rag RepoRAGPipeline, ``photon_inference``
+    # is absent and ``photon_turn_history`` stays ``None`` — the UI then
+    # renders an "N/A (baseline_rag)" panel.
+    photon_turn_history: list[Any] | None = None
+    session_turns: list[Any] | None = None
+    try:
+        photon_inference = getattr(pipeline, "photon_inference", None)
+        if photon_inference is not None:
+            photon_session = getattr(photon_inference, "_sessions", {}).get(session_key)
+            if photon_session is not None:
+                photon_turn_history = list(
+                    getattr(photon_session, "turn_history", []) or []
+                )
+            else:
+                # Photon pipeline exists but this session has not reached a
+                # state that records turn_history yet (e.g. first-turn
+                # fail-closed) — render an empty panel rather than N/A.
+                photon_turn_history = []
+        sessions_mgr = getattr(getattr(pipeline, "baseline", None), "sessions", None)
+        if sessions_mgr is None:
+            sessions_mgr = getattr(pipeline, "sessions", None)
+        if sessions_mgr is not None:
+            internal = getattr(sessions_mgr, "_sessions", {}) or {}
+            sess = internal.get(session_key)
+            if sess is not None:
+                session_turns = list(getattr(sess, "turns", []) or [])
+    except Exception:
+        _logger.exception("Failed to extract turn_history for project %s", proj.name)
+
+    metadata["photon_turn_history"] = photon_turn_history
+    metadata["session_turns"] = session_turns
+
+    return result.answer, metadata
+
+
+def _build_drift_thresholds(cfg: Any) -> dict[str, float | None]:
+    """Map ``cfg.safe_recgen.thresholds`` to the 4 UI indicator slots.
+
+    Issue #82 Wave 3 (W3-T3): ``configs/photon_small.yaml:262-266`` exposes
+    only the ``latent_cosine_drift`` and ``topic_shift_score`` thresholds;
+    the token/mid levels have no configured threshold so those slots are
+    ``None`` (classify_drift returns "ok" when the threshold is None).
+    """
+    sr = getattr(cfg, "safe_recgen", None)
+    if sr is None:
+        return {
+            "token_level": None,
+            "mid_level": None,
+            "top_level": None,
+            "topic_shift": None,
         }
+    thr = getattr(sr, "thresholds", None)
+    if thr is None:
+        return {
+            "token_level": None,
+            "mid_level": None,
+            "top_level": None,
+            "topic_shift": None,
+        }
+    # ``thr`` is a ``Config`` (dot-access wrapper) when loaded from YAML,
+    # but a plain dict in tests. Both support ``.get(...)``.
+    getter = thr.get if hasattr(thr, "get") else (lambda k, d=None: d)
+    return {
+        "token_level": None,
+        "mid_level": None,
+        "top_level": getter("latent_cosine_drift", None),
+        "topic_shift": getter("topic_shift_score", None),
+    }
 
-        return result.answer, metadata
 
-    except Exception as e:
-        return f"エラーが発生しました: {e}", {}
+def _working_memory_enabled(cfg: Any) -> bool:
+    """Return ``True`` iff ``cfg.session_memory.working_memory.enabled``."""
+    sm = getattr(cfg, "session_memory", None)
+    if sm is None:
+        return False
+    wm = getattr(sm, "working_memory", None)
+    if wm is None:
+        return False
+    return bool(getattr(wm, "enabled", False))
 
 
 # ================================================================

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -227,3 +227,58 @@ python scripts/build_symbol_graph.py --config configs/baseline.yaml
 ```
 
 Restart the server after re-indexing to pick up the new data.
+
+---
+
+## Streamlit App: PHOTON Wave 2-4 UI (Issue #82)
+
+The management app (`app/photon_app.py`) exposes the Wave 2-4 PHOTON features through a GUI instead of requiring YAML edits.
+
+### PHOTON プロジェクト作成ウィザード
+
+`page_projects()` の「Create new project」フォーム内に **PHOTON settings** expander を配置。`use_photon=True` で作成するプロジェクトは以下をフォームで設定可能:
+
+- **Config template**: `photon_small` / `photon_tiny` / `photon_long_context`
+- **RecGen (PHOTON generation)**: 有効/無効トグル + Fallback policy (`qwen` / `abort`)
+- **2-pass search**: 有効/無効トグル + pass1/pass2 top_k
+- **Working memory**: enable, max_turns, aggregation (`weighted`/`attention`/`last`), storage_mode (`full`/`top_level_only`), past_turn_pinning
+
+「**Apply best-practice**」チェックボックスを有効にして保存すると、以下 5 キーがテンプレートに merge される:
+
+- `safe_recgen.enabled: true`
+- `generation.evidence_pruning_enabled: true`
+- `session_memory.working_memory.enabled: true`
+- `inference.photon_generation_enabled: false`（RecGen 非推奨・MT eval で +6.1pp NC）
+- `retrieval.two_pass_search.enabled: false`（Static 悪化）
+
+プロファイル `photon_tiny_recgen` / `photon_tiny` / `photon_600m_paper` に対しては意図的な設定の上書きについて警告が表示される（生成された YAML は `projects/<project_name>/photon.yaml` に保存）。
+
+### Drift metrics panel（チャット画面）
+
+PHOTON プロジェクトでのチャット応答ごとに以下 4 指標が表示される:
+
+- `token_level`（`latent_cosine_drift_token`）
+- `mid_level`（`latent_cosine_drift_mid`）
+- `top_level`（`latent_cosine_drift_top`）— 閾値は `cfg.safe_recgen.thresholds.latent_cosine_drift`
+- `topic_shift`（`topic_shift_score`）— 閾値は `cfg.safe_recgen.thresholds.topic_shift_score`
+
+閾値超過時は `⚠` バッジ付きで視覚的に区別。baseline プロジェクトや初回ターンは `N/A (baseline_rag or first turn)` 表示。
+
+### Working memory panel（turn_history）
+
+PHOTON + `session_memory.working_memory.enabled=true` のプロジェクトでは最新 `max_turns` 件の履歴を表示:
+
+- Turn ID, question_text, timestamp
+- cited_chunk_ids（`SessionManager` の `Turn.cited_chunk_ids` と `turn_id` で join）
+
+baseline プロジェクトは `N/A (baseline_rag)`、working_memory OFF は `N/A (working_memory disabled)` 表示。
+
+### Eval runner（training 詳細）
+
+学習ジョブの展開パネル内から eval を起動可能:
+
+- `[Run Static Eval]`: `scripts.run_baseline_eval` を `-m` で起動
+- `[Run Multi-Turn Eval]`: `scripts.run_multi_turn_eval` を `-m` で起動
+- 同時実行数は 1（`MAX_CONCURRENT_EVAL=1`）、wall-clock timeout 3600s
+
+Eval ジョブの状態は `.cache/photon_app_state.json` の `eval_jobs` dict に永続化される。起動時の subprocess は `shell=False`、結果 JSON は `reports/eval_runs/<job_id>.json`、ログは `logs/eval/<job_id>.log`（両方 gitignore 済み）。進捗は `PROGRESS done=N total=M p50_ms=X nc=Y` 形式のログ行から自動抽出。正常終了時に `reports/eval_runs/<job_id>.done` マーカーファイルが作成される。

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -137,3 +137,34 @@ top -pid $(pgrep -f baseline_reporag)
 5. **`torch_ref` 経路で長コンテキスト**: `torch_ref` は 128 位置までしか扱えない。長コンテキストは必ず MLX 経路（`PhotonModel`）で使うこと。`torch_ref/_precompute_rope` で `scaling != "none"` を渡すと `NotImplementedError` が明示的に raise される（silent fallback なし）。
 
 参考: `reports/issue-55-long-context.md`
+
+---
+
+## Streamlit アプリ: drift_metrics が `N/A` のまま表示される (Issue #82)
+
+**Symptom**: PHOTON プロジェクトのチャット画面で drift metrics パネルが常に `N/A (baseline_rag or first turn)` を表示し、4 指標が取れない。
+
+**Checklist**:
+
+1. **`cfg.model.provider` が `"photon"` か**: `build_pipeline(cfg)` は `cfg.model.provider == "photon"` の場合のみ `PhotonRAGPipeline` を返す。プロジェクトの `photon_config_path` が指す YAML を確認し、`model.provider: "photon"` が設定されているか (`configs/photon_small.yaml:155` 等が参考)。
+2. **MLX がインストールされているか**: baseline-only マシンでは `ModuleNotFoundError: mlx.core` が `build_pipeline` 内で発生し、UI は `photon_unavailable_{project_name}` フラグを立てて送信をブロックする。チャット画面上部の赤色エラーバナーを確認。
+3. **初回ターン**: drift metrics は 2 ターン目以降から値が入る仕様。最初の質問では `N/A (first turn)` は正常。
+4. **`use_photon=False` の baseline プロジェクト**: これは仕様通り `N/A (baseline_rag)`。PHOTON を試したい場合は新規プロジェクトを `use_photon=True` + PHOTON config で作成。
+
+---
+
+## Streamlit アプリ: eval ジョブが進まない / 消えない (Issue #82)
+
+**Symptom**: `[Run Static Eval]` を押したがステータスが `running` のまま止まる、または Streamlit 再起動後に孤児ジョブが残る。
+
+**Checklist**:
+
+1. **state ファイルで PID 確認**: `.cache/photon_app_state.json` を開き、該当 `eval_jobs[<job_id>]` の `pid` を確認。
+2. **プロセス存在確認**: `ps -p <pid>`。プロセスがいなければマーカーが作られなかったまま死んだ（OOM や SIGKILL が典型）。この場合次回 `_sync_eval_job` が走ったタイミングで `status='failed'` に遷移する（即時反映したい場合は Streamlit を一度再起動）。
+3. **Wall-clock timeout**: 経過 3600 秒を超えると自動的に `status='failed'` + `error_message='wall-clock timeout'` に遷移する（Apple Silicon で 120Q の Static eval でも通常 40 分で終わる想定）。
+4. **手動 kill**: `kill -15 <pid>`（SIGTERM）で停止。`kill -9 <pid>`（SIGKILL）は log/marker が不完全になるため最終手段に。
+5. **ログ確認**: `logs/eval/<job_id>.log` の末尾を確認。tokenizer エラーや MLX 初期化エラーが典型。
+6. **マニュアル cleanup（retention）**: `AppState.eval_jobs` は自動削除されないため、不要になったエントリは `.cache/photon_app_state.json` を直接編集して削除するか、Streamlit を停止 → JSON 編集 → 再起動。成果物（`reports/eval_runs/*.json`、`logs/eval/*.log`、`reports/eval_runs/*.done`）は安全に削除可能（gitignore 済み）。
+7. **Concurrent 起動**: `MAX_CONCURRENT_EVAL=1` のため、既に running の eval がある場合は Start ボタンが disabled になる（仕様）。
+
+参考: 設計方針書 `workspace/design/issue-82-app-photon-features-design-policy.md` §6.4 / §7.2

--- a/reports/issue_103_opt_in_benefit_eval.md
+++ b/reports/issue_103_opt_in_benefit_eval.md
@@ -1,0 +1,63 @@
+# Issue #103 Opt-in Benefit Eval Report
+
+**実行日**: 2026-04-23
+**Config**: `configs/photon_small_pinning_on.yaml`（`past_turn_pinning_enabled: true`）
+**目的**: PR #105 で追加した opt-in feature の実効性検証
+
+## 結果（2-run MT eval）
+
+| Run | NC | Turn 1 | Turn 2 | Turn 3 | Turn 4 | Turn 5 | Turn 6 |
+|-----|-----|--------|--------|--------|--------|--------|--------|
+| Run 1 | 9.4% | 13% | 17% | 17% | 3% | 7% | 0% |
+| Run 2 | 8.9% | 10% | 17% | 17% | 10% | 0% | 0% |
+| **Avg** | **9.2%** | 11.7% | 16.7% | **16.7%** | 6.7% | 3.3% | 0% |
+
+### Default OFF 2-run 比較
+
+| metric | default OFF | **pinning ON** | delta |
+|--------|-------------|---------------|-------|
+| 全体 MT NC | 7.8% | **9.2%** | **+1.4pp 悪化** |
+| Turn 2 | ~22% | 16.7% | **-5pp 改善** ✓ |
+| Turn 3 | ~9% | **16.7%** | **+8pp 悪化** ⚠️ |
+
+## 判定：**opt-in benefit 実証されず**
+
+Hypothesis（Issue #103 本文）は Turn 2-3 NC 低減を予測していたが、実測では **Turn 2 で改善・Turn 3 で悪化**と mixed signal。全体では +1.4pp regression。
+
+## 原因分析
+
+### Turn 2 改善（-5pp）の解釈
+- Turn 2 は直前ターン（Turn 1）への follow-up が多く、context 継続性が高い
+- pinning された過去ターンの chunks が評価に有効
+
+### Turn 3 悪化（+8pp）の解釈
+- **Turn 3 は topic shift が起こりやすい**（例: Turn 2 で話題 A の diff、Turn 3 で話題 B のテスト）
+- Turn 2 完了時点で pin された chunks は Turn 3 にとって stale
+- evidence pack の 16 chunks 枠を stale pinning が消費し、より関連の高い新 chunks が除外される
+- 結果として **retrieval noise** が増加
+
+### 設計上の限界
+- `find_relevant_past_turn` は **直前ターン専用**ではなく、**任意の過去ターン**を pin
+- しかし evidence pack の枠消費で **今回のクエリに最適な chunks** が削られる trade-off
+- threshold (0.7) と `max_pinned_chunks` (3) のデフォルトは本 workload に対して過度に寛容
+
+## 決定
+
+1. **PR #105 は merge 済み維持**（実装は clean、default off のため regression リスクなし）
+2. **opt-in feature として残置**（特定 workload で効果が期待できる可能性）
+3. **default 化は推奨せず**
+4. **Issue #103 は本実測結果で「実装完了、benefit not proven」としてクローズ**
+5. Follow-up：threshold/max_pinned_chunks チューニングで Turn 3 悪化を回避できるかの A/B は別 Issue（Epic #81 の延長）で検討
+
+## 教訓
+
+**context 継続性を仮定する feature は、topic shift がある workload で逆効果になる**。将来の類似 feature（#104 dynamic aggregation 含む）では：
+- default は opt-in で導入
+- 2-run MT eval gate で実効性確認
+- Turn 別の詳細ブレークダウン分析を必須化
+
+## 成果物
+
+- `reports/mt_nc_issue103_pinning_on.jsonl` / `.summary.json` (Run 1)
+- `reports/mt_nc_issue103_pinning_on_verify.jsonl` / `.summary.json` (Run 2)
+- 本レポート

--- a/reports/issue_103_pre_merge_eval.md
+++ b/reports/issue_103_pre_merge_eval.md
@@ -1,0 +1,51 @@
+# Issue #103 Pre-merge Eval Report
+
+**実行日**: 2026-04-23
+**PR**: #105 (commit dfc228f)
+**目的**: `past_turn_pinning` 機能追加後、**default off** での regression 検証
+
+## 結果（2-run MT eval, default=false）
+
+| Run | Total | NC | Rate | Turn 1 | Turn 2 | Turn 5-6 |
+|-----|-------|----|----- |--------|--------|----------|
+| Run 1 | 180 | 17 | 9.4% | 3% | 33% (outlier) | 0% / 0% |
+| Run 2 | 180 | 11 | 6.1% | 13% | 10% | 0% / 0% |
+| **Average** | — | — | **7.8%** | — | — | **0% 維持** |
+
+### 歴史的コンテキスト
+
+| Run | NC |
+|-----|-----|
+| Wave 5 default weighted | 7.8% |
+| Post-revert baseline | 5.0% |
+| #92 post-merge run 1 | 12.2% |
+| #92 post-merge run 2 (verify) | 7.2% |
+| #103 default off run 1 | 9.4% |
+| #103 default off run 2 | 6.1% |
+| **全 6-run 平均** | **7.9%** |
+
+2-run avg 7.8% は歴史的平均 7.9% と完全一致 → **regression なし**。
+
+## 判定：**PASS**
+
+- default off のコード path は意味的変化なし（code review 済）
+- Turn 5-6 NC = 0% 維持 → PHOTON working memory 健全
+- Run 1 の 9.4% は Turn 2=33% 異常値を含む single-run 外れ値（前例：#92 run 1 も 12.2% → verify で 7.2%）
+- Run 2 は 6.1% で Wave 5 range 下限
+
+## 教訓
+
+**single-run MT eval の分散は ±4-5pp、2-run average が最低限の gate 基準**。  
+本 PR で確立されたプロトコルは今後の A-3 以降でも継続採用。
+
+## 次アクション
+
+- PR #105 merge → develop tip `dfc228f`
+- **post-merge eval (opt-in ON)** で benefit 検証（Turn 2-3 NC 低下確認）
+- 改善確認できたら Issue に結果コメント、後続 Issue で default 化検討
+
+## 成果物
+
+- `reports/mt_nc_issue103_default.jsonl` / `.summary.json`（Run 1、feature worktree 内）
+- `reports/mt_nc_issue103_default_verify.jsonl` / `.summary.json`（Run 2）
+- 本レポート

--- a/reports/issue_104_hybrid_mini_ab.md
+++ b/reports/issue_104_hybrid_mini_ab.md
@@ -1,0 +1,54 @@
+# Issue #104 Hybrid Mini A/B Report
+
+**実行日**: 2026-04-23
+**Config**: `configs/photon_small_hybrid.yaml`（`aggregation: dynamic` + `dynamic_strategy: hybrid`）
+**目的**: hybrid strategy の default 化判定
+
+## 結果（2-run MT eval）
+
+| Run | NC | Turn 1 | Turn 2 | Turn 3 | Turn 4 | Turn 5 | Turn 6 |
+|-----|-----|--------|--------|--------|--------|--------|--------|
+| Run 1 | 7.8% | 0% | 13% | 23% | 10% | 0% | 0% |
+| Run 2 | 9.4% | 0% | 20% | 13% | 10% | 0% | 13% |
+| **Avg** | **8.6%** | **0%** | 16.7% | 18.3% | 10% | 0% | 6.7% |
+
+### Weighted baseline 比較
+
+| metric | weighted | **hybrid** | delta |
+|--------|----------|-----------|-------|
+| 全体 MT NC | 7.8% | **8.6%** | **+0.8pp 悪化** |
+| Turn 1 | ~3% | **0%** | **-3pp 改善** ✓ |
+| Turn 2-4 | 6-15% | 10-18% | +2〜+8pp 悪化 |
+| Turn 6 | ~0% | 6.7% | +7pp 悪化 |
+
+## 判定：**default 化推奨せず**
+
+hybrid は Wave 5 分析で予測された通り Turn 1 で attention の強みを活かせる。しかし alpha blending（weighted + attention）の **中間値が Turn 2-6 で weighted を下回る**。全体では +0.8pp の悪化で default 化は非推奨。
+
+## 設計上の原因分析
+
+`hybrid_alpha_base: 0.5`, `hybrid_alpha_per_turn: 0.1` という default:
+- Turn 1: alpha=0.5（半々）→ Turn 1 は history 不在で attention fallback → 0%
+- Turn 2+: alpha 徐々に増加 → weighted の強みが薄まる
+- Turn 4+: alpha 高め → attention 寄り、Turn 4-6 で weighted より悪化
+
+実質、**hybrid の alpha schedule が本 workload に最適化されていない**。alpha_base=0.1、per_turn=0.05 など attention 比率を下げれば改善余地あるが、hyperparameter tuning は別 Issue の範囲。
+
+## 決定
+
+1. **dynamic aggregation (Issue #92) 実装は merged**、opt-in として利用可能
+2. **default は `aggregation: weighted` 維持**
+3. Issue #104 は「empirical A/B 完了、hybrid strategy default 化は empirical 根拠なし」でクローズ
+4. Follow-up：
+   - `hybrid_alpha_base` / `hybrid_alpha_per_turn` の grid search（別 Issue、Epic #81 の延長）
+   - `turn_position` と `drift_based` strategy の独立 A/B（今回未実施）
+
+## 教訓
+
+Wave 5 分析（`reports/mt_nc_eval_wave5_analysis.md`）で示された turn 別の最適 mode は実測と整合（Turn 1 attention、Turn 2-4 weighted）。しかし **単純な alpha blending** では両モードの strengths を捕捉しきれない。より精度の高い dispatcher（例：`turn_count < 2 ? attention : weighted` のような条件付き）が必要な可能性。
+
+## 成果物
+
+- `reports/mt_nc_issue104_hybrid_run1.jsonl` / `.summary.json`
+- `reports/mt_nc_issue104_hybrid_run2.jsonl` / `.summary.json`
+- 本レポート

--- a/reports/issue_89_bge_reranker_retry_abort.md
+++ b/reports/issue_89_bge_reranker_retry_abort.md
@@ -1,0 +1,48 @@
+# Issue #89 bge-reranker Retry — Abort Report
+
+**実行日**: 2026-04-23
+**commit**: cherry-pick bcb2f26 → 059305e（merge せず、worktree 廃棄）
+**判定**: **Abort（merge せず Issue #89 クローズ推奨）**
+
+## 実測結果（pre-merge Static NC）
+
+| Run | Reranker | Static NC | Delta vs baseline |
+|-----|----------|-----------|-------------------|
+| Baseline (post-revert) | `cross-encoder/ms-marco-MiniLM-L-6-v2` | **17.5%** | — |
+| **#89 feature branch** | `BAAI/bge-reranker-base` | **18.3%** | **+0.8pp 悪化** |
+
+### カテゴリ別
+| category | NC |
+|----------|-----|
+| onboarding | 3.3% |
+| bug_localization | 13.3% |
+| change_planning | 26.7% |
+| impact_analysis | 30.0% |
+
+## 判定理由
+
+1. **Issue #89 の目標は Static NC < 16% 改善**、結果は 18.3%（未達かつ悪化方向）
+2. Wave 5 分析（`reports/two_pass_search_analysis.md`）で既に
+   「MS-MARCO MiniLM (reranker) が bge より強い」と実測済み
+3. Wave 6 全 revert 時の regression 要因推定とも整合
+4. bge-reranker-base は多言語 IR tuned だが FastAPI（英語 code-heavy）workload では
+   MS-MARCO MiniLM の code/NL ranking 適合性が勝る
+
+## 結論
+
+**本 workload において bge-reranker-base による Static NC 改善は得られない**。
+MT eval を実行しても改善は期待できず（Wave 6 の MT regression 要因推定と整合）、
+3h の eval コストはリターンに見合わない。
+
+## 次アクション
+
+- Issue #89 に本結果をコメントしてクローズ（"bge-reranker does not improve Static NC on this workload"）
+- Epic #81 配下の retrieval tuning は以下で進める：
+  - **embedding モデル更新（#90）**— 未検証のため別トライ価値あり
+  - **retrieval パラメータ grid search（#88 harness 使用）**— 現行 reranker 上での最適化
+  - **graph expansion 調整（#91）**— Wave 6 regression 要因の可能性、慎重に
+
+## 成果物
+
+- `reports/static_nc_issue89_pre.jsonl`（feature worktree 内、120Q 予測）
+- 本レポート

--- a/reports/issue_92_post_merge_eval.md
+++ b/reports/issue_92_post_merge_eval.md
@@ -1,0 +1,32 @@
+# Issue #92 Post-merge Eval Report
+
+**実行日**: 2026-04-23
+**PR**: #101 (commit a72775e, cherry-pick of reverted bf6dd52)
+**目的**: dynamic aggregation 機能追加後の weighted (default) 経路の regression 検証
+
+## 結果
+
+| Run | Total | NC | Rate | Turn 1 | Turn 2 | Turn 3 | Turn 4 | Turn 5 | Turn 6 |
+|-----|-------|----|----- |--------|--------|--------|--------|--------|--------|
+| Post-revert baseline (pre-#92) | 180 | 9 | **5.0%** | 0.0% | 16.7% | 10.0% | 3.3% | 0.0% | 0.0% |
+| Post-#92 run 1 | 180 | 22 | 12.2% | 23.3% | 10.0% | 16.7% | 10.0% | 0.0% | 13.3% |
+| Post-#92 run 2 (verify) | 180 | 13 | **7.2%** | 0.0% | 10.0% | 20.0% | 10.0% | 3.3% | 0.0% |
+| Wave 5 default (過去参考) | 180 | — | 7.8% | — | — | — | — | — | — |
+
+## 判定：**PASS**
+
+- Run 1 の 12.2% は Turn 1=23.3% という異常値を含む外れ値。Run 2 verify で Turn 1=0% に回帰。
+- Run 2 の 7.2% は Wave 5 default (7.8%) と同等で refactor による semantic 変化なし。
+- default `aggregation: weighted` 維持のため既存挙動への影響は想定通り皆無。
+- dynamic モードは opt-in（`aggregation: "dynamic"` 明示時のみ）。
+
+## 教訓
+
+1. **LLM 非決定性による single-run 分散が ±4-5pp ある**（Qwen 2.5-Coder-14B-Instruct-4bit, temp=0.2, top_p=0.9）。
+2. **今後の eval-gate は 2-run average を基準とすべき**。single-run での ±3pp 判定は誤検知リスクあり。
+3. Run 1 の 23.3% Turn 1 NC は Turn 1 が session state を使わない（history 空）点と矛盾しており、Qwen 生成時の stochastic な引用タグ欠落が主因と推定。
+
+## 次アクション（A-2: Issue #88 retrieval grid search）
+
+- 同じ single-PR + post-merge eval-gate プロトコル
+- ただし eval は **2-run average** を採用する

--- a/scripts/run_baseline_eval.py
+++ b/scripts/run_baseline_eval.py
@@ -28,10 +28,17 @@ def main() -> None:
     parser.add_argument("--eval-set", default="data/eval_sets/static_eval.jsonl")
     parser.add_argument("--max-questions", type=int, default=0)
     parser.add_argument("--output", default="")
+    # Issue #82 Wave 4: ``--repo-id`` lets the Streamlit eval runner
+    # override the repo_id (the default path only has cfg.repo.repo_id).
+    parser.add_argument("--repo-id", default="")
+    # Issue #82 Wave 4: when the Streamlit app invokes this script it
+    # passes a ``--marker-file`` path; we ``touch()`` it on successful
+    # completion so the async sync loop can detect success reliably.
+    parser.add_argument("--marker-file", default="")
     args = parser.parse_args()
 
     cfg = load_config(args.config)
-    repo_id = cfg.repo.repo_id
+    repo_id = args.repo_id or cfg.repo.repo_id
 
     # Route via ``build_pipeline`` so PHOTON / baseline providers both
     # receive a fully-wired pipeline and so evaluation runs observe
@@ -57,9 +64,18 @@ def main() -> None:
     print(f"questions: {len(questions)}")
     print()
 
-    output_path = (
-        Path(args.output) if args.output else Path(f"logs/{run_id}_predictions.jsonl")
-    )
+    # Issue #82 Wave 4: when ``--output`` is a .json path (used by the
+    # Streamlit eval runner) predictions land in a sibling .jsonl file so
+    # the .json path can carry the UI summary instead.  Classic CLI usage
+    # (no --output or .jsonl) keeps the pre-Wave-4 behaviour.
+    if args.output:
+        output_arg = Path(args.output)
+        if output_arg.suffix == ".json":
+            output_path = output_arg.with_suffix(".predictions.jsonl")
+        else:
+            output_path = output_arg
+    else:
+        output_path = Path(f"logs/{run_id}_predictions.jsonl")
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
     with open(output_path, "w", encoding="utf-8") as f:
@@ -93,6 +109,50 @@ def main() -> None:
 
     print(f"\nPredictions saved -> {output_path}")
     print(f"Run log -> logs/{run_id}.jsonl")
+
+    # Issue #82 Wave 4: when invoked with ``--output`` pointing at a JSON
+    # path (vs. the default JSONL predictions file), also emit a summary
+    # JSON with aggregated progress fields.  The async sync loop reads
+    # this JSON to populate ``EvalJob`` progress on success.
+    if args.output and args.output.endswith(".json"):
+        total_latencies: list[float] = []
+        total_no_cite = 0
+        total_q = 0
+        for line in output_path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            total_q += 1
+            lat = rec.get("latency_ms", 0.0)
+            if isinstance(lat, (int, float)):
+                total_latencies.append(float(lat))
+            if rec.get("no_citation"):
+                total_no_cite += 1
+        total_latencies.sort()
+        p50 = total_latencies[len(total_latencies) // 2] if total_latencies else 0.0
+        nc_rate = (total_no_cite / total_q) if total_q > 0 else 0.0
+        summary = {
+            "done_q": total_q,
+            "total_q": total_q,
+            "p50_latency_ms": p50,
+            "nc_rate": nc_rate,
+        }
+        Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.output).write_text(
+            json.dumps(summary, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        print(f"Summary -> {args.output}")
+
+    # Issue #82 Wave 4: touch marker_file on successful completion.
+    if args.marker_file:
+        marker = Path(args.marker_file)
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.touch()
+        print(f"Marker -> {marker}")
 
 
 if __name__ == "__main__":

--- a/scripts/run_multi_turn_eval.py
+++ b/scripts/run_multi_turn_eval.py
@@ -29,10 +29,17 @@ def main() -> None:
     parser.add_argument("--eval-set", default="data/eval_sets/multi_turn_eval.jsonl")
     parser.add_argument("--max-sessions", type=int, default=0)
     parser.add_argument("--output", default="")
+    # Issue #82 Wave 4: ``--repo-id`` lets the Streamlit eval runner
+    # override the repo_id (the default path only has cfg.repo.repo_id).
+    parser.add_argument("--repo-id", default="")
+    # Issue #82 Wave 4: when the Streamlit app invokes this script it
+    # passes a ``--marker-file`` path; we ``touch()`` it on successful
+    # completion so the async sync loop can detect success reliably.
+    parser.add_argument("--marker-file", default="")
     args = parser.parse_args()
 
     cfg = load_config(args.config)
-    repo_id = cfg.repo.repo_id
+    repo_id = args.repo_id or cfg.repo.repo_id
     run_id = f"mt_eval_{repo_id}_{time.strftime('%Y%m%d_%H%M%S')}"
 
     # Stage 3 DR3-001: route via build_pipeline so PHOTON / baseline
@@ -51,9 +58,19 @@ def main() -> None:
     print(f"sessions: {len(sessions)}")
     print()
 
-    output_path = (
-        Path(args.output) if args.output else Path(f"logs/{run_id}_predictions.jsonl")
-    )
+    # Issue #82 Wave 4: when ``--output`` is a .json path (used by the
+    # Streamlit eval runner) predictions land in a sibling .jsonl file so
+    # the .json path can carry the UI summary instead.  Classic CLI usage
+    # (no --output or .jsonl) keeps the pre-Wave-4 behaviour.
+    if args.output:
+        output_arg = Path(args.output)
+        if output_arg.suffix == ".json":
+            predictions_path = output_arg.with_suffix(".predictions.jsonl")
+        else:
+            predictions_path = output_arg
+    else:
+        predictions_path = Path(f"logs/{run_id}_predictions.jsonl")
+    output_path = predictions_path
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
     session_stats: list[dict] = []
@@ -129,6 +146,49 @@ def main() -> None:
     )
     print(f"\nPredictions -> {output_path}")
     print(f"Summary -> {summary_path}")
+
+    # Issue #82 Wave 4: when invoked with ``--output`` pointing at a JSON
+    # path, also emit the async-eval summary (done_q / total_q / p50 /
+    # nc_rate) to that path so the UI sync loop can read it on success.
+    if args.output and args.output.endswith(".json"):
+        total_latencies: list[float] = []
+        total_no_cite = 0
+        total_q = 0
+        for line in output_path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            total_q += 1
+            lat = rec.get("latency_ms", 0.0)
+            if isinstance(lat, (int, float)):
+                total_latencies.append(float(lat))
+            if rec.get("no_citation"):
+                total_no_cite += 1
+        total_latencies.sort()
+        p50 = total_latencies[len(total_latencies) // 2] if total_latencies else 0.0
+        nc_rate = (total_no_cite / total_q) if total_q > 0 else 0.0
+        ui_summary = {
+            "done_q": total_q,
+            "total_q": total_q,
+            "p50_latency_ms": p50,
+            "nc_rate": nc_rate,
+        }
+        Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.output).write_text(
+            json.dumps(ui_summary, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        print(f"UI summary -> {args.output}")
+
+    # Issue #82 Wave 4: touch marker_file on successful completion.
+    if args.marker_file:
+        marker = Path(args.marker_file)
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.touch()
+        print(f"Marker -> {marker}")
 
 
 if __name__ == "__main__":

--- a/tests/test_photon_app_components.py
+++ b/tests/test_photon_app_components.py
@@ -1,0 +1,790 @@
+"""Unit tests for ``app/components/`` (Issue #82 Wave 2).
+
+These tests pin the security invariants documented in the design
+policy §6.4–§6.5 and §8:
+
+* ``T-C-streamlit-absent``: every module in ``app/components/`` is
+  streamlit-free, even when imported into a fresh Python process.
+* ``T-C7``: ``_safe_id`` on project-name inputs rejects traversal,
+  metacharacters, and the empty string while accepting the allowlist.
+* ``T-C8``: YAML loading rejects ``!!python/object``-style injection
+  and the allowlist ``_assert_safe_yaml`` accepts normal trees.
+* ``T-C9``: ``sanitize_job_id`` / ``make_eval_paths`` constrain eval
+  artifacts to ``reports/eval_runs/`` and ``logs/eval/``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+COMPONENTS_DIR = PROJECT_ROOT / "app" / "components"
+
+
+def _load_component(mod_name: str, path: Path):
+    """Load ``app/components/<mod_name>.py`` under a private module name.
+
+    Using a direct file import avoids the namespace-package collision
+    with the ``app`` directory of neighbouring projects on ``sys.path``
+    (our test environment has another ``app`` under ``MySwiftAgent``).
+    """
+
+    full_name = f"_photon_components_{mod_name}"
+    if full_name in sys.modules:
+        return sys.modules[full_name]
+    spec = importlib.util.spec_from_file_location(full_name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[full_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+eval_panel = _load_component("eval_panel", COMPONENTS_DIR / "eval_panel.py")
+wizard = _load_component("wizard", COMPONENTS_DIR / "wizard.py")
+drift_panel = _load_component("drift_panel", COMPONENTS_DIR / "drift_panel.py")
+turn_history_panel = _load_component(
+    "turn_history_panel", COMPONENTS_DIR / "turn_history_panel.py"
+)
+
+
+# ---------------------------------------------------------------
+# T-C-streamlit-absent: components/ must not import streamlit at
+# module scope. Uses a fresh subprocess so the main test runner's
+# imports (which may pull in streamlit transitively via conftest)
+# cannot pollute the check.
+# ---------------------------------------------------------------
+
+
+class TestComponentsStreamlitAbsent:
+    """Guardrail: no module in ``app/components/`` may import streamlit."""
+
+    def test_subprocess_import_does_not_pull_streamlit(self) -> None:
+        # Import each component module by absolute file path to bypass any
+        # ``app``-named namespace collisions on the subprocess sys.path.
+        components_dir = str(COMPONENTS_DIR)
+        script = textwrap.dedent(
+            f"""
+            import importlib.util
+            import sys
+            from pathlib import Path
+            root = Path({components_dir!r})
+            for name in (
+                "__init__",
+                "eval_panel",
+                "wizard",
+                "drift_panel",
+                "turn_history_panel",
+            ):
+                spec = importlib.util.spec_from_file_location(
+                    f"_c_{{name}}", root / f"{{name}}.py"
+                )
+                assert spec and spec.loader
+                module = importlib.util.module_from_spec(spec)
+                sys.modules[spec.name] = module
+                spec.loader.exec_module(module)
+            leaked = sorted(m for m in sys.modules if m.startswith("streamlit"))
+            assert not leaked, leaked
+            """
+        )
+        # Run in a cold interpreter so we are not contaminated by fixtures.
+        proc = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert proc.returncode == 0, f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+
+
+# ---------------------------------------------------------------
+# T-C7: _safe_id on project_name
+# ---------------------------------------------------------------
+
+
+# Lazy-import app/photon_app.py without pulling streamlit for every
+# test in this module — only the _safe_id helper is needed.
+def _load_safe_id():
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "photon_app_for_components_test",
+        PROJECT_ROOT / "app" / "photon_app.py",
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module._safe_id
+
+
+_safe_id = _load_safe_id()
+
+
+class TestSafeIdProjectName:
+    """T-C7: project_name inputs rejected/accepted by _safe_id."""
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "../foo",
+            "foo bar",
+            "",
+            "foo/bar",
+            "foo\\bar",
+            "foo.bar",
+        ],
+    )
+    def test_rejects_bad_names(self, bad: str) -> None:
+        with pytest.raises(ValueError):
+            _safe_id(bad, label="project_name")
+
+    @pytest.mark.parametrize(
+        "good",
+        [
+            "valid",
+            "valid-name_01",
+            "ABC123",
+        ],
+    )
+    def test_accepts_allowlist_names(self, good: str) -> None:
+        assert _safe_id(good, label="project_name") == good
+
+
+# ---------------------------------------------------------------
+# T-C8: YAML safety
+# ---------------------------------------------------------------
+
+
+class TestAssertSafeYaml:
+    """T-C8: unsafe YAML is rejected by safe_load or _assert_safe_yaml."""
+
+    def test_python_object_apply_is_blocked(self) -> None:
+        """!!python/object/apply:os.system must not materialize a callable.
+
+        ``yaml.safe_load`` rejects the tag with a ConstructorError. If a
+        future PyYAML version silenced that error, the resulting tree
+        would still fail the allowlist check in ``_assert_safe_yaml``.
+        Either line of defense is acceptable for the security contract.
+        """
+
+        payload = "!!python/object/apply:os.system ['echo pwned']\n"
+        constructor_err = yaml.constructor.ConstructorError
+        try:
+            loaded = yaml.safe_load(payload)
+        except constructor_err:
+            return  # First line of defense held — done.
+        # Unlikely fall-through path: allowlist must catch it instead.
+        with pytest.raises(ValueError):
+            wizard._assert_safe_yaml(loaded)
+
+    def test_tuple_value_rejected_by_allowlist(self) -> None:
+        """Crafted dict with a tuple (non-allowed type) → ValueError."""
+
+        with pytest.raises(ValueError):
+            wizard._assert_safe_yaml({"foo": (1, 2, 3)})
+
+    def test_normal_nested_tree_is_accepted(self) -> None:
+        tree = {
+            "safe_recgen": {"enabled": True, "thresholds": [0.1, 0.2, 0.3]},
+            "session_memory": {
+                "working_memory": {
+                    "enabled": False,
+                    "max_turns": 8,
+                    "aggregation": "mean",
+                }
+            },
+            "retrieval": {"two_pass_search": None},
+        }
+        # Must not raise.
+        wizard._assert_safe_yaml(tree)
+
+    def test_bytes_value_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            wizard._assert_safe_yaml({"foo": b"bytes-not-allowed"})
+
+
+# ---------------------------------------------------------------
+# T-C9: sanitize_job_id + make_eval_paths
+# ---------------------------------------------------------------
+
+
+class TestSanitizeJobId:
+    def test_traversal_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            eval_panel.sanitize_job_id("../../etc/passwd")
+
+    def test_plain_hex_accepted(self) -> None:
+        assert eval_panel.sanitize_job_id("validhexabc123") == "validhexabc123"
+
+    def test_underscore_rejected(self) -> None:
+        # The stricter _SAFE_JOB_ID_RE disallows underscore so a tampered
+        # state file cannot smuggle in characters that would pass repo_id's
+        # broader allowlist.
+        with pytest.raises(ValueError):
+            eval_panel.sanitize_job_id("valid_hex_abc123")
+
+    def test_none_returns_uuid_hex(self) -> None:
+        job_id = eval_panel.sanitize_job_id()
+        assert len(job_id) == 32
+        assert all(c in "0123456789abcdef" for c in job_id)
+        # Two draws should differ with overwhelming probability.
+        assert job_id != eval_panel.sanitize_job_id()
+
+    def test_empty_string_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            eval_panel.sanitize_job_id("")
+
+
+class TestBuildEvalJobCmd:
+    """W4-T1: build_eval_job_cmd returns a shell=False argv list."""
+
+    def test_static_argv_shape(self, tmp_path: Path) -> None:
+        out_json = tmp_path / "reports" / "eval_runs" / "abc.json"
+        marker = tmp_path / "reports" / "eval_runs" / "abc.done"
+        argv = eval_panel.build_eval_job_cmd(
+            eval_type="static",
+            project_name="demo_proj",
+            repo_id="demo_repo",
+            config_path=str(tmp_path / "configs" / "photon_small.yaml"),
+            output_json=out_json,
+            marker_file=marker,
+            python_exec="/usr/bin/python3",
+        )
+        assert argv[0] == "/usr/bin/python3"
+        assert "-u" in argv
+        assert "-m" in argv
+        assert "scripts.run_baseline_eval" in argv
+        assert "--config" in argv
+        assert "--repo-id" in argv
+        assert "demo_repo" in argv
+        assert "--output" in argv
+        assert str(out_json) in argv
+        assert "--marker-file" in argv
+        assert str(marker) in argv
+
+    def test_multi_turn_uses_correct_module(self, tmp_path: Path) -> None:
+        out_json = tmp_path / "reports" / "eval_runs" / "abc.json"
+        marker = tmp_path / "reports" / "eval_runs" / "abc.done"
+        argv = eval_panel.build_eval_job_cmd(
+            eval_type="multi_turn",
+            project_name="demo",
+            repo_id="demo_repo",
+            config_path=str(tmp_path / "c.yaml"),
+            output_json=out_json,
+            marker_file=marker,
+        )
+        assert "scripts.run_multi_turn_eval" in argv
+
+    def test_unknown_eval_type_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError):
+            eval_panel.build_eval_job_cmd(
+                eval_type="nope",
+                project_name="demo",
+                repo_id="demo_repo",
+                config_path=str(tmp_path / "c.yaml"),
+                output_json=tmp_path / "a.json",
+                marker_file=tmp_path / "a.done",
+            )
+
+    def test_rejects_bad_project_name(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError):
+            eval_panel.build_eval_job_cmd(
+                eval_type="static",
+                project_name="foo bar",
+                repo_id="demo_repo",
+                config_path=str(tmp_path / "c.yaml"),
+                output_json=tmp_path / "a.json",
+                marker_file=tmp_path / "a.done",
+            )
+
+    def test_rejects_bad_repo_id(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError):
+            eval_panel.build_eval_job_cmd(
+                eval_type="static",
+                project_name="demo",
+                repo_id="../repo",
+                config_path=str(tmp_path / "c.yaml"),
+                output_json=tmp_path / "a.json",
+                marker_file=tmp_path / "a.done",
+            )
+
+
+class TestParseEvalProgress:
+    """W4-T1: parse_eval_progress extracts the latest PROGRESS line."""
+
+    def test_extracts_latest(self, tmp_path: Path) -> None:
+        log = tmp_path / "eval.log"
+        log.write_text(
+            "starting run\n"
+            "PROGRESS done=10 total=120 p50_ms=18000 nc=0.15\n"
+            "more output\n"
+            "PROGRESS done=25 total=120 p50_ms=19300 nc=0.183\n"
+            "trailing log line\n"
+        )
+        result = eval_panel.parse_eval_progress(log)
+        assert result["done_q"] == 25
+        assert result["total_q"] == 120
+        assert result["p50_latency_ms"] == 19300.0
+        assert result["nc_rate"] == 0.183
+
+    def test_empty_log_returns_empty_dict(self, tmp_path: Path) -> None:
+        log = tmp_path / "eval.log"
+        log.write_text("no progress here\n")
+        assert eval_panel.parse_eval_progress(log) == {}
+
+    def test_missing_file_returns_empty_dict(self, tmp_path: Path) -> None:
+        assert eval_panel.parse_eval_progress(tmp_path / "nope.log") == {}
+
+
+class TestTailLogBytes:
+    """W4-T1: tail_log_bytes returns the trailing max_bytes of a log file."""
+
+    def test_truncates_to_max_bytes(self, tmp_path: Path) -> None:
+        log = tmp_path / "big.log"
+        log.write_bytes(b"A" * 4096)
+        tail = eval_panel.tail_log_bytes(log, 2048)
+        assert len(tail) == 2048
+        assert tail == "A" * 2048
+
+    def test_short_file_returned_verbatim(self, tmp_path: Path) -> None:
+        log = tmp_path / "small.log"
+        log.write_text("oops\nfailed\n")
+        assert eval_panel.tail_log_bytes(log, 2048) == "oops\nfailed\n"
+
+    def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        assert eval_panel.tail_log_bytes(tmp_path / "nope.log", 2048) == ""
+
+
+class TestMakeEvalPaths:
+    def test_paths_under_allowed_dirs(self, tmp_path: Path) -> None:
+        result_json, log_file, marker_file = eval_panel.make_eval_paths(
+            "abc123", tmp_path
+        )
+        root = tmp_path.resolve()
+        assert result_json.is_relative_to(root / "reports" / "eval_runs")
+        assert log_file.is_relative_to(root / "logs" / "eval")
+        assert marker_file.is_relative_to(root / "reports" / "eval_runs")
+        # Concrete suffixes:
+        assert result_json.name == "abc123.json"
+        assert log_file.name == "abc123.log"
+        assert marker_file.name == "abc123.done"
+
+    def test_escape_via_bad_job_id_raises(self, tmp_path: Path) -> None:
+        # Defense-in-depth: make_eval_paths re-validates the job_id so a
+        # caller that forgot sanitize_job_id still cannot escape.
+        with pytest.raises(ValueError):
+            eval_panel.make_eval_paths("../x", tmp_path)
+
+    def test_uuid_roundtrip(self, tmp_path: Path) -> None:
+        job_id = eval_panel.sanitize_job_id()
+        result_json, log_file, marker_file = eval_panel.make_eval_paths(
+            job_id, tmp_path
+        )
+        # All three paths must live under project_root.
+        root = tmp_path.resolve()
+        for p in (result_json, log_file, marker_file):
+            assert p.is_relative_to(root)
+
+
+# ---------------------------------------------------------------
+# T-C1: classify_drift boundary conditions
+# T-C2 / T-C3: format_drift_panel behaviour
+# (Wave 3 — drift_panel.py)
+# ---------------------------------------------------------------
+
+
+class TestClassifyDrift:
+    """T-C1: classify_drift maps (value, threshold) -> 'ok'|'warn'|'alert'."""
+
+    def test_none_value_returns_ok(self) -> None:
+        assert drift_panel.classify_drift(None, 0.5) == "ok"
+
+    def test_none_threshold_returns_ok(self) -> None:
+        assert drift_panel.classify_drift(0.3, None) == "ok"
+
+    def test_below_warn_band_returns_ok(self) -> None:
+        # 0.3 / 0.5 = 0.6 → below 80% band
+        assert drift_panel.classify_drift(0.3, 0.5) == "ok"
+
+    def test_in_warn_band_returns_warn(self) -> None:
+        # 0.41 / 0.5 = 0.82 → above 80% band, below threshold
+        assert drift_panel.classify_drift(0.41, 0.5) == "warn"
+
+    def test_above_threshold_returns_alert(self) -> None:
+        assert drift_panel.classify_drift(0.6, 0.5) == "alert"
+
+
+class TestFormatDriftPanel:
+    """T-C2 / T-C3: format_drift_panel derives rows from DriftMetrics dict."""
+
+    def test_none_metrics_marks_unavailable(self) -> None:
+        result = drift_panel.format_drift_panel(
+            None,
+            {
+                "token_level": None,
+                "mid_level": None,
+                "top_level": 0.5,
+                "topic_shift": 0.65,
+            },
+        )
+        assert result["available"] is False
+        assert "N/A" in result["reason"]
+        assert result["rows"] == []
+        assert result["safe_recgen_fired"] is False
+
+    def test_empty_metrics_marks_unavailable(self) -> None:
+        result = drift_panel.format_drift_panel(
+            {},
+            {
+                "token_level": None,
+                "mid_level": None,
+                "top_level": 0.5,
+                "topic_shift": 0.65,
+            },
+        )
+        assert result["available"] is False
+
+    def test_full_metrics_produce_ordered_rows(self) -> None:
+        dm = {
+            "latent_cosine_drift_token": 0.1,
+            "latent_cosine_drift_mid": 0.3,
+            "latent_cosine_drift_top": 0.52,
+            "topic_shift_score": 0.66,
+        }
+        th = {
+            "token_level": None,
+            "mid_level": None,
+            "top_level": 0.50,
+            "topic_shift": 0.65,
+        }
+        result = drift_panel.format_drift_panel(dm, th)
+        assert result["available"] is True
+        assert len(result["rows"]) == 4
+        assert [r["name"] for r in result["rows"]] == [
+            "token_level",
+            "mid_level",
+            "top_level",
+            "topic_shift",
+        ]
+        # Top-level level: 0.52 > 0.50 → alert
+        assert result["rows"][2]["level"] == "alert"
+        # Topic shift: 0.66 > 0.65 → alert
+        assert result["rows"][3]["level"] == "alert"
+        assert result["rows"][2]["badge"] == "⚠"
+        # Token and mid have no threshold → ok regardless of value
+        assert result["rows"][0]["level"] == "ok"
+        assert result["rows"][1]["level"] == "ok"
+        assert result["rows"][0]["value_str"] == "0.10"
+        assert result["rows"][1]["value_str"] == "0.30"
+
+    def test_missing_key_yields_em_dash(self) -> None:
+        dm = {
+            "latent_cosine_drift_token": 0.1,
+            "latent_cosine_drift_mid": 0.3,
+            "latent_cosine_drift_top": 0.52,
+            # topic_shift_score deliberately omitted
+        }
+        th = {
+            "token_level": None,
+            "mid_level": None,
+            "top_level": 0.50,
+            "topic_shift": 0.65,
+        }
+        result = drift_panel.format_drift_panel(dm, th)
+        assert result["available"] is True
+        topic_row = result["rows"][3]
+        assert topic_row["name"] == "topic_shift"
+        assert topic_row["value"] is None
+        assert topic_row["value_str"] == "—"
+        assert topic_row["level"] == "ok"
+        assert topic_row["badge"] == ""
+
+    def test_safe_recgen_fired_propagates(self) -> None:
+        dm = {
+            "latent_cosine_drift_token": 0.0,
+            "latent_cosine_drift_mid": 0.0,
+            "latent_cosine_drift_top": 0.0,
+            "topic_shift_score": 0.0,
+            "safe_recgen_fired": True,
+        }
+        th = {
+            "token_level": None,
+            "mid_level": None,
+            "top_level": None,
+            "topic_shift": None,
+        }
+        result = drift_panel.format_drift_panel(dm, th)
+        assert result["safe_recgen_fired"] is True
+
+
+# ---------------------------------------------------------------
+# T-C4: format_turn_history_panel
+# (Wave 3 — turn_history_panel.py)
+# ---------------------------------------------------------------
+
+
+class TestFormatTurnHistoryPanel:
+    """T-C4: turn_history_panel joins PhotonSessionState + SessionManager."""
+
+    def test_working_memory_disabled_marks_unavailable(self) -> None:
+        result = turn_history_panel.format_turn_history_panel(
+            None,
+            None,
+            working_memory_enabled=False,
+            max_turns=8,
+        )
+        assert result["available"] is False
+        assert "working_memory disabled" in result["reason"]
+        assert result["rows"] == []
+
+    def test_baseline_rag_marks_unavailable(self) -> None:
+        result = turn_history_panel.format_turn_history_panel(
+            None,
+            [],
+            working_memory_enabled=True,
+            max_turns=8,
+        )
+        assert result["available"] is False
+        assert "baseline_rag" in result["reason"]
+
+    def test_max_turns_truncates_to_last_n(self) -> None:
+        from types import SimpleNamespace
+
+        ph_list = [
+            SimpleNamespace(turn_id=i, question_text=f"q{i}", timestamp=f"t{i}")
+            for i in range(10)
+        ]
+        result = turn_history_panel.format_turn_history_panel(
+            ph_list,
+            [],
+            working_memory_enabled=True,
+            max_turns=3,
+        )
+        assert result["available"] is True
+        assert len(result["rows"]) == 3
+        assert [r.turn_id for r in result["rows"]] == [7, 8, 9]
+        assert result["rows"][0].question_text == "q7"
+
+    def test_join_by_turn_id_fills_cited_chunks(self) -> None:
+        from types import SimpleNamespace
+
+        ph_list = [
+            SimpleNamespace(turn_id=1, question_text="q1", timestamp="t1"),
+            SimpleNamespace(turn_id=2, question_text="q2", timestamp="t2"),
+            SimpleNamespace(turn_id=3, question_text="q3", timestamp="t3"),
+        ]
+        sm_turns = [
+            SimpleNamespace(turn_id=1, cited_chunk_ids=["C:1"]),
+            # turn 2 deliberately missing
+            SimpleNamespace(turn_id=3, cited_chunk_ids=["C:5"]),
+        ]
+        result = turn_history_panel.format_turn_history_panel(
+            ph_list,
+            sm_turns,
+            working_memory_enabled=True,
+            max_turns=8,
+        )
+        assert result["available"] is True
+        assert len(result["rows"]) == 3
+        assert result["rows"][0].cited_chunk_ids == ["C:1"]
+        assert result["rows"][1].cited_chunk_ids == []
+        assert result["rows"][2].cited_chunk_ids == ["C:5"]
+
+    def test_empty_history_is_available_empty_rows(self) -> None:
+        result = turn_history_panel.format_turn_history_panel(
+            [],
+            [],
+            working_memory_enabled=True,
+            max_turns=8,
+        )
+        assert result["available"] is True
+        assert result["reason"] == ""
+        assert result["rows"] == []
+
+
+# ---------------------------------------------------------------
+# T-C5: apply_best_practice (Wave 5 — wizard.py)
+# ---------------------------------------------------------------
+
+
+class TestApplyBestPractice:
+    """T-C5: apply_best_practice merges 5 keys with profile-aware warnings."""
+
+    def test_photon_small_no_changes(self) -> None:
+        # photon_small already has all 5 best-practice values → no warnings
+        yaml_text = (
+            "inference:\n"
+            "  photon_generation_enabled: false\n"
+            "retrieval:\n"
+            "  two_pass_search:\n"
+            "    enabled: false\n"
+            "session_memory:\n"
+            "  working_memory:\n"
+            "    enabled: true\n"
+            "safe_recgen:\n"
+            "  enabled: true\n"
+            "generation:\n"
+            "  evidence_pruning_enabled: true\n"
+        )
+        _new_text, warnings = wizard.apply_best_practice(yaml_text, "photon_small")
+        assert warnings == []
+
+    def test_photon_long_context_creates_missing_two_pass_section(self) -> None:
+        yaml_text = (
+            "inference:\n"
+            "  photon_generation_enabled: false\n"
+            "session_memory:\n"
+            "  working_memory:\n"
+            "    enabled: true\n"
+            "safe_recgen:\n"
+            "  enabled: true\n"
+            "generation:\n"
+            "  evidence_pruning_enabled: true\n"
+        )
+        new_text, warnings = wizard.apply_best_practice(
+            yaml_text, "photon_long_context"
+        )
+        assert any("retrieval.two_pass_search.enabled" in w for w in warnings)
+        loaded = yaml.safe_load(new_text)
+        assert loaded["retrieval"]["two_pass_search"]["enabled"] is False
+
+    def test_photon_tiny_recgen_warns_on_conflict(self) -> None:
+        # photon_tiny_recgen has photon_generation_enabled: true (intentional)
+        # and working_memory deliberately omitted.
+        yaml_text = (
+            "inference:\n"
+            "  photon_generation_enabled: true\n"
+            "retrieval:\n"
+            "  two_pass_search:\n"
+            "    enabled: false\n"
+            "safe_recgen:\n"
+            "  enabled: true\n"
+            "generation:\n"
+            "  evidence_pruning_enabled: true\n"
+        )
+        new_text, warnings = wizard.apply_best_practice(yaml_text, "photon_tiny_recgen")
+        # Expect conflict warning for photon_generation_enabled (was True,
+        # target False, profile is intentional-conflict) and an additive
+        # warning for the missing working_memory.enabled path.
+        assert any("photon_generation_enabled" in w for w in warnings)
+        assert any("session_memory.working_memory.enabled" in w for w in warnings)
+        loaded = yaml.safe_load(new_text)
+        assert loaded["inference"]["photon_generation_enabled"] is False
+        assert loaded["session_memory"]["working_memory"]["enabled"] is True
+
+    def test_non_mapping_raises(self) -> None:
+        with pytest.raises(ValueError):
+            wizard.apply_best_practice("- a\n- b\n", "photon_small")
+
+    def test_round_trip_preserves_other_keys(self) -> None:
+        yaml_text = (
+            "version: 1\n"
+            "project:\n"
+            "  name: demo\n"
+            "safe_recgen:\n"
+            "  enabled: true\n"
+            "generation:\n"
+            "  evidence_pruning_enabled: true\n"
+            "session_memory:\n"
+            "  working_memory:\n"
+            "    enabled: true\n"
+            "inference:\n"
+            "  photon_generation_enabled: false\n"
+            "retrieval:\n"
+            "  two_pass_search:\n"
+            "    enabled: false\n"
+        )
+        new_text, _warnings = wizard.apply_best_practice(yaml_text, "photon_small")
+        loaded = yaml.safe_load(new_text)
+        assert loaded["version"] == 1
+        assert loaded["project"]["name"] == "demo"
+
+
+# ---------------------------------------------------------------
+# T-C6: generate_yaml_from_wizard (Wave 5 — wizard.py)
+# ---------------------------------------------------------------
+
+
+class TestGenerateYamlFromWizard:
+    """T-C6: generate_yaml_from_wizard applies toggles + validates fallback."""
+
+    def test_invalid_fallback_policy_raises(self) -> None:
+        with pytest.raises(ValueError, match="fallback_policy"):
+            wizard.generate_yaml_from_wizard(
+                "photon_small",
+                {"fallback_policy": "invalid"},
+                base_yaml_text="model: {}\n",
+            )
+
+    def test_accepts_qwen_and_abort(self) -> None:
+        for policy in ("qwen", "abort"):
+            result = wizard.generate_yaml_from_wizard(
+                "photon_small",
+                {"fallback_policy": policy},
+                base_yaml_text="model: {}\n",
+            )
+            loaded = yaml.safe_load(result)
+            assert loaded["inference"]["generation_fallback_policy"] == policy
+
+    def test_applies_toggles_to_base(self) -> None:
+        base = "model:\n  architecture: photon_decoder\n"
+        result = wizard.generate_yaml_from_wizard(
+            "photon_small",
+            {
+                "recgen_enabled": True,
+                "two_pass_search_enabled": True,
+                "two_pass_pass1_top_k": 32,
+            },
+            base_yaml_text=base,
+        )
+        loaded = yaml.safe_load(result)
+        assert loaded["inference"]["photon_generation_enabled"] is True
+        assert loaded["retrieval"]["two_pass_search"]["enabled"] is True
+        assert loaded["retrieval"]["two_pass_search"]["pass1_top_k"] == 32
+        # base key preserved
+        assert loaded["model"]["architecture"] == "photon_decoder"
+
+    def test_working_memory_toggles_all_applied(self) -> None:
+        result = wizard.generate_yaml_from_wizard(
+            "photon_small",
+            {
+                "working_memory_enabled": True,
+                "working_memory_max_turns": 12,
+                "working_memory_aggregation": "attention",
+                "working_memory_storage_mode": "top_level_only",
+                "past_turn_pinning_enabled": True,
+            },
+            base_yaml_text="model: {}\n",
+        )
+        loaded = yaml.safe_load(result)
+        wm = loaded["session_memory"]["working_memory"]
+        assert wm["enabled"] is True
+        assert wm["max_turns"] == 12
+        assert wm["aggregation"] == "attention"
+        assert wm["storage_mode"] == "top_level_only"
+        assert wm["past_turn_pinning_enabled"] is True
+
+    def test_ignores_unknown_toggles(self) -> None:
+        # Unknown keys must not raise so the UI can feed a full form dict.
+        result = wizard.generate_yaml_from_wizard(
+            "photon_small",
+            {"recgen_enabled": True, "ignored_extra": "whatever"},
+            base_yaml_text="model: {}\n",
+        )
+        loaded = yaml.safe_load(result)
+        assert loaded["inference"]["photon_generation_enabled"] is True
+        assert "ignored_extra" not in loaded
+
+
+if __name__ == "__main__":  # pragma: no cover - manual run only
+    import pytest as _pytest
+
+    raise SystemExit(_pytest.main([__file__, "-v"]))

--- a/tests/test_photon_app_eval_jobs.py
+++ b/tests/test_photon_app_eval_jobs.py
@@ -1,0 +1,445 @@
+"""Tests for app/photon_app.py EvalJob + AppState.eval_jobs (Issue #82 Wave 1).
+
+These tests pin the new EvalJob dataclass, the AppState.eval_jobs mapping,
+and the _load_state / _save_state round-trip behaviour so that legacy state
+files (4-key shape) can be rehydrated without loss and always serialise back
+as 5-key JSON including ``eval_jobs: {}``.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "app"))
+
+import photon_app  # noqa: E402
+
+
+class TestEvalJobDataclass(unittest.TestCase):
+    def test_eval_job_defaults(self) -> None:
+        job = photon_app.EvalJob()
+        self.assertEqual(job.job_id, "")
+        self.assertEqual(job.project_name, "")
+        self.assertEqual(job.eval_type, "")
+        self.assertEqual(job.status, "pending")
+        self.assertEqual(job.pid, None)
+        self.assertEqual(job.done_q, 0)
+        self.assertEqual(job.total_q, 0)
+        self.assertEqual(job.p50_latency_ms, 0.0)
+        self.assertEqual(job.nc_rate, 0.0)
+        self.assertEqual(job.error_message, "")
+
+    def test_is_terminal_true_for_succeeded(self) -> None:
+        self.assertTrue(photon_app.EvalJob(status="succeeded").is_terminal)
+
+    def test_is_terminal_true_for_failed(self) -> None:
+        self.assertTrue(photon_app.EvalJob(status="failed").is_terminal)
+
+    def test_is_terminal_false_for_running(self) -> None:
+        self.assertFalse(photon_app.EvalJob(status="running").is_terminal)
+
+    def test_is_terminal_false_for_pending(self) -> None:
+        self.assertFalse(photon_app.EvalJob(status="pending").is_terminal)
+
+
+class TestFilterKnownFieldsForEvalJob(unittest.TestCase):
+    """T-E3: _filter_known_fields drops unknown keys for EvalJob."""
+
+    def test_drops_unknown_keeps_known(self) -> None:
+        raw = {
+            "job_id": "abc",
+            "project_name": "demo",
+            "status": "running",
+            "unknown_key_1": 123,
+            "another_unknown": "x",
+        }
+        filtered = photon_app._filter_known_fields(photon_app.EvalJob, raw)
+        self.assertIn("job_id", filtered)
+        self.assertIn("project_name", filtered)
+        self.assertIn("status", filtered)
+        self.assertNotIn("unknown_key_1", filtered)
+        self.assertNotIn("another_unknown", filtered)
+        self.assertEqual(filtered["job_id"], "abc")
+
+
+class TestLoadStateMissingEvalJobsKey(unittest.TestCase):
+    """T-E1: a legacy 4-key state file round-trips to a 5-key file."""
+
+    def test_load_then_save_emits_five_keys(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            state_file = Path(td) / "state.json"
+            # 4-key legacy shape (no ``eval_jobs`` field).
+            state_file.write_text(
+                json.dumps(
+                    {
+                        "training_jobs": {},
+                        "index_jobs": {},
+                        "projects": {},
+                        "chat_histories": {},
+                    }
+                )
+            )
+
+            with patch.object(photon_app, "STATE_FILE", state_file):
+                state = photon_app._load_state()
+                # New field defaults to empty dict.
+                self.assertEqual(state.eval_jobs, {})
+                photon_app._save_state(state)
+                data = json.loads(state_file.read_text())
+
+        self.assertEqual(
+            set(data.keys()),
+            {
+                "training_jobs",
+                "index_jobs",
+                "projects",
+                "chat_histories",
+                "eval_jobs",
+            },
+        )
+        self.assertEqual(data["eval_jobs"], {})
+
+
+class TestSaveLoadRoundtripEvalJobs(unittest.TestCase):
+    """T-E2: 2-entry EvalJob dict survives save → load unchanged."""
+
+    def test_roundtrip_preserves_two_entries(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            state_file = Path(td) / "state.json"
+
+            # Wave 2 (W2-T4): _load_state now enforces that eval_job paths
+            # live under PROJECT_ROOT, so the round-trip fixture must use
+            # paths inside the repo. Files do not need to actually exist.
+            log_file = str(photon_app.PROJECT_ROOT / "logs" / "eval" / "j1.log")
+            result_json = str(
+                photon_app.PROJECT_ROOT / "reports" / "eval_runs" / "j1.json"
+            )
+            marker_file = str(
+                photon_app.PROJECT_ROOT / "reports" / "eval_runs" / "j1.done"
+            )
+
+            original = photon_app.AppState()
+            original.eval_jobs["j1"] = photon_app.EvalJob(
+                job_id="j1",
+                project_name="demo",
+                eval_type="static",
+                status="succeeded",
+                started_at="2026-04-20T10:00:00",
+                started_at_epoch=1_700_000_000.0,
+                finished_at="2026-04-20T10:05:00",
+                pid=4321,
+                log_file=log_file,
+                result_json=result_json,
+                marker_file=marker_file,
+                done_q=30,
+                total_q=30,
+                p50_latency_ms=1234.5,
+                nc_rate=0.1,
+            )
+            original.eval_jobs["j2"] = photon_app.EvalJob(
+                job_id="j2",
+                project_name="demo",
+                eval_type="multi_turn",
+                status="failed",
+                error_message="timeout",
+            )
+
+            with patch.object(photon_app, "STATE_FILE", state_file):
+                photon_app._save_state(original)
+                reloaded = photon_app._load_state()
+
+        self.assertEqual(set(reloaded.eval_jobs), {"j1", "j2"})
+        self.assertEqual(reloaded.eval_jobs["j1"].status, "succeeded")
+        self.assertEqual(reloaded.eval_jobs["j1"].done_q, 30)
+        self.assertAlmostEqual(reloaded.eval_jobs["j1"].p50_latency_ms, 1234.5)
+        self.assertAlmostEqual(reloaded.eval_jobs["j1"].nc_rate, 0.1)
+        self.assertEqual(reloaded.eval_jobs["j1"].marker_file, marker_file)
+        self.assertEqual(reloaded.eval_jobs["j2"].status, "failed")
+        self.assertEqual(reloaded.eval_jobs["j2"].error_message, "timeout")
+
+
+class TestStateTamperingDetection(unittest.TestCase):
+    """T-E7 (Issue #82 Wave 2): ``_load_state`` rejects tampered eval_jobs.
+
+    The integrity checks added by W2-T4 / D4-004 cover three classes of
+    tamper:
+        1. ``log_file`` / ``result_json`` / ``marker_file`` pointing
+           outside ``PROJECT_ROOT``
+        2. ``status`` set to an unknown value
+        3. ``pid`` stored as a non-int (e.g. a string)
+
+    Each case should produce either ``status='failed'`` with an
+    ``error_message`` mentioning ``tampering`` (for path escapes) or a
+    silent normalization (for pid / status).
+    """
+
+    def _write_state(self, state_dir: Path, job_dict: dict) -> Path:
+        state_file = state_dir / "state.json"
+        state_file.write_text(
+            json.dumps(
+                {
+                    "training_jobs": {},
+                    "index_jobs": {},
+                    "projects": {},
+                    "chat_histories": {},
+                    "eval_jobs": {"j1": job_dict},
+                }
+            )
+        )
+        return state_file
+
+    def test_tampered_log_file_escapes_project_root(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            state_file = self._write_state(
+                Path(td),
+                {
+                    "job_id": "j1",
+                    "project_name": "demo",
+                    "eval_type": "static",
+                    "status": "running",
+                    "log_file": "/etc/passwd",
+                },
+            )
+            with patch.object(photon_app, "STATE_FILE", state_file):
+                state = photon_app._load_state()
+
+        job = state.eval_jobs["j1"]
+        self.assertEqual(job.status, "failed")
+        self.assertIn("tampering", job.error_message)
+
+    def test_tampered_result_json_escapes_project_root(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            state_file = self._write_state(
+                Path(td),
+                {
+                    "job_id": "j1",
+                    "project_name": "demo",
+                    "eval_type": "static",
+                    "status": "running",
+                    "result_json": "/tmp/../etc/passwd",
+                },
+            )
+            with patch.object(photon_app, "STATE_FILE", state_file):
+                state = photon_app._load_state()
+
+        job = state.eval_jobs["j1"]
+        self.assertEqual(job.status, "failed")
+        self.assertIn("tampering", job.error_message)
+
+    def test_unknown_status_normalized_to_failed(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            state_file = self._write_state(
+                Path(td),
+                {
+                    "job_id": "j1",
+                    "project_name": "demo",
+                    "eval_type": "static",
+                    "status": "hacked",
+                },
+            )
+            with patch.object(photon_app, "STATE_FILE", state_file):
+                state = photon_app._load_state()
+
+        self.assertEqual(state.eval_jobs["j1"].status, "failed")
+
+    def test_non_int_pid_reset_to_none(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            state_file = self._write_state(
+                Path(td),
+                {
+                    "job_id": "j1",
+                    "project_name": "demo",
+                    "eval_type": "static",
+                    "status": "running",
+                    "pid": "not-an-int",
+                },
+            )
+            with patch.object(photon_app, "STATE_FILE", state_file):
+                state = photon_app._load_state()
+
+        self.assertIsNone(state.eval_jobs["j1"].pid)
+        # Status must remain valid (still ``running`` because path
+        # validation passed and the pid was merely normalized, not the
+        # trigger for a failed state).
+        self.assertEqual(state.eval_jobs["j1"].status, "running")
+
+    def test_paths_inside_project_root_accepted(self) -> None:
+        """Valid paths under PROJECT_ROOT must survive untouched."""
+
+        with tempfile.TemporaryDirectory() as td:
+            valid_log = photon_app.PROJECT_ROOT / "logs" / "eval" / "ok.log"
+            valid_marker = photon_app.PROJECT_ROOT / "reports" / "eval_runs" / "ok.done"
+            state_file = self._write_state(
+                Path(td),
+                {
+                    "job_id": "j1",
+                    "project_name": "demo",
+                    "eval_type": "static",
+                    "status": "running",
+                    "pid": 4321,
+                    "log_file": str(valid_log),
+                    "marker_file": str(valid_marker),
+                },
+            )
+            with patch.object(photon_app, "STATE_FILE", state_file):
+                state = photon_app._load_state()
+
+        job = state.eval_jobs["j1"]
+        self.assertEqual(job.status, "running")
+        self.assertEqual(job.pid, 4321)
+        self.assertEqual(job.log_file, str(valid_log))
+        self.assertEqual(job.marker_file, str(valid_marker))
+        self.assertEqual(job.error_message, "")
+
+
+class TestSyncEvalJob(unittest.TestCase):
+    """W4-T2: _sync_eval_job transitions status from marker_file / timeout / dead pid."""
+
+    def _make_job(self, **overrides) -> "photon_app.EvalJob":
+        defaults = dict(
+            job_id="j1",
+            project_name="demo",
+            eval_type="static",
+            status="running",
+            started_at="2026-04-20T10:00:00",
+            started_at_epoch=1_000_000.0,
+            pid=9999,
+            log_file="",
+            result_json="",
+            marker_file="",
+        )
+        defaults.update(overrides)
+        return photon_app.EvalJob(**defaults)
+
+    def test_marker_file_transitions_to_succeeded(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            marker = Path(td) / "j1.done"
+            marker.touch()
+            result_json = Path(td) / "j1.json"
+            result_json.write_text(
+                json.dumps(
+                    {
+                        "done_q": 120,
+                        "total_q": 120,
+                        "p50_latency_ms": 19400.5,
+                        "nc_rate": 0.183,
+                    }
+                )
+            )
+            job = self._make_job(
+                marker_file=str(marker),
+                result_json=str(result_json),
+            )
+            changed = photon_app._sync_eval_job(job, now_epoch=1_000_100.0)
+
+        self.assertTrue(changed)
+        self.assertEqual(job.status, "succeeded")
+        self.assertEqual(job.done_q, 120)
+        self.assertEqual(job.total_q, 120)
+        self.assertAlmostEqual(job.p50_latency_ms, 19400.5)
+        self.assertAlmostEqual(job.nc_rate, 0.183)
+        self.assertNotEqual(job.finished_at, "")
+
+    def test_timeout_marks_failed(self) -> None:
+        job = self._make_job(
+            started_at_epoch=1_000_000.0,
+        )
+        # now is far past the timeout (3600s).
+        with patch.object(photon_app, "_is_process_running", return_value=False):
+            changed = photon_app._sync_eval_job(job, now_epoch=1_000_000.0 + 7200.0)
+
+        self.assertTrue(changed)
+        self.assertEqual(job.status, "failed")
+        self.assertIn("timeout", job.error_message)
+
+    def test_dead_process_no_marker_marks_failed(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            log = Path(td) / "j1.log"
+            log.write_text("traceback: runtime error\n")
+            # No marker file.
+            job = self._make_job(
+                log_file=str(log),
+                started_at_epoch=1_000_000.0,
+            )
+            with patch.object(photon_app, "_is_process_running", return_value=False):
+                changed = photon_app._sync_eval_job(job, now_epoch=1_000_010.0)
+
+        self.assertTrue(changed)
+        self.assertEqual(job.status, "failed")
+        # error_message should contain tail of log.
+        self.assertIn("traceback", job.error_message)
+
+    def test_running_with_progress_updates(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            log = Path(td) / "j1.log"
+            log.write_text(
+                "starting\nPROGRESS done=30 total=120 p50_ms=19500 nc=0.15\n"
+            )
+            job = self._make_job(
+                log_file=str(log),
+                started_at_epoch=1_000_000.0,
+            )
+            with patch.object(photon_app, "_is_process_running", return_value=True):
+                changed = photon_app._sync_eval_job(job, now_epoch=1_000_050.0)
+
+        self.assertTrue(changed)
+        self.assertEqual(job.status, "running")
+        self.assertEqual(job.done_q, 30)
+        self.assertEqual(job.total_q, 120)
+        self.assertAlmostEqual(job.p50_latency_ms, 19500.0)
+        self.assertAlmostEqual(job.nc_rate, 0.15)
+
+    def test_running_no_progress_no_change(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            log = Path(td) / "j1.log"
+            log.write_text("starting\n")
+            job = self._make_job(
+                log_file=str(log),
+                started_at_epoch=1_000_000.0,
+            )
+            with patch.object(photon_app, "_is_process_running", return_value=True):
+                changed = photon_app._sync_eval_job(job, now_epoch=1_000_050.0)
+
+        self.assertFalse(changed)
+        self.assertEqual(job.status, "running")
+
+    def test_terminal_job_is_not_reprocessed(self) -> None:
+        job = self._make_job(status="succeeded", done_q=120, total_q=120)
+        changed = photon_app._sync_eval_job(job, now_epoch=1_000_050.0)
+        self.assertFalse(changed)
+        self.assertEqual(job.status, "succeeded")
+
+    def test_sync_all_jobs_iterates_eval_jobs(self) -> None:
+        """_sync_all_jobs must also reconcile eval_jobs."""
+        with tempfile.TemporaryDirectory() as td:
+            marker = Path(td) / "j1.done"
+            marker.touch()
+            result_json = Path(td) / "j1.json"
+            result_json.write_text(
+                json.dumps(
+                    {
+                        "done_q": 10,
+                        "total_q": 10,
+                        "p50_latency_ms": 100.0,
+                        "nc_rate": 0.0,
+                    }
+                )
+            )
+            state = photon_app.AppState()
+            state.eval_jobs["j1"] = self._make_job(
+                marker_file=str(marker),
+                result_json=str(result_json),
+            )
+            changed = photon_app._sync_all_jobs(state)
+
+        self.assertTrue(changed)
+        self.assertEqual(state.eval_jobs["j1"].status, "succeeded")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_photon_app_helpers.py
+++ b/tests/test_photon_app_helpers.py
@@ -10,6 +10,8 @@ import importlib.util
 import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -99,33 +101,59 @@ class TestSafeId:
 
 
 class TestPageIndexNoShellTrue:
-    """Guardrail: no `shell=True` should remain in photon_app.py.
+    """Guardrail: no `shell=True` should remain in photon_app.py or eval_panel.py.
 
     This is a smoke-style regression test rather than a full UI test, since
     the goal is to prevent future regressions that reintroduce shell=True in
-    ANY subprocess spawn inside the app module.
+    ANY subprocess spawn inside the app module or its eval-runner helpers.
+    Wave 4 (W4-T1, T-E6) extended the scan to ``app/components/eval_panel.py``
+    so the new subprocess orchestration helpers are also covered.
     """
 
-    def test_source_has_no_shell_true(self) -> None:
-        src = PHOTON_APP_PATH.read_text(encoding="utf-8")
-        # Strip single-line Python comments so a comment-level mention of
-        # shell=True wouldn't fail the guardrail. Adequate for this file's
-        # coding style (no multi-line strings contain the literal).
+    @staticmethod
+    def _strip_comments_and_module_docstring(src: str) -> str:
         code_lines = [
             line for line in src.splitlines() if not line.lstrip().startswith("#")
         ]
-        # Strip the module docstring too (a triple-quoted block at the top)
-        # to keep the check focused on actual executable code.
         joined = "\n".join(code_lines)
-        # Quick and simple: remove the first triple-double-quoted block if
-        # it starts at the very beginning of the file.
         if joined.startswith('"""'):
             end = joined.find('"""', 3)
             if end >= 0:
                 joined = joined[end + 3 :]
+        return joined
+
+    def test_source_has_no_shell_true(self) -> None:
+        src = PHOTON_APP_PATH.read_text(encoding="utf-8")
+        joined = self._strip_comments_and_module_docstring(src)
         assert "shell=True" not in joined, (
             "shell=True must not appear in app/photon_app.py — use argv list + shell=False"
         )
+
+    def test_eval_panel_has_no_shell_true(self) -> None:
+        eval_panel_path = PROJECT_ROOT / "app" / "components" / "eval_panel.py"
+        assert eval_panel_path.exists(), f"missing {eval_panel_path}"
+        src = eval_panel_path.read_text(encoding="utf-8")
+        # AST-based check: reject any keyword literal ``shell=True`` passed
+        # to any call expression.  This is stricter than a plain-text scan
+        # because it ignores docstrings / comments that legitimately
+        # mention the token (e.g. warnings in the function docstring) and
+        # catches whitespace variations like ``shell = True``.
+        import ast
+
+        tree = ast.parse(src)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            for kw in node.keywords:
+                if (
+                    kw.arg == "shell"
+                    and isinstance(kw.value, ast.Constant)
+                    and kw.value.value is True
+                ):
+                    raise AssertionError(
+                        "shell=True literal found in app/components/eval_panel.py "
+                        f"at line {node.lineno}"
+                    )
 
 
 class TestSubprocessImportAvailable:
@@ -135,3 +163,112 @@ class TestSubprocessImportAvailable:
         assert subprocess.Popen  # sanity
         src = PHOTON_APP_PATH.read_text(encoding="utf-8")
         assert "import subprocess" in src
+
+
+# ---------------------------------------------------------------
+# Issue #82 Wave 1 (W1-T1): _run_query routes through build_pipeline(cfg)
+# ---------------------------------------------------------------
+
+
+def _make_proj(tmp_path: Path, name: str = "demo") -> "photon_app.Project":
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text("model:\n  provider: baseline\n")
+    return photon_app.Project(
+        name=name,
+        repo_id="demo_repo",
+        index_dir=str(tmp_path / "idx"),
+        config_path=str(cfg_path),
+        photon_config_path="",
+        checkpoint_dir="",
+        use_photon=False,
+        created_at="2026-04-20T00:00:00",
+    )
+
+
+class _FakeSessionState(dict):
+    """Minimal stand-in for ``streamlit.session_state``.
+
+    Supports both ``obj["k"]`` and ``obj.k`` access so code that mixes the
+    two (as photon_app does) keeps working under test.
+    """
+
+    def __getattr__(self, key: str):
+        try:
+            return self[key]
+        except KeyError as exc:
+            raise AttributeError(key) from exc
+
+    def __setattr__(self, key: str, value) -> None:
+        self[key] = value
+
+
+class TestRunQueryUsesBuildPipeline:
+    """W1-T1: _run_query must go through baseline_reporag.pipeline_factory."""
+
+    def test_run_query_uses_build_pipeline(self, tmp_path: Path) -> None:
+        proj = _make_proj(tmp_path)
+
+        # Fake QueryResult returned by the mocked pipeline.
+        result = SimpleNamespace(
+            answer="hello",
+            session_id="s1",
+            turn_id=1,
+            cited_chunk_ids=["c1"],
+            wrong_citation_indices=[],
+            no_citation=False,
+            latency=SimpleNamespace(total_ms=123.0),
+            memory=SimpleNamespace(),
+            drift_metrics=None,
+        )
+        fake_pipeline = MagicMock()
+        fake_pipeline.query.return_value = result
+
+        fake_cfg = SimpleNamespace(model=SimpleNamespace(provider="baseline"))
+
+        fake_session_state = _FakeSessionState()
+
+        with (
+            patch.object(photon_app, "load_config", create=True, return_value=fake_cfg),
+            patch.object(
+                photon_app,
+                "build_pipeline",
+                create=True,
+                return_value=fake_pipeline,
+            ) as mock_build,
+            patch.object(photon_app.st, "session_state", fake_session_state),
+        ):
+            answer, metadata = photon_app._run_query(proj, "q?", "sess")
+
+        mock_build.assert_called_once_with(fake_cfg)
+        fake_pipeline.query.assert_called_once()
+        assert answer == "hello"
+        assert metadata["latency_ms"] == 123.0
+        assert metadata["cited_count"] == 1
+
+    def test_run_query_handles_mlx_import_error(self, tmp_path: Path) -> None:
+        proj = _make_proj(tmp_path, name="demo_photon")
+        fake_cfg = SimpleNamespace(model=SimpleNamespace(provider="photon"))
+
+        fake_session_state = _FakeSessionState()
+
+        def _raise_mlx(*_args, **_kwargs):
+            raise ModuleNotFoundError("No module named 'mlx'")
+
+        with (
+            patch.object(photon_app, "load_config", create=True, return_value=fake_cfg),
+            patch.object(
+                photon_app, "build_pipeline", create=True, side_effect=_raise_mlx
+            ),
+            patch.object(photon_app.st, "session_state", fake_session_state),
+        ):
+            answer, metadata = photon_app._run_query(proj, "q?", "sess")
+
+        assert "photon_unavailable_demo_photon" in fake_session_state
+        assert answer.startswith("エラー")
+        # Metadata contract preserved even on error.
+        assert "latency_ms" in metadata
+        assert "cited_count" in metadata
+        assert "pack_size" in metadata
+        assert "no_citation" in metadata
+        assert "drift_metrics" in metadata
+        assert "turn_id" in metadata

--- a/workspace/mvp/app_guide.md
+++ b/workspace/mvp/app_guide.md
@@ -1,0 +1,396 @@
+# PHOTON-RepoRAG アプリ 使い方ガイド
+
+## 起動
+
+```bash
+cd /path/to/photon-mlx
+streamlit run app/photon_app.py --server.port 3012 --server.baseUrlPath /proxy/photon
+```
+
+ブラウザで http://localhost:3012/proxy/photon を開く。
+
+---
+
+## 画面構成
+
+左サイドバーの 4 つのメニューで操作。
+
+| メニュー | 用途 |
+|---------|------|
+| 💬 チャット | リポジトリに質問する（drift / turn_history パネル付き） |
+| 📦 ベクトルDB作成 | リポジトリを検索可能にする |
+| 🧠 PHOTON学習 | follow-up 高速化モデルを学習（+ 評価ジョブ実行） |
+| 📋 プロジェクト登録 | DB + モデルを紐づけて管理（+ PHOTON wizard） |
+
+---
+
+## 初回セットアップ (3 ステップ)
+
+### Step 1: ベクトルDB作成
+
+**目的**: リポジトリのコードを検索可能にする
+
+1. 左メニュー **📦 ベクトルDB作成** を選択
+2. 入力:
+   - **対象リポジトリのディレクトリ**: 対象リポジトリの絶対パス
+     - 例: `/Users/maenokota/share/work/github_kewton/mulmoclaude`
+   - **リポジトリ ID**: 英数字の識別子 (スペース・ハイフン不可)
+     - 例: `mulmoclaude`
+   - **Embedding モデル**: ベクトル検索に使うモデルを選択
+     - `multilingual-e5-small` — 日本語を含む場合に推奨 (デフォルト)
+     - `all-MiniLM-L6-v2` — 英語のみの場合に軽量
+     - `multilingual-e5-base` — 多言語で高精度が必要な場合
+     - `all-MiniLM-L12-v2` — 英語で高精度が必要な場合
+3. **作成開始** をクリック
+4. バックグラウンドで 3 フェーズが実行される:
+   - Phase 1: Ingest (コードをチャンク分割)
+   - Phase 2: BM25 + Embedding (検索インデックス構築)
+   - Phase 3: Symbol Graph (import/call 関係の解析)
+5. ステータスが `completed` になるまで待つ (通常 2-5 分)
+
+### Step 2: プロジェクト登録
+
+**目的**: DB とモデルを紐づけて「プロジェクト」として使えるようにする
+
+1. 左メニュー **📋 プロジェクト登録** を選択
+2. 入力:
+   - **プロジェクト名**: 任意の名前 (例: `mulmoclaude`)
+     - ⚠ 制約: 英数字・ハイフン・アンダースコアのみ（path traversal 防止）
+   - **ベクトルデータベース**: Step 1 で作った repo_id を選択
+   - **PHOTON モデル**: 
+     - 初回は `(なし — baseline のみ)` を選択
+     - PHOTON 学習済みの場合は checkpoint を選択
+   - **Config ファイル**:
+     - baseline のみ: `configs/baseline.yaml`
+     - PHOTON あり: `configs/photon_small.yaml`
+     - あるいは **PHOTON settings (Wave 2-4 toggles)** で wizard 使用（§PHOTON wizard 参照）
+3. **登録** をクリック
+
+### Step 3: チャット
+
+**目的**: リポジトリに質問する
+
+1. 左メニュー **💬 チャット** を選択
+2. 上部のドロップダウンでプロジェクトを選択
+3. 下部の入力欄に質問を入力
+4. 回答が表示される
+   - `[C:N]` は引用 (どのコードチャンクを根拠にしたか)
+   - **メトリクス** を展開すると Latency / Citations 数が見える
+   - **Drift metrics** を展開すると PHOTON の内部指標が見える（PHOTON プロジェクトのみ、§Drift metrics 参照）
+   - **Turn history** を展開するとターンごとの引用数などが見える（§Turn history 参照）
+5. 続けて質問すると前の回答を踏まえたマルチターン会話になる
+6. **会話をクリア** で新しいセッションを開始
+
+---
+
+## PHOTON wizard（プロジェクト登録画面、Wave 2-4 機能 toggle）
+
+baseline から一歩進めて PHOTON 拡張機能を試す場合、手動 YAML 編集不要で使える wizard。
+
+### 使い方
+
+1. **📋 プロジェクト登録** ページで **PHOTON モデル** を選択
+2. **PHOTON settings (Wave 2-4 toggles)** expander を展開
+3. **この form で PHOTON YAML を生成して保存** をオンにする
+4. 下記の toggle を設定
+5. **登録** クリックで `projects/<name>/photon.yaml` が自動生成・保存される
+
+### Toggle 一覧
+
+| Toggle | YAML path | 効果 |
+|--------|-----------|------|
+| **Config template** | — | `photon_small` / `photon_tiny` / `photon_long_context` から base を選択 |
+| **RecGen enabled** | `inference.photon_generation_enabled` | PHOTON で回答生成（⚠ 実測で +6.1pp 悪化、推奨せず）|
+| **Fallback policy** | `inference.generation_fallback_policy` | RecGen 失敗時の fallback（`qwen` / `abort`）|
+| **2-pass search enabled** | `retrieval.two_pass_search.enabled` | PHOTON 再ランク（⚠ 実測で +4.2pp 悪化、推奨せず）|
+| **pass1_top_k / pass2_top_k** | `retrieval.two_pass_search.*_top_k` | 2-pass 検索の 1/2 段目数 |
+| **Working memory enabled** | `session_memory.working_memory.enabled` | PHOTON working memory（推奨: ON）|
+| **max_turns** | `session_memory.working_memory.max_turns` | 保持するターン数（default 8）|
+| **aggregation** | `session_memory.working_memory.aggregation` | `weighted`（推奨）/ `attention` / `last` |
+| **storage_mode** | `session_memory.working_memory.storage_mode` | `full`（推奨 2048 コンテキスト）/ `top_level_only`（長コンテキスト）|
+| **past_turn_pinning_enabled** | `session_memory.working_memory.past_turn_pinning_enabled` | 過去ターン引用 pin（⚠ 実測で +1.4pp 悪化、推奨せず）|
+| **Apply best-practice** | — | 5 キーの推奨値をマージ（下記）|
+
+### Apply best-practice の中身
+
+5 キーを「Gate 2 v4 実測で最良」の組合せに上書き:
+
+- `inference.safe_recgen_enabled: true`
+- `inference.evidence_pruning_enabled: true`
+- `session_memory.working_memory.enabled: true`
+- `inference.photon_generation_enabled: false`（RecGen 非推奨）
+- `retrieval.two_pass_search.enabled: false`（2-pass 非推奨）
+
+手動 toggle で敢えて true にしたものと衝突する場合は UI で警告表示。
+
+---
+
+## Drift metrics パネル（チャット画面、PHOTON プロジェクトのみ）
+
+各回答直後、**Drift metrics** expander で PHOTON の内部状態を可視化。
+
+### 表示される指標
+
+| 指標 | 意味 | 色分け |
+|------|------|--------|
+| **token_level** | token 埋め込みのドリフト | `ok` / `warn` / `alert` |
+| **mid_level** | 中間層 coarse state のドリフト | 同上 |
+| **top_level** | 最上位 coarse state のドリフト | 同上 |
+| **topic_shift** | 話題転換スコア | 同上 |
+
+閾値は config の `drift_thresholds` から読み込み。色分けは Safe RecGen の発火条件と同一基準のため、**ドリフト追跡とフォールバック判定が一致**。
+
+### 使いどころ
+
+- 話題が大きく変わった直後に `topic_shift` が alert → PHOTON 判断で retrieval やり直しが発生している（正常）
+- `top_level` が安定して低い → マルチターン文脈継続が効いている
+
+---
+
+## Turn history パネル（チャット画面）
+
+ターンごとの情報を 1 行ずつ表示:
+
+| 列 | 意味 |
+|---|------|
+| turn_id | ターン番号（1 始まり）|
+| question (head) | 質問冒頭 |
+| cited | 引用した chunk ID 数 |
+| timestamp | 実行時刻 |
+
+PHOTON `turn_history` と baseline `SessionManager.turns` を `turn_id` で join して表示。fail-closed 経路で片方だけ更新された場合は cited が空で表示される（UI が壊れない保証）。
+
+---
+
+## 評価ジョブ実行（training ページ、Wave 4）
+
+PHOTON 学習結果の質を数値で確認するための async eval runner。
+
+### 使い方
+
+1. 左メニュー **🧠 PHOTON学習** を選択
+2. 既存の training ジョブの expander 内（または専用セクション）で「評価ジョブ (Issue #82 Wave 4)」を確認
+3. **評価対象プロジェクト** を選択
+4. **Run Static Eval** または **Run Multi-Turn Eval** をクリック
+5. 進捗バー（`done_q / total_q · p50 latency · NC rate`）で状態確認
+
+### eval_type
+
+| タイプ | 対象 eval set | 所要時間 | 用途 |
+|--------|-------------|---------|------|
+| **Static Eval** | `data/eval_sets/static_eval.jsonl`（120Q）| ~30 分 | 単発質問の NC rate |
+| **Multi-Turn Eval** | `data/eval_sets/multi_turn_eval.jsonl`（30 session × 6 turn = 180Q）| ~90 分 | 会話の NC rate |
+
+### 制約
+
+- 同時実行は **1 eval のみ**（LLM ロード競合防止、`MAX_CONCURRENT_EVAL=1`）
+- 実行中は両ボタン無効化
+- 結果 JSON は `reports/eval_runs/<job_id>.json`、ログは `logs/eval/<job_id>.log`（allowlist 外に書き込まない security guardrail）
+
+### 最近の eval（同一プロジェクト）
+
+最大 5 件まで status・開始時刻・p50・NC rate が表示される。succeeded なら result 場所、failed なら最終エラー 1 行を表示。
+
+---
+
+## PHOTON 学習 (オプション)
+
+**目的**: follow-up ターンを高速化する PHOTON モデルを学習する
+
+> baseline のみでも使えます。PHOTON は「2 問目以降を速くしたい」場合のオプション。
+
+1. 左メニュー **🧠 PHOTON学習** を選択
+2. 入力:
+   - **対象リポジトリのディレクトリ**: ベクトルDB と同じパス
+   - **最大ステップ数**: 学習の長さ
+     - 小さいリポジトリ (~100 ファイル): 500
+     - 中程度 (~500 ファイル): 1000
+     - 大きい (~2000 ファイル): 2000
+   - **バッチサイズ**: 2 (メモリ不足なら 1)
+   - **学習率**: 0.00015 (デフォルト推奨)
+   - **評価間隔**: 100 (デフォルト推奨)
+3. **学習開始** をクリック
+4. バックグラウンドで学習が進行
+   - プログレスバーで進捗を確認
+   - val_loss が表示される (低いほど良い)
+   - 所要時間: 500 steps で約 1 時間、1000 steps で約 2 時間
+5. 完了後、**📋 プロジェクト登録** で PHOTON モデルを選択して再登録
+6. 登録後、**評価ジョブ** セクションで Static / Multi-Turn NC を計測し質を確認
+
+### Resume / 追加学習
+
+既存 checkpoint から学習を継続することも可能。CLI から:
+
+```bash
+python scripts/train_photon.py --resume checkpoints/<run>/step_000600
+```
+
+step 数と optimizer state（AdamW momentum）が完全に復元される。
+
+---
+
+## 質問の例
+
+### Repo オンボーディング
+
+```
+このリポジトリの主要モジュールは何ですか？
+エントリーポイントはどこですか？
+テストはどう構成されていますか？
+```
+
+### コードの理解
+
+```
+認証処理の流れを教えてください
+データベース接続はどこで管理されていますか？
+設定ファイルの読み込み方法は？
+```
+
+### 影響範囲分析
+
+```
+この関数を変更したら何が壊れますか？
+このモジュールに依存しているファイルは？
+APIの引数を変えた場合の影響は？
+```
+
+### バグ調査
+
+```
+ファイルアップロードで 413 が返る原因は？
+リクエストボディが消費される問題の原因は？
+テストでエラーになる箇所はどこですか？
+```
+
+### 変更計画
+
+```
+キャッシュ機能を追加するならどこに入れるべき？
+非同期処理に移行する場合の設計案は？
+ログ出力を改善する方法は？
+```
+
+---
+
+## マルチターン会話のコツ
+
+PHOTON の効果はマルチターン (深掘り質問) で発揮されます。
+
+```
+良い使い方 (ドリルダウン型):
+  Q1: 「認証処理の全体像は？」        ← 広い質問
+  Q2: 「その中の JWT 検証の詳細は？」 ← 絞り込み
+  Q3: 「そこを変えたら何が壊れる？」  ← さらに深掘り
+  Q4: 「修正案を出して」              ← 具体的
+
+あまり効果がない使い方 (単発質問の繰り返し):
+  Q1: 「認証処理は？」
+  Q2: 「データベース接続は？」  ← 話題が変わる
+  Q3: 「テストの書き方は？」    ← また変わる
+```
+
+PHOTON ならではの効果が出るシーン:
+- Turn 5-6 で NC rate 0%（baseline は 6-7%）
+- follow-up latency 20s → 13-14s（-34%、KV cache #54）
+
+---
+
+## トラブルシューティング
+
+### ベクトルDB作成が失敗する
+
+**ステータスが `failed` になった場合:**
+
+1. ログを確認:
+   ```bash
+   cat logs/idx_YYYYMMDD_HHMMSS.log
+   ```
+2. よくある原因:
+   - ディレクトリパスが間違っている
+   - Git リポジトリでない (`.git` がない)
+   - ディスク容量不足
+
+### チャットでエラーが出る
+
+**「エラーが発生しました」と表示される場合:**
+
+1. ベクトルDB が `completed` になっているか確認
+2. プロジェクト登録で正しい repo_id を選択しているか確認
+3. Qwen 14B モデルの初回ダウンロードに時間がかかる場合がある (初回のみ ~8GB)
+
+### Drift metrics が "N/A" 表示
+
+- PHOTON プロジェクト（`use_photon=True`）でないと drift は取得されない
+- baseline プロジェクトでは正常に "N/A" 表示（エラーではない）
+
+### 評価ジョブが失敗する
+
+- 他の eval 実行中は新規実行不可（1 並列制限）
+- 失敗時は UI に最終エラー行が表示される、詳細は `logs/eval/<job_id>.log`
+- eval set が `data/eval_sets/` に存在するか確認
+
+### PHOTON 学習が止まる
+
+1. メモリ不足: バッチサイズを 1 に下げる
+2. コーパスが小さすぎる: 100 ファイル未満の場合は baseline のみ推奨
+3. ログ確認:
+   ```bash
+   cat logs/train_YYYYMMDD_HHMMSS.log
+   ```
+
+### 回答に引用 [C:N] が付かない
+
+- 質問が曖昧すぎる → より具体的に聞く
+- リポジトリに該当するコードがない → ABSTAIN は正常動作
+- 日本語の質問で検索が弱い → Embedding モデルに `multilingual-e5-small` を使用
+
+### wizard で保存した YAML が反映されない
+
+- `PHOTON モデル` が選択されているか確認（baseline のみでは wizard は無効）
+- `projects/<name>/photon.yaml` が生成されているか確認
+- 「この form で PHOTON YAML を生成して保存」のチェックが必要
+
+---
+
+## Security Notes（Wave 2）
+
+Wave 2 で以下の guardrail を実装:
+
+- **project_name**: 英数字 + `-_` のみ、path traversal 防止（`_safe_id`）
+- **eval paths**: `reports/eval_runs/` と `logs/eval/` のみ書き込み許可
+- **state loading**: JSON schema 検証、不正値で起動失敗
+- **YAML**: `yaml.safe_load` のみ許可、`!!python/object` 等のカスタムタグ拒否
+
+不審な入力は UI でエラー表示され、ディスク上に不正なファイルは残らない設計。
+
+---
+
+## 技術仕様
+
+### 使用モデル一覧
+
+| モデル | 用途 | サイズ | DL タイミング |
+|--------|------|--------|-------------|
+| Embedding (選択式) | ベクトル検索 | 100-400 MB | DB 作成時 |
+| ms-marco-MiniLM-L-6-v2 | 検索結果の再ランキング | 100 MB | 初回チャット時 |
+| PHOTON Small | evidence pruning + session state | 1.5 GB | 学習時に生成 |
+| Qwen2.5-Coder-14B-4bit | 回答生成 | 8 GB | 初回チャット時 |
+
+### 現在の実測メトリクス（weighted aggregation、2-run average）
+
+| metric | baseline | PHOTON（default）| PHOTON の効果 |
+|--------|---------|-------------------|--------------|
+| Static NC | 16.7% | 17.5% | ±ノイズ（Static には寄与せず）|
+| MT NC | 9.4% | 7-8% | **-2〜4pp 改善** |
+| Turn 5-6 NC | 6-7% | **0%** | **working memory で長期文脈維持** |
+| Follow-up latency | 20.1s | 13-14s | **-34%（KV cache #54）**|
+
+### システム要件
+
+| 項目 | 最小 | 推奨 |
+|------|------|------|
+| OS | macOS 14+ (Apple Silicon) | macOS 15 |
+| RAM | 32 GB | 64 GB |
+| Storage | 15 GB | 30 GB |
+| Python | 3.12+ | 3.12+ |

--- a/workspace/mvp/architecture.md
+++ b/workspace/mvp/architecture.md
@@ -1,0 +1,163 @@
+# MVP アーキテクチャ
+
+**更新日**: 2026-04-24
+
+## 現在の稼働構成
+
+```
+リポジトリ クローン → Streamlit app (port 3012) または CLI で利用
+  │
+  ├── app/photon_app.py               # Streamlit UI
+  │   ├── components/drift_panel.py        # Wave 3 drift 可視化
+  │   ├── components/turn_history_panel.py # Wave 3 会話履歴
+  │   ├── components/eval_panel.py         # Wave 4 eval runner
+  │   └── components/wizard.py             # Wave 2-4 toggle wizard
+  │
+  ├── baseline_reporag/               # ← main code path
+  │   ├── ingestion/                       # chunker + SQLite store
+  │   ├── indexing/                        # BM25 + embedding + symbol graph
+  │   ├── retrieval/                       # hybrid + graph expansion + reranker
+  │   ├── memory/session.py                # SessionManager (baseline 側 turn history)
+  │   ├── generation/                      # evidence_pack + prompt + mlx_lm generator
+  │   ├── pipeline.py                      # baseline Qwen-only pipeline
+  │   ├── pipeline_factory.py              # provider 分岐 (baseline / photon)
+  │   ├── photon_pipeline.py               # PHOTON 拡張 pipeline
+  │   ├── server.py                        # FastAPI
+  │   └── cli.py                           # CLI エントリ
+  │
+  ├── photon_mlx/                     # ← PHOTON モデル
+  │   ├── model.py / blocks.py             # 階層 encoder + RoPE
+  │   ├── session.py                       # PhotonSessionState + DriftMetrics
+  │   ├── inference.py                     # hierarchical prefill + prune
+  │   ├── safe_recgen.py                   # drift ベース fallback
+  │   ├── trainer.py / data.py             # 学習ループ
+  │   └── tests/                           # 517 tests
+  │
+  ├── configs/                        # プロファイル一覧
+  │   ├── baseline.yaml                    # Qwen only
+  │   ├── photon_small.yaml                # PHOTON Small（推奨 default）
+  │   ├── photon_tiny.yaml                 # Tiny モデル
+  │   ├── photon_long_context.yaml         # 長コンテキスト用
+  │   └── photon_600m_paper.yaml           # 研究参考
+  │
+  └── scripts/                        # オペレーション
+      ├── run_baseline_eval.py             # Static NC eval (120Q)
+      ├── run_multi_turn_eval.py           # MT NC eval (180Q)
+      ├── retrieval_grid_search.py         # #88 grid search harness
+      └── train_photon.py                  # PHOTON 学習 (resume 対応)
+```
+
+### MVP 配布目標（Phase 3 完了時の想定）
+
+```
+pip install photon-rag        # ← 未着手 (Phase 3)
+  │
+  ├── HuggingFace から自動 DL:
+  │   ├── kewton/photon-python-small    # 未公開
+  │   ├── Qwen2.5-Coder-14B-4bit        # 公開済
+  │   ├── all-MiniLM-L6-v2              # 公開済
+  │   └── ms-marco-MiniLM-L-6-v2        # 公開済
+  │
+  └── CLI / FastAPI / Streamlit で利用
+```
+
+---
+
+## モデル構成（ローカル配置）
+
+| モデル | サイズ | 役割 | 入手 |
+|--------|--------|------|------|
+| **Qwen2.5-Coder-14B-4bit** | ~8 GB | 回答生成（LLM）| HF 自動 DL |
+| **PHOTON Small** | ~1.5 GB | session state + drift + prune | 学習で生成 |
+| **all-MiniLM-L6-v2** | ~100 MB | Embedding 検索 | HF 自動 DL |
+| **ms-marco-MiniLM-L-6-v2** | ~100 MB | cross-encoder 再ランク | HF 自動 DL |
+| （オプション）multilingual-e5-small | ~120 MB | 日本語対応 Embedding | HF 自動 DL |
+
+---
+
+## データフロー（現行実装）
+
+### 初回セットアップ
+
+```
+リポジトリ → ingest (ast-chunker) → chunks.db (SQLite)
+          → BM25 (rank-bm25) + embedding (MiniLM) → インデックス
+          → symbol graph (import/call) → symbol_graph.json
+```
+
+### Turn 1（初回質問）
+
+```
+質問 → query expansion → BM25 + embedding (hybrid)
+     → graph expansion → cross-encoder reranker → top 16 chunks
+     → PHOTON hierarchical prefill → coarse state 保存
+     → evidence pack → LLM (Qwen 14B) → 回答 [C:N]
+     → turn_history に記録
+```
+
+### Turn 2+（follow-up）
+
+```
+質問 → query expansion → BM25 + embedding (reranker skip 可)
+     → PHOTON prune_evidence (coarse state 経由 cosine で絞り込み)
+     → 8 chunks（default）
+     → PHOTON KV cache 活用で prefill skip
+     → LLM (Qwen 14B) → 回答 [C:N]
+     → drift 検知 (3 階層 + topic shift) → Safe RecGen 判定
+```
+
+---
+
+## PHOTON セッション状態管理（本プロダクトの核心）
+
+### Working Memory（`photon_mlx/session.py`）
+
+```python
+PhotonSessionState
+  ├── turn_history: list[TurnState]          # Turn 1..N の記録
+  │   └── TurnState                           # question_text, coarse_states, timestamp, turn_id
+  ├── current_state: LevelStates             # 現在の階層状態 (token, mid, top)
+  ├── drift_history: list[DriftMetrics]      # 各 turn の drift 値
+  └── aggregation: weighted / attention / last / dynamic
+```
+
+- **decay_factor=0.5** で過去ターン重み減衰
+- **max_turns=8** 超過時は自動圧縮（storage_mode: full / top_level_only）
+- **aggregation 選択肢**: weighted（推奨、default）/ attention / last / dynamic (turn_position / drift_based / hybrid)
+
+### Drift 検知（`DriftMetrics`）
+
+| 階層 | 検知対象 | 用途 |
+|------|---------|------|
+| `latent_cosine_drift_token` | token-level | 細かい表現変化 |
+| `latent_cosine_drift_mid` | mid-level | 意味的変化 |
+| `latent_cosine_drift_top` | top-level | 話題転換 |
+| `topic_shift_score` | 統合スコア | Safe RecGen トリガ |
+
+閾値超過時は **Safe RecGen controller** が fallback action を選択（`re_retrieve` / `reprefill_hierarchy` / `fallback_to_baseline_path`）。
+
+---
+
+## システム要件
+
+| 項目 | 最小 | 推奨 |
+|------|------|------|
+| OS | macOS 14+ (Apple Silicon) | macOS 15 |
+| RAM | 32 GB | 64 GB |
+| Storage | 15 GB | 30 GB |
+| Python | 3.12+ | 3.12+ |
+| GPU | Apple Silicon M1+ | M2 Ultra / M3 Ultra |
+
+---
+
+## 現行パフォーマンス（2026-04-23 実測）
+
+| シナリオ | baseline | PHOTON（weighted default） | 効果 |
+|---------|---------|----------------------------|------|
+| Static NC (120Q) | 16.7% | 17.5% | ±ノイズ |
+| MT NC (180Q) | 9.4% | **7-8%** | **-2〜4pp** |
+| Turn 5-6 NC | ~6.7% | **0.0%** | **working memory が完全有効** |
+| First-turn latency | 22.3s | 22.2s | ±同等 |
+| Follow-up latency (P50) | 20.1s | **13-14s** | **-34%（KV cache #54）**|
+
+詳細は `metrics.md`。

--- a/workspace/mvp/issues.md
+++ b/workspace/mvp/issues.md
@@ -1,0 +1,101 @@
+# MVP Issue 一覧
+
+**更新日**: 2026-04-24
+
+## 完了済み Wave（Epic #65 / Epic #93）
+
+### Wave 1-4（Gate 2 v4）— ✅ 全完了
+
+Gate 2 v4 判定で PHOTON 差分価値確定。詳細は `reports/gate2_judgment_v4_final.md`。
+
+- session state / drift / Safe RecGen / KV cache 等の core 機能が本線実装として merge 済み。
+
+### Wave 5（#78, #79, #80）— ✅ 全完了・Merged
+
+| Issue | 内容 | 状態 |
+|-------|------|------|
+| #78 | `find_relevant_past_turn()` method | ✅ Closed |
+| #79 | 圧縮保存 + `storage_mode` 対応 | ✅ Closed |
+| #80 | aggregation mode 選択可能化（weighted/attention/last）| ✅ Closed |
+
+### Wave 6 初回マージ — ❌ 全 Revert（regression 対応）
+
+| Issue | 内容 | 結果 |
+|-------|------|------|
+| #88 initial | grid search harness | Revert |
+| #89 initial | bge-reranker-base | Revert |
+| #90 initial | bge-small-en-v1.5 embedding | Revert |
+| #91 initial | graph neighborhood 調整 | Revert |
+| #92 initial | dynamic aggregation | Revert |
+
+Wave 6 batch merge で MT NC 5.6% → 17.8% に regression、全件 revert（PR #99 / #100）。
+
+### Wave 6 再着手（single-PR + eval-gate）— ✅ 完結
+
+| Issue | 再着手結果 | commit / 判定 |
+|-------|----------|--------------|
+| #92 dynamic aggregation | ✅ Merged | `a72775e` (PR #101) |
+| #88 grid search harness | ✅ Merged | `5c461a6` (PR #102、harness のみ） |
+| #89 bge-reranker | ❌ Abort | Static +0.8pp 悪化、empirical rejection |
+| #103 past_turn_pinning (pipeline 統合) | ⚠️ Merged（default off）| `dfc228f` (PR #105)、opt-in benefit 未実証 |
+| #104 hybrid default 化 A/B | ❌ 非採用 | MT NC +0.8pp 悪化で weighted 維持 |
+| Epic #93 | ✅ Closed | main sync PR #106 で `64144ff` |
+
+### Streamlit アプリ強化 — ✅ Merged
+
+| Issue | 内容 | 状態 |
+|-------|------|------|
+| #82 | Wave 1-4 機能を Streamlit に反映（drift panel / turn history / eval runner / PHOTON wizard）| ✅ Merged (PR #107, commit `ea108a1`) |
+
+---
+
+## Open Issues（MVP 作業として残存）
+
+| Issue | タイトル | 種別 | 優先 |
+|-------|---------|------|------|
+| #81 | [Epic] Static NC < 15% 達成のための retrieval チューニング | enhancement | 中（#88 harness で grid 実行可）|
+| #49 | PHOTON Medium (1B) スケールアップ検討 | research | 低（MVP 後）|
+
+---
+
+## MVP Phase 別 Issue 整理
+
+### Phase 1: 品質保証 — ✅ 実質完了
+
+| 項目 | 状態 |
+|------|------|
+| Safe RecGen ログ修正 | ✅ 完了済み |
+| fallback recall 計測 | ✅ スクリプト化済 |
+| Gate 3 判定 | ✅ 条件付き Go |
+| test_photon_pipeline 修正 | ✅ 現状 832/834 pass（既知 2 pre-existing failure のみ）|
+| 異常入力テスト | ✅ `_safe_id` / YAML safe_load guardrail で Wave 2 に反映 |
+
+### Phase 2: 汎用化 — ❌ 未着手（MVP のボトルネック）
+
+| タスク | 工数見積 | 状態 |
+|-------|--------|------|
+| Django repo eval 検証 | 3 日 | 未着手 |
+| Pydantic repo eval 検証 | 2 日 | 未着手 |
+| query_expansion 汎用化 | 2 日 | 未着手（FastAPI 固有マッピング残存）|
+| noise patterns 設定化 | 1 日 | 未着手 |
+| eval set 自動生成スクリプト | 3 日 | 未着手 |
+
+### Phase 3: 配布（pip） — ❌ 未着手
+
+| タスク | 工数見積 | 状態 |
+|-------|--------|------|
+| 汎用コーパス拡張（20+ repos）| 3 日 | 未着手 |
+| 汎用モデル学習 | 2 日 | 未着手 |
+| 未知 repo eval | 2 日 | 未着手 |
+| HuggingFace weights 公開 | 1 日 | 未着手 |
+| 自動 DL + pip パッケージ化 | 4 日 | 未着手 |
+
+---
+
+## 未起票の内部改善候補
+
+- `find_relevant_past_turn` の閾値 / `max_pinned_chunks` チューニング（#103 follow-up）
+- `hybrid_alpha_base` / `hybrid_alpha_per_turn` チューニング（#104 follow-up）
+- retrieval grid search 実行（#88 harness を使って #81 を推進）
+- Embedding 更新の独立 A/B（Wave 6 で #90 初回 revert、再試験候補）
+- PHOTON Small の State management 特化再訓練（mulmoclaude 1000 step → 10K step へ拡張）

--- a/workspace/mvp/metrics.md
+++ b/workspace/mvp/metrics.md
@@ -1,0 +1,116 @@
+# MVP メトリクス基準
+
+**更新日**: 2026-04-24
+
+## 現在のメトリクス
+
+### baseline_rag（`configs/baseline.yaml`、Qwen 14B のみ）
+
+| 指標 | Static | MT |
+|------|--------|-----|
+| NC (raw, no_citation) | **16.7%** | 9.4% |
+| NC (true, answerable only) | 12.4% | — |
+| Wrong citation | 0% | 0% |
+| P50 latency | 19.5s | 22.3s first / 20.1s follow-up |
+| Retrieval noise | 0% | 0% |
+
+### photon_rag（`configs/photon_small.yaml`、default `aggregation: weighted`）
+
+2-run average（LLM 非決定性分散 ±4-5pp を平滑化、2026-04-23 実測）
+
+| 指標 | Static | MT |
+|------|--------|-----|
+| NC (raw) | **17.5%** | **7.8%**（2-run avg、range 5.0-9.4%）|
+| Turn 5-6 NC | — | **0.0%**（PHOTON working memory 効果）|
+| first-turn latency | 22.2s | — |
+| follow-up P50 | — | **13-14s（-34% vs baseline）**|
+
+### ターン別 MT NC（180Q、2026-04-23 実測）
+
+| Turn | baseline | PHOTON weighted |
+|------|---------|-----------------|
+| 1 | 3.3% | 0.0-3.3% |
+| 2 | 23.3% | 10-17% |
+| 3 | 20.0% | 7-17% |
+| 4 | 3.3% | 7-10% |
+| 5 | 6.7% | **0.0%** |
+| 6 | 0.0% | **0.0%** |
+
+PHOTON の本領は **Turn 5-6 の長期文脈維持**。単発質問（Static, Turn 1）では baseline と差なし。
+
+---
+
+## opt-in feature の実測結果（empirical 根拠）
+
+本日（2026-04-23）の 2-run MT eval でのデータ。全て **default 化推奨せず**。
+
+| feature | config | 結果 | 判定 |
+|---------|--------|------|------|
+| `photon_generation_enabled`（RecGen）| true | +6.1pp 悪化 | ❌ 非推奨 |
+| `two_pass_search.enabled` | true | Static +4.2pp 悪化 | ❌ 非推奨 |
+| `aggregation: dynamic, hybrid` | — | +0.8pp 悪化 | ❌ default 化せず |
+| `past_turn_pinning_enabled` | true | +1.4pp 悪化（Turn 2 -5pp / Turn 3 +8pp）| ⚠️ opt-in 維持 |
+| `reranker: BAAI/bge-reranker-base` | — | Static +0.8pp 悪化 | ❌ Wave 6 abort |
+
+教訓: **PHOTON は state management 専用エンジン**として最強。retrieval rescoring / answer generation / stale context pinning はいずれも既存強ツールに劣る。
+
+---
+
+## MVP 達成基準
+
+### Phase 1（品質保証）— ✅ 達成
+
+| 指標 | 基準 | 現状 | 判定 |
+|------|------|------|------|
+| Gate 3 判定 | Go | Conditional Go | ✅ |
+| fallback recall | ≥ 0.80 | スクリプト化済・計測運用中 | ✅ |
+| テスト通過率 | 100% | 832/834（pre-existing 2 除外）| ✅ |
+
+### Phase 2（汎用化）— ❌ 未達
+
+| 指標 | 基準 | 現状 | 判定 |
+|------|------|------|------|
+| 他 repo MT NC | < 15% | FastAPI のみで 7.8% | ❌ 未検証 |
+| 他 repo latency 改善 | baseline -20%+ | FastAPI のみで -34% | ❌ 未検証 |
+| FastAPI 改善の再現率 | 70%+ | 未計測 | ❌ |
+
+### Phase 3（配布）— ❌ 未達
+
+| 指標 | 基準 | 現状 | 判定 |
+|------|------|------|------|
+| 未知 repo NC | < 15% | 未計測 | ❌ |
+| 未知 repo latency 改善 | baseline -20%+ | 未計測 | ❌ |
+| セットアップ時間 | < 10 分（ingest 除く）| 手動 setup（Streamlit 起動自動化 Wave 2 で短縮）| ⚠️ |
+| pip install 成功率 | 100%（Python 3.12+, Apple Silicon）| pip 未パッケージ化 | ❌ |
+
+---
+
+## Epic #65 vs 現実ギャップ
+
+| 当初目標 | 現状 | 差分 |
+|---------|------|------|
+| Static NC < 5% | 17.5% | **-12.5pp 未達**（PHOTON は Static に寄与しにくい）|
+| MT NC < 5% | 7.8% | **-2.8pp 未達**（Wave 6 数々の opt-in 実験も default 化の benefit なし）|
+| follow-up latency -30% | **-34%**（13-14s）| ✅ 達成 |
+| MT NC baseline 改善 | ✅ -2-4pp | ✅ 達成 |
+
+---
+
+## 将来目標（MVP 後）
+
+| 指標 | 目標 |
+|------|------|
+| Static NC (true) | < 5%（retrieval 全面刷新、#81 Epic）|
+| MT NC | < 5%（PHOTON 追加学習で State management 強化 or Medium 1B）|
+| follow-up latency | baseline -50%（追加最適化）|
+| 同時セッション | 8（stress eval pass）|
+| 対応言語 | Python, TypeScript, Go |
+
+---
+
+## 計測時の注意事項
+
+- **LLM 非決定性**: Qwen temp=0.2, top_p=0.9 で 180Q single-run の分散は **±4-5pp**。single-run 判定は誤検知リスクあり、**2-run average を eval-gate の最低基準**とする（Wave 6 教訓）。
+- **Turn 2 NC**: historically 15-33% レンジ。ノイズ大きいため比較時は必ず 2-run 以上。
+- **Turn 5-6 NC**: PHOTON では常に 0%（指標 loadbearing）。ここが上がったら PHOTON 機能退化のシグナル。
+- **Static NC の小改善**: ±1-2pp 以内は LLM 非決定性内。明確な勝ち判定には 2-run 以上推奨。

--- a/workspace/mvp/roadmap.md
+++ b/workspace/mvp/roadmap.md
@@ -1,0 +1,233 @@
+# PHOTON 実用化ロードマップ
+
+- **更新日**: 2026-04-24
+- **目標**: PHOTON を MVP (Minimum Viable Product) として公開可能にする
+- **MVP 定義**: pip install → 学習済みモデル自動 DL → 自分のリポジトリで使える
+- **当初想定**: 5 週間（Phase 1-3）
+- **現在の進捗**: Phase 1 完了、Phase 2 未着手（Phase 3 へのボトルネック）
+
+---
+
+## 現在地（2026-04-24）
+
+### ✅ 達成済み
+
+| 項目 | 状態 | 備考 |
+|------|------|------|
+| PHOTON アーキテクチャ（Small 377M）| ✅ 実装完了 | val_loss 0.4525、600 step 学習済 |
+| Hierarchical working memory | ✅ Wave 1-5 で本線統合 | 3 階層 + drift + aggregation 選択 |
+| Evidence pruning | ✅ follow-up 16→8 chunks | |
+| KV cache（#54）| ✅ merged | follow-up -34% 達成 |
+| Safe RecGen controller | ✅ merged | 3 階層 drift トリガ |
+| Multi-turn 完走率 | ✅ 180/180 全 variant | |
+| Follow-up latency -30% | ✅ 達成（-34%） | spec 超過 |
+| MT NC 改善 | ✅ baseline 9.4% → PHOTON 7.8% | -2〜4pp |
+| Turn 5-6 NC 0% | ✅ 確定 | PHOTON 独自価値 |
+| Gate 2 Go 判定 | ✅ | Gate 2 v4 最終 |
+| Gate 3 判定 | ✅ Conditional Go | log 修正完了 |
+| **Streamlit アプリ（#82）** | ✅ merged 2026-04-23 | drift panel / eval runner / wizard |
+| **Wave 6 再着手サイクル** | ✅ 完結 2026-04-23 | single-PR + eval-gate で安定化 |
+
+### ❌ 未達（MVP 実現に必要）
+
+| 項目 | ブロッカー |
+|------|----------|
+| **Phase 2: 汎用化**（FastAPI 以外の検証）| 最大ボトルネック |
+| **Phase 3: 配布**（pip install + HuggingFace 公開）| Phase 2 の blocker |
+| 未知 repo での eval セット自動生成 | 未着手 |
+| query_expansion / noise patterns の汎用化 | 未着手 |
+
+---
+
+## Phase 1: 品質保証 — ✅ 完了
+
+### 達成項目
+
+- Safe RecGen ログ修正 ✅
+- fallback recall 計測スクリプト化 ✅
+- Gate 3 判定 Conditional Go ✅
+- テスト 832/834 pass（pre-existing 2 failure のみ、CLAUDE.md 既知）✅
+- 異常入力 guardrail（Wave 2 で `_safe_id`, YAML safe_load 等）✅
+
+### Wave 6 教訓の反映
+
+- **batch merge 禁止**: single-PR + eval-gate 必須
+- **2-run MT eval**: LLM 非決定性 ±4-5pp を平滑化
+- **empirical 根拠なき default 変更禁止**: #89/#103/#104 いずれも abort / opt-in 維持
+
+---
+
+## Phase 2: 汎用化 — ❌ 未着手（MVP の主要タスク）
+
+### 目的
+
+**FastAPI 以外でも動くことを証明する**。現状は FastAPI に最適化されており、他 repo での有効性が未検証。
+
+### タスク
+
+| # | タスク | 工数 | 成果物 | 現状 |
+|---|-------|------|--------|------|
+| 2-1 | Django repo で eval | 3 日 | eval 結果レポート | 未着手 |
+| 2-2 | Pydantic repo で eval | 2 日 | eval 結果レポート | 未着手 |
+| 2-3 | query_expansion 汎用化 | 2 日 | FastAPI 固有マッピング分離 | 未着手 |
+| 2-4 | noise patterns 設定化 | 1 日 | `_NOISE_PATTERNS` を config に | 未着手 |
+| 2-5 | eval set 自動生成スクリプト | 3 日 | `scripts/generate_eval_set.py` | 未着手 |
+
+### 成功条件
+
+- [ ] Django / Pydantic で MT NC < 15%
+- [ ] Django / Pydantic で follow-up latency baseline -20% 以上
+- [ ] repo 切り替えが config 変更のみで可能
+
+### 判定基準
+
+FastAPI で得られた改善の **70% 以上** が他リポジトリでも再現すること。  
+再現しなければ PHOTON の汎用性に問題があり、**Phase 3（配布）に進まない**。
+
+---
+
+## Phase 3: 学習済みモデル配布 — ❌ 未着手
+
+### 目的
+
+ユーザが学習なしで PHOTON を使える状態にする。
+
+### タスク
+
+| # | タスク | 工数 | 成果物 | 現状 |
+|---|-------|------|--------|------|
+| 3-1 | 汎用コーパス拡張（20+ repos）| 3 日 | `data/processed/train_universal.jsonl` | 未着手 |
+| 3-2 | 汎用モデル学習 | 2 日 | `checkpoints/universal/` | 未着手 |
+| 3-3 | 未知 repo での eval | 2 日 | 汎化性能レポート | 未着手 |
+| 3-4 | HuggingFace 公開 | 1 日 | `kewton/photon-python-small` | 未着手 |
+| 3-5 | 自動 DL 機能実装 | 2 日 | config の `photon_model_id` で自動取得 | 未着手 |
+| 3-6 | pip パッケージ化 | 2 日 | `pip install photon-rag` | 未着手 |
+
+### 成功条件
+
+- [ ] HuggingFace に weights 公開済み
+- [ ] 学習データに含まれない repo で eval → NC < 15%, latency -20%+
+- [ ] `pip install photon-rag` で動作
+
+### ユーザ体験（Phase 3 完了時）
+
+```bash
+pip install photon-rag
+photon-rag ingest --repo /path/to/my/project
+photon-rag index --repo /path/to/my/project
+photon-rag serve --config my_config.yaml
+photon-rag ask "認証処理の入口はどこ？"
+```
+
+---
+
+## Phase 4: ユーザ体験向上（MVP 後、オプション）
+
+| # | タスク | 工数 | 現状 |
+|---|-------|------|------|
+| 4-1 | ワンコマンドセットアップ `photon-rag init --repo .` | 3 日 | 未着手 |
+| 4-2 | Streaming 応答（SSE）| 2 日 | 未着手 |
+| 4-3 | Web UI | — | **部分達成**（Streamlit #82 merged）|
+| 4-4 | VS Code Extension | 5 日 | 未着手 |
+| 4-5 | Quick Start ドキュメント（5 ステップ）| 1 日 | **達成**（`app_guide.md` 330 行）|
+
+---
+
+## Phase 5: プロダクション運用（MVP 後、オプション）
+
+| # | タスク | 工数 |
+|---|-------|------|
+| 5-1 | Index 差分更新（`git pull` 後の増分再 index）| 3 日 |
+| 5-2 | Multi-user 対応（セッション分離, 認証）| 2 日 |
+| 5-3 | 監視ダッシュボード（NC/latency 時系列）| 2 日 |
+| 5-4 | ユーザ feedback（👍/👎）| 2 日 |
+| 5-5 | Docker イメージ | 2 日 |
+
+---
+
+## 更新後タイムライン
+
+```
+[完了済み]  Phase 1 品質保証 → Gate 3 Conditional Go
+            Wave 6 再着手サイクル → single-PR + eval-gate 定着
+            #82 Streamlit app → Wave 2-4 機能 UI 反映
+
+[現在]      2026-04-24 時点
+            Phase 2 未着手（MVP 最大の残作業）
+
+[次スプリント（2 週間）]
+Week 1:     Phase 2-3 query_expansion / noise patterns 汎用化（4 日）
+            Phase 2-5 eval set 自動生成スクリプト（3 日）
+Week 2:     Phase 2-1 Django eval 実測（3 日）
+            Phase 2-2 Pydantic eval 実測（2 日）
+            Phase 2 判定（70%+ 再現？）
+
+[MVP スプリント（2 週間）Phase 3]
+Week 3:     Phase 3-1 汎用コーパス拡張（3 日）
+            Phase 3-2 汎用モデル学習（2 日）
+Week 4:     Phase 3-3 未知 repo eval（2 日）
+            Phase 3-4/5/6 HuggingFace 公開 + 自動 DL + pip 化（5 日）
+            ════════════ MVP リリース ════════════
+
+[MVP 後]    Phase 4 UX（CLI 改善、VS Code Extension）
+            Phase 5 運用（差分更新、Docker）
+```
+
+---
+
+## マイルストーン別の「使える度」
+
+| Phase | 完了後の状態 | 誰が使えるか | 2026-04-24 時点 |
+|-------|------------|------------|----------------|
+| Wave 1-6 + #82 | 開発者本人 + Streamlit UI。手動 ingest + プロジェクト登録 | 本人・チームメンバー（手動セットアップ）| ✅ **現状** |
+| Phase 2 | FastAPI 以外でも動作確認済み | Python 開発者（手動セットアップ）| ❌ 未達 |
+| **Phase 3（MVP）** | **pip install + config だけで使える** | **Python 開発者全般** | ❌ 未達 |
+| Phase 4 | ブラウザで質問するだけ | 非 Python 開発者も | 部分達成（Streamlit UI 有）|
+| Phase 5 | チーム全体で常時運用 | 全員 | ❌ 未達 |
+
+**現状は「本人 + チームメンバー（Streamlit UI 経由）」まで到達**。MVP としては **Phase 2 と 3 が残り 4 週間分の作業**。
+
+---
+
+## リスクと対策（更新版）
+
+| リスク | 影響 | 対策 | 2026-04-24 時点 |
+|--------|------|------|----------------|
+| Phase 2 で他 repo に汎化しない | MVP 遅延 | 汎用コーパスで再学習、repo-specific fine-tune を fallback に | 未検証、最大リスク |
+| 汎用モデルの品質が低い | ユーザ体験悪化 | fine-tune オプションを残す | Phase 3 判定時に評価 |
+| Apple Silicon 以外で動かない | ユーザ限定 | PyTorch backend 整備（`torch_ref` 活用）| 優先度低 |
+| pip パッケージ化で依存衝突 | インストール失敗 | optional dependencies で MLX/PyTorch 分離 | Phase 3 に内包 |
+| **Static NC 改善の停滞** | ユーザ体験 | **#81 retrieval tuning + #88 harness の grid 実行** | 新規リスク |
+| **PHOTON 追加学習の ROI** | 汎用性 | まず現行 Small の 10K step 学習、その後 Medium 検討 | #49 と関連 |
+
+---
+
+## 予算・リソース
+
+| 項目 | 必要量 | 現状 |
+|------|--------|------|
+| 開発工数 | Phase 2-3: ~4 人週（残作業）| 計画待ち |
+| ハードウェア | Mac Studio M2/M3 Ultra | ✅ 利用中 |
+| 外部費用 | なし（全てローカル + OSS）| ✅ |
+| HuggingFace | 無料（public repo）| アカウント既設 |
+| PyPI | 無料 | 未登録 |
+
+---
+
+## Next Action（MVP リリースに向けて）
+
+### 即時実行可能（orchestrate / pm-auto-issue2dev 経由）
+
+1. **#81 retrieval tuning Epic 着手**（#88 harness で grid search 実行）
+2. **Phase 2-3 query_expansion 汎用化** — 新規 Issue 化して着手
+3. **Phase 2-5 eval set 自動生成** — 新規 Issue 化
+
+### 要計画（ユーザ判断）
+
+- **Phase 2-1 Django / 2-2 Pydantic eval** — repo 選定と期間計画
+- **Phase 3 汎用モデル学習** — データセット選定と 10K step 学習の実施可否
+
+### オプション
+
+- #49 PHOTON Medium 1B スケールアップ（MVP 後）
+- find_relevant_past_turn の閾値チューニング（#103 follow-up）


### PR DESCRIPTION
## Summary

2026-04-23〜24 の成果を main に同期。

### Included Commits

- `ea108a1` feat(app): Wave 1-4 で追加された PHOTON 機能を Streamlit アプリに反映 (#107, Issue #82)
- `1e3539a` docs(mvp): update MVP release docs and Wave 6 retry eval reports

### 主な変更

**#82 Streamlit UI（PR #107 で develop に merged）**

Wave 1-4 で追加された PHOTON 機能を Streamlit から利用可能に：
- Drift metrics panel（3 階層 + topic shift）
- Turn history panel
- Async eval runner（Static / Multi-Turn）
- PHOTON project wizard（Wave 2-4 toggles + best-practice merge）
- Security guardrails（project_name / eval paths / YAML safe_load）

**MVP docs refresh（`workspace/mvp/`）**

- `architecture.md`: 現行稼働構成、PHOTON session state 詳細
- `issues.md`: Wave 5/6 cycle closed、残 open (#81, #49)
- `metrics.md`: 実測値（Static 17.5% / MT 7.8% / Turn 5-6 NC 0% / follow-up -34%）
- `roadmap.md`: Phase 1 完了、Phase 2（他 repo 汎用化）が MVP 残作業として明示
- `app_guide.md`: 228 → 330 行に拡張、#82 新機能の使い方を追加

**Wave 6 再着手 eval レポート（`reports/issue_*.md`）**

- #89 bge-reranker abort（empirical +0.8pp 悪化）
- #92 post-merge verify PASS
- #103 default off / opt-in benefit 未実証
- #104 hybrid default 化せず判定

## Test plan

- [x] develop branch 全品質チェック pass
- [x] #82 マージ時の回帰テスト（178 app tests + 832 全体 pass）
- [x] MVP docs は文書のみのため追加検証不要

## 関連

- Issue #82 closed（#107 で merged）
- Epic #93 Wave 6 closed（#106 で main 反映済）

🤖 Generated with [Claude Code](https://claude.com/claude-code)