### PR TITLE
feat(ingestion): Markdown chunker + symbol graph conditional skip (#109)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ python scripts/build_indexes.py --repo-id target_repo
 python scripts/build_symbol_graph.py --repo-id target_repo
 ```
 
+> Symbol graph の構築は **optional** です（Issue #109）。Python ソース中心の repo ではデフォルト（`indexing.symbol_graph.enabled: true`）で build/load されますが、制度文書の markdown など Python シンボルが存在しない repo では YAML で `indexing.symbol_graph.enabled: false` を指定すると `build_symbol_graph.py` は早期 return し、runtime でも `SymbolGraph.load` は呼ばれず `graph=None` で pipeline が組み立てられます。`expand_with_graph` は file-neighbors のみで動作するため retrieval は壊れません。
+
 5. baseline RepoRAG を起動
 ```
 python -m baseline_reporag.server --config configs/local.baseline.yaml

--- a/baseline_reporag/config.py
+++ b/baseline_reporag/config.py
@@ -1,9 +1,53 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any
 
 import yaml
+
+# CB-004 / CB-005: single allowlist for safe ``repo_id`` path segments.
+# Matches ``scripts/build_symbol_graph.py``'s historical regex so the
+# script, the pipeline factory, and demo entry points all reject the
+# same traversal / shell-metacharacter / unicode shapes.
+_REPO_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+# CB-R2-001: cap ``repo_id`` length so downstream path concatenations
+# (``<data_root>/indexes/<repo_id>/...``) stay well under the 255-byte
+# POSIX ``NAME_MAX`` limit even after suffixes like ``/symbol_graph.json``.
+# 64 leaves ample headroom for these suffixes on every supported FS.
+_REPO_ID_MAX_LENGTH = 64
+
+
+def validate_repo_id(repo_id: str) -> str:
+    """Return ``repo_id`` unchanged iff it is a safe path segment.
+
+    Enforces ``[A-Za-z0-9_-]+`` so that values like ``../outside``,
+    ``/tmp/x``, ``a/b``, empty strings, or unicode/shell-metacharacters
+    cannot escape ``<data_root>/indexes/`` via ``Path`` concatenation.
+    Callers construct filesystem paths from this value, so fail-fast at
+    the entry point (factory / CLI / demo) is preferable to defensive
+    checks scattered across each index loader.
+
+    CB-R2-001: values longer than ``_REPO_ID_MAX_LENGTH`` are rejected so
+    overly long ids surface as a clear ``ValueError`` here rather than as
+    a late ``OSError`` from ``Path`` operations on the resulting index
+    directory.
+    """
+    if not isinstance(repo_id, str):
+        raise TypeError(f"repo_id must be str, got {type(repo_id).__name__}")
+    if not _REPO_ID_RE.match(repo_id):
+        raise ValueError(
+            f"repo_id must match [A-Za-z0-9_-]+ (got {repo_id!r}); "
+            "unsafe characters or path traversal segments are rejected."
+        )
+    if len(repo_id) > _REPO_ID_MAX_LENGTH:
+        raise ValueError(
+            f"repo_id length {len(repo_id)} exceeds {_REPO_ID_MAX_LENGTH} "
+            "characters; shorten it so derived filesystem paths stay "
+            "within OS limits."
+        )
+    return repo_id
 
 
 def deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
@@ -74,3 +118,30 @@ def load_config(path: str | Path) -> Config:
     cfg = Config(data)
     object.__setattr__(cfg, "_config_path", str(path))
     return cfg
+
+
+def is_symbol_graph_enabled(cfg: Config | dict[str, Any]) -> bool:
+    """Return whether ``indexing.symbol_graph.enabled`` is on (default True).
+
+    Accepts a :class:`Config` instance (which exposes ``.get()`` and
+    recursively wraps nested dicts) or a plain ``dict``. The recursive
+    lookup relies only on the shared ``.get(key, default)`` protocol, so
+    both forms work without branching. Missing intermediate blocks resolve
+    to the default ``True`` so existing configurations that predate
+    Issue #109 keep their current behaviour.
+
+    CB-003: Non-bool YAML values (e.g. the quoted string ``"false"``, or
+    an integer) are rejected with :class:`TypeError`. ``bool("false")`` is
+    ``True`` in Python, so a silent truthy cast here would silently enable
+    the symbol graph on operator typos. Fail-fast keeps wiring bugs
+    visible in CI instead of surfacing as load-time errors later.
+    """
+    indexing = cfg.get("indexing", {}) or {}
+    symbol_graph = indexing.get("symbol_graph", {}) or {}
+    val = symbol_graph.get("enabled", True)
+    if not isinstance(val, bool):
+        raise TypeError(
+            "indexing.symbol_graph.enabled must be a bool (true/false), "
+            f"got {type(val).__name__}={val!r}"
+        )
+    return val

--- a/baseline_reporag/ingestion/chunker.py
+++ b/baseline_reporag/ingestion/chunker.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import ast
-from dataclasses import dataclass
+import re
+from dataclasses import dataclass, field
 
 
 @dataclass
@@ -131,6 +132,41 @@ def _chunk_python(
 
 
 # ---------------------------------------------------------------------------
+# Shared sliding-window helper (Issue #109 DR2-004)
+# ---------------------------------------------------------------------------
+
+
+def _slide_char_window(
+    text: str,
+    *,
+    max_chars: int,
+    overlap_chars: int,
+) -> list[tuple[int, int, str]]:
+    """Slide a character window over ``text``.
+
+    Returns ``(start_char, end_char, body)`` tuples. Pure function — no line
+    indexing, no ``Chunk`` construction. Used by ``_chunk_plain`` (wrapped
+    back into line indices) and by the markdown paragraph overflow fallback
+    (consumed directly so offsets land inside the original paragraph).
+    """
+    if max_chars <= 0:
+        raise ValueError("max_chars must be positive")
+    step = max(1, max_chars - max(0, overlap_chars))
+    if len(text) <= max_chars:
+        return [(0, len(text), text)]
+    out: list[tuple[int, int, str]] = []
+    start = 0
+    n = len(text)
+    while start < n:
+        end = min(n, start + max_chars)
+        out.append((start, end, text[start:end]))
+        if end >= n:
+            break
+        start += step
+    return out
+
+
+# ---------------------------------------------------------------------------
 # Plain text / line-based chunker (used for non-Python files and fallback)
 # ---------------------------------------------------------------------------
 
@@ -185,6 +221,322 @@ def _chunk_plain(
 
 
 # ---------------------------------------------------------------------------
+# Markdown chunker (Issue #109)
+# ---------------------------------------------------------------------------
+
+# Heading regex: captures only H1-H3 (^#{1,3} ) per design decision #6.
+_HEADING_RE = re.compile(r"^(#{1,3})\s+(.+?)\s*$")
+# Article/section boundary: 第N条 / 第N節 with half-width, full-width, or
+# kanji digits. Leading whitespace disqualifies (indented lines are body).
+_ARTICLE_RE = re.compile(r"^第[0-9０-９〇一二三四五六七八九十百千]+[条節](?:\s|$)")
+# Backtick code fence. Captures the full backtick run so we can compare
+# opener vs. closer length (CB-002: 4-backtick opener must not close on a
+# 3-backtick inner line). Tildes are intentionally excluded per design #6.
+_BACKTICK_FENCE_RE = re.compile(r"^(`{3,})")
+
+
+@dataclass
+class _Boundary:
+    line_idx: int  # 0-based index into the `lines` list
+    kind: str  # "heading" | "article"
+    level: int  # 1..3 for headings, 0 for articles
+    title: str
+
+
+@dataclass
+class _Section:
+    header_path: list[str]
+    body: str
+    start_line: int  # 1-based
+    end_line: int  # 1-based inclusive
+    article_lead: bool = field(default=False)
+
+
+def _detect_markdown_boundaries(lines: list[str]) -> list[_Boundary]:
+    """Scan ``lines`` and return boundary positions.
+
+    Headings (H1-H3) and article/section openers (``第N条``/``第N節`` at
+    column 0) act as boundaries. Backtick fences toggle a guard so that
+    ``#`` characters inside fenced code do not register as headings.
+    Tilde-fenced and indented blocks are treated as normal body.
+
+    CB-002: the length of the opening backtick run is kept in
+    ``open_fence_len``. A line only closes the fence if its leading
+    backtick run is at least that long — otherwise shorter inner
+    ``````` lines would close a 4-backtick opener and leak ``#`` lines
+    back into the heading scanner.
+    """
+    boundaries: list[_Boundary] = []
+    open_fence_len: int | None = None
+    for i, raw in enumerate(lines):
+        stripped = raw.rstrip("\n\r")
+        fence_match = _BACKTICK_FENCE_RE.match(stripped)
+        if fence_match:
+            run_len = len(fence_match.group(1))
+            if open_fence_len is None:
+                open_fence_len = run_len
+            elif run_len >= open_fence_len:
+                open_fence_len = None
+            # A shorter inner run is body, not a fence toggle — keep
+            # scanning, but the line stays suppressed from heading
+            # detection because we're still inside the fence.
+            continue
+        if open_fence_len is not None:
+            continue
+        m = _HEADING_RE.match(stripped)
+        if m:
+            level = len(m.group(1))
+            title = m.group(2).strip()
+            boundaries.append(
+                _Boundary(line_idx=i, kind="heading", level=level, title=title)
+            )
+            continue
+        if _ARTICLE_RE.match(stripped):
+            title = stripped.strip()
+            boundaries.append(
+                _Boundary(line_idx=i, kind="article", level=0, title=title)
+            )
+    return boundaries
+
+
+def _format_section_header(path: list[str]) -> str:
+    return " > ".join(p for p in path if p)
+
+
+def _build_sections(lines: list[str], boundaries: list[_Boundary]) -> list[_Section]:
+    """Convert boundary positions into concrete sections with bodies.
+
+    ``path`` only carries H1-H3 titles (H4+ aren't detected as boundaries
+    in the first place). Article openers don't push a new path level —
+    the article body is attached to the current heading path. Each
+    article opener produces its own section so the article line itself
+    becomes part of that section's body.
+    """
+    if not lines:
+        return []
+
+    if not boundaries:
+        body = "".join(lines)
+        if not body.strip():
+            return []
+        return [_Section(header_path=[], body=body, start_line=1, end_line=len(lines))]
+
+    sections: list[_Section] = []
+    heading_stack: list[tuple[int, str]] = []  # (level, title)
+
+    # Optional preamble (lines before the first boundary)
+    first_idx = boundaries[0].line_idx
+    if first_idx > 0:
+        body = "".join(lines[:first_idx])
+        if body.strip():
+            sections.append(
+                _Section(
+                    header_path=[],
+                    body=body,
+                    start_line=1,
+                    end_line=first_idx,
+                )
+            )
+
+    for i, b in enumerate(boundaries):
+        start = b.line_idx
+        end = boundaries[i + 1].line_idx if i + 1 < len(boundaries) else len(lines)
+        if b.kind == "heading":
+            # Trim stack to strictly shallower levels, then push.
+            while heading_stack and heading_stack[-1][0] >= b.level:
+                heading_stack.pop()
+            heading_stack.append((b.level, b.title))
+            header_path = [title for _, title in heading_stack]
+            article_lead = False
+        else:
+            header_path = [title for _, title in heading_stack]
+            article_lead = True
+
+        # Body for this section: lines[start:end]. For a heading we skip
+        # the heading line itself so the header isn't duplicated inside
+        # the body content.
+        body_start = start + 1 if b.kind == "heading" else start
+        body = "".join(lines[body_start:end])
+        if not body.strip():
+            continue
+        sections.append(
+            _Section(
+                header_path=header_path,
+                body=body,
+                start_line=body_start + 1,
+                end_line=end,
+                article_lead=article_lead,
+            )
+        )
+
+    return sections
+
+
+_PARA_SEP_RE = re.compile(r"\n[ \t]*\n+")
+
+
+def _split_paragraphs(text: str) -> list[str]:
+    """Split on one-or-more blank lines. Empty fragments are dropped."""
+    parts = _PARA_SEP_RE.split(text)
+    return [p for p in parts if p.strip()]
+
+
+def _apply_size_limit(
+    sections: list[_Section],
+    *,
+    rel_path: str,
+    repo_id: str,
+    repo_commit: str,
+    max_chars: int,
+    overlap_chars: int,
+    file_header: str,
+) -> list[Chunk]:
+    """Emit ``Chunk`` objects, splitting oversize sections on paragraphs.
+
+    Paragraphs are joined greedily up to ``max_chars``. A single paragraph
+    bigger than ``max_chars`` falls back to :func:`_slide_char_window`
+    (see design decision #6).
+
+    CB-001: when a section is split into multiple pieces, every piece
+    reused ``sec.start_line`` / ``sec.end_line`` — which collides in
+    ``chunk_id`` and overwrites entries in ``ChunkStore``. We now buffer
+    the pieces per section and, if there are 2+, append a ``#partN``
+    suffix to the chunk_id. Single-chunk sections keep the original
+    ``{repo}::{path}::{start}-{end}`` shape so existing citation /
+    retrieval tests are untouched.
+    """
+    chunks: list[Chunk] = []
+    for sec in sections:
+        header = _format_section_header(sec.header_path)
+        body = sec.body
+        if len(body) <= max_chars:
+            chunks.append(
+                _make_md_chunk(
+                    body=body,
+                    rel_path=rel_path,
+                    repo_id=repo_id,
+                    repo_commit=repo_commit,
+                    start_line=sec.start_line,
+                    end_line=sec.end_line,
+                    section_header=header,
+                    file_header=file_header,
+                )
+            )
+            continue
+
+        # Oversize section: collect pieces first, then stamp unique ids.
+        pieces: list[str] = []
+        paragraphs = _split_paragraphs(body)
+        current_parts: list[str] = []
+        current_len = 0
+        for para in paragraphs:
+            if len(para) > max_chars:
+                if current_parts:
+                    pieces.append("\n\n".join(current_parts))
+                    current_parts = []
+                    current_len = 0
+                for _s, _e, piece in _slide_char_window(
+                    para, max_chars=max_chars, overlap_chars=overlap_chars
+                ):
+                    pieces.append(piece)
+                continue
+            if current_len and current_len + len(para) + 2 > max_chars:
+                pieces.append("\n\n".join(current_parts))
+                current_parts = []
+                current_len = 0
+            current_parts.append(para)
+            current_len += len(para) + (2 if current_len else 0)
+        if current_parts:
+            pieces.append("\n\n".join(current_parts))
+
+        # Emit with a stable ``#partN`` suffix so chunk_ids stay unique
+        # even when line numbers cannot be recovered reliably.
+        total = len(pieces)
+        for idx, piece in enumerate(pieces, start=1):
+            suffix = f"#part{idx}of{total}" if total > 1 else ""
+            chunks.append(
+                _make_md_chunk(
+                    body=piece,
+                    rel_path=rel_path,
+                    repo_id=repo_id,
+                    repo_commit=repo_commit,
+                    start_line=sec.start_line,
+                    end_line=sec.end_line,
+                    section_header=header,
+                    file_header=file_header,
+                    id_suffix=suffix,
+                )
+            )
+    return chunks
+
+
+def _make_md_chunk(
+    *,
+    body: str,
+    rel_path: str,
+    repo_id: str,
+    repo_commit: str,
+    start_line: int,
+    end_line: int,
+    section_header: str,
+    file_header: str,
+    id_suffix: str = "",
+) -> Chunk:
+    # CB-001: ``id_suffix`` is empty for single-chunk sections (unchanged
+    # id shape) and ``#partNofM`` when a section was split. The suffix is
+    # appended to ``chunk_id`` only; ``start_line`` / ``end_line`` still
+    # point at the enclosing section so citation ranges remain valid.
+    return Chunk(
+        chunk_id=_make_id(repo_id, rel_path, start_line, end_line) + id_suffix,
+        repo_id=repo_id,
+        repo_commit=repo_commit,
+        rel_path=rel_path,
+        language="markdown",
+        start_line=start_line,
+        end_line=end_line,
+        content=body,
+        symbols=[],
+        section_header=section_header,
+        file_header=file_header,
+    )
+
+
+def _chunk_markdown(
+    content: str,
+    rel_path: str,
+    repo_id: str,
+    repo_commit: str,
+    max_chars: int,
+    overlap_chars: int,
+) -> list[Chunk]:
+    """Chunk a Markdown document into heading/article-aware sections.
+
+    Honours H1-H3 headings, ``第N条`` / ``第N節`` article/section openers,
+    and backtick code fences. H4+ headings are not boundaries and are not
+    reflected in ``section_header``. Tilde fences and indented blocks are
+    plain body. Oversize sections split on paragraphs; single paragraphs
+    exceeding ``max_chars`` fall back to a character-level sliding window.
+    """
+    lines = content.splitlines(keepends=True)
+    header = _file_header(content)
+
+    if not lines or not content.strip():
+        return []
+
+    boundaries = _detect_markdown_boundaries(lines)
+    sections = _build_sections(lines, boundaries)
+    return _apply_size_limit(
+        sections,
+        rel_path=rel_path,
+        repo_id=repo_id,
+        repo_commit=repo_commit,
+        max_chars=max_chars,
+        overlap_chars=overlap_chars,
+        file_header=header,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Public entry point
 # ---------------------------------------------------------------------------
 
@@ -200,6 +552,10 @@ def chunk_file(
 ) -> list[Chunk]:
     if language == "python":
         return _chunk_python(
+            content, rel_path, repo_id, repo_commit, max_chars, overlap_chars
+        )
+    if language == "markdown":
+        return _chunk_markdown(
             content, rel_path, repo_id, repo_commit, max_chars, overlap_chars
         )
     return _chunk_plain(

--- a/baseline_reporag/pipeline.py
+++ b/baseline_reporag/pipeline.py
@@ -94,7 +94,7 @@ class RepoRAGPipeline:
         store: ChunkStore,
         lexical: LexicalIndex,
         embedding: EmbeddingIndex,
-        graph: SymbolGraph,
+        graph: SymbolGraph | None,
         sessions: SessionManager,
         generator: Generator,
         logger: RunLogger,

--- a/baseline_reporag/pipeline_factory.py
+++ b/baseline_reporag/pipeline_factory.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from .config import Config
+from .config import Config, is_symbol_graph_enabled, validate_repo_id
 from .contracts import QueryResult  # re-exported; MLX-free
 
 if TYPE_CHECKING:
@@ -106,11 +106,22 @@ def _build_baseline_deps_no_mlx(cfg: Config) -> dict:
     from .memory.session import SessionManager
     from .retrieval.reranker import CrossEncoderReranker
 
-    idx_dir = Path(cfg.paths.data_root) / "indexes" / cfg.repo.repo_id
+    # CB-004: refuse ``../outside`` / ``/tmp/x`` / etc. before they reach
+    # ``Path`` concatenation. ``scripts/build_symbol_graph.py`` already
+    # ran the same check; now every index-loading entry point does.
+    repo_id = validate_repo_id(cfg.repo.repo_id)
+    idx_dir = Path(cfg.paths.data_root) / "indexes" / repo_id
     store = ChunkStore(idx_dir / "chunks.db")
     lexical = LexicalIndex.load(idx_dir / "lexical.pkl")
     embedding = EmbeddingIndex.load(idx_dir / "embedding")
-    graph = SymbolGraph.load(idx_dir / "symbol_graph.json")
+    # Issue #109: ``indexing.symbol_graph.enabled=false`` skips graph load.
+    # The ``graph_expansion`` helper accepts ``graph=None`` and falls back
+    # to file-neighbors only (see ``retrieval/graph_expansion.py``).
+    graph: SymbolGraph | None = (
+        SymbolGraph.load(idx_dir / "symbol_graph.json")
+        if is_symbol_graph_enabled(cfg)
+        else None
+    )
     sessions = SessionManager(log_dir=Path(cfg.paths.log_root) / "sessions")
     generator = Generator(
         model_id=cfg.model.model_id,

--- a/baseline_reporag/retrieval/graph_expansion.py
+++ b/baseline_reporag/retrieval/graph_expansion.py
@@ -8,7 +8,7 @@ from .hybrid import RetrievalResult
 def expand_with_graph(
     results: list[RetrievalResult],
     store: ChunkStore,
-    graph: SymbolGraph,
+    graph: SymbolGraph | None,
     repo_id: str,
     repo_commit: str,
     max_hops: int = 1,
@@ -16,7 +16,12 @@ def expand_with_graph(
     neighborhood_before: int = 1,
     neighborhood_after: int = 1,
 ) -> list[str]:
-    """Return deduplicated chunk IDs: original + graph neighbors + file neighbors."""
+    """Return deduplicated chunk IDs: original + graph neighbors + file neighbors.
+
+    When ``graph is None`` (Issue #109: ``indexing.symbol_graph.enabled=false``
+    for non-Python repositories), the graph-neighbor expansion is skipped
+    but file-neighbor expansion via ``store.get_neighbors`` still runs.
+    """
     seen: set[str] = set()
     ordered: list[str] = []
 
@@ -28,14 +33,15 @@ def expand_with_graph(
     for r in results:
         add(r.chunk_id)
 
-    # Graph-based neighbors
-    for r in results:
-        if len(ordered) >= max_nodes:
-            break
-        for neighbor_id in graph.get_related_chunks(r.chunk_id, max_hops=max_hops):
+    # Graph-based neighbors (skipped when SymbolGraph is disabled)
+    if graph is not None:
+        for r in results:
             if len(ordered) >= max_nodes:
                 break
-            add(neighbor_id)
+            for neighbor_id in graph.get_related_chunks(r.chunk_id, max_hops=max_hops):
+                if len(ordered) >= max_nodes:
+                    break
+                add(neighbor_id)
 
     # File-level neighbors (before/after in the same file)
     primary_chunks = store.get_many([r.chunk_id for r in results])

--- a/baseline_reporag/tests/test_chunker_markdown.py
+++ b/baseline_reporag/tests/test_chunker_markdown.py
@@ -1,0 +1,332 @@
+"""Markdown chunker tests (Issue #109).
+
+Covers:
+- Heading boundary detection (H1-H3 only; H4+ not a boundary nor path element)
+- Article boundary regex (``第N条`` / ``第N節`` with half-width / full-width /
+  kanji digits; indented lines excluded)
+- Code fence handling (backtick fences only; tildes / indents are body text)
+- Empty-section skip
+- Section-header path construction (``"H1 > H3"`` when intermediate absent)
+- Size limit fallback (paragraph split; single-paragraph overflow via
+  ``_slide_char_window``)
+- Chunk field contract (``language``, ``symbols``, ``section_header``,
+  ``chunk_id``, ``file_header``)
+- ``chunk_file`` dispatch routing ``language="markdown"`` into
+  ``_chunk_markdown``
+"""
+
+from __future__ import annotations
+
+from baseline_reporag.ingestion.chunker import (
+    _chunk_markdown,
+    _slide_char_window,
+    chunk_file,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _md_chunks(content: str, *, max_chars: int = 2400, overlap_chars: int = 300):
+    return _chunk_markdown(
+        content=content,
+        rel_path="doc.md",
+        repo_id="repo",
+        repo_commit="head",
+        max_chars=max_chars,
+        overlap_chars=overlap_chars,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Heading boundary detection
+# ---------------------------------------------------------------------------
+
+
+class TestHeadingBoundaries:
+    def test_h1_split_produces_two_chunks(self):
+        content = "# Top\n\nbody-a\n\n# Next\n\nbody-b\n"
+        chunks = _md_chunks(content)
+        assert len(chunks) == 2
+        assert chunks[0].section_header == "Top"
+        assert chunks[1].section_header == "Next"
+
+    def test_h1_h2_h3_path_composition(self):
+        content = (
+            "# Parent\n\nintro\n\n## Child\n\nchild-body\n\n### Grand\n\ngrand-body\n"
+        )
+        chunks = _md_chunks(content)
+        headers = [c.section_header for c in chunks]
+        assert "Parent" in headers
+        assert "Parent > Child" in headers
+        assert "Parent > Child > Grand" in headers
+
+    def test_h4_plus_is_not_a_boundary_and_excluded_from_path(self):
+        content = (
+            "# Top\n\n"
+            "body-a\n\n"
+            "#### Detail\n\n"
+            "detail-body text that stays in the Top section.\n"
+        )
+        chunks = _md_chunks(content)
+        assert len(chunks) == 1
+        assert chunks[0].section_header == "Top"
+        # H4 heading text must NOT appear in section_header
+        assert "Detail" not in chunks[0].section_header
+
+    def test_parent_skip_only_lists_existing_levels(self):
+        # H1 then directly H3 (no H2)
+        content = "# Root\n\nbody-root\n\n### Leaf\n\nbody-leaf\n"
+        chunks = _md_chunks(content)
+        headers = [c.section_header for c in chunks]
+        # No '> (empty)' or double '>' artefact
+        assert "Root > Leaf" in headers
+        for h in headers:
+            assert "> >" not in h
+            assert "(" not in h
+
+
+# ---------------------------------------------------------------------------
+# 2. Article boundary detection
+# ---------------------------------------------------------------------------
+
+
+class TestArticleBoundaries:
+    def test_kanji_numeral_article_boundary(self):
+        content = "# Law\n\npreamble\n\n第十条 text of article ten.\n\n"
+        chunks = _md_chunks(content)
+        # Preamble + article chunk
+        joined = "\n".join(c.content for c in chunks)
+        assert "article ten" in joined
+        # An article-body chunk exists
+        assert any("第十条" in c.content for c in chunks)
+
+    def test_halfwidth_and_fullwidth_digit_article(self):
+        content = (
+            "# Law\n\n"
+            "第1条 halfwidth one\n\n"
+            "第１０条 fullwidth ten\n\n"
+            "第2節 section two\n"
+        )
+        chunks = _md_chunks(content)
+        # Each article starts a new section boundary
+        assert any("halfwidth one" in c.content for c in chunks)
+        assert any("fullwidth ten" in c.content for c in chunks)
+        assert any("section two" in c.content for c in chunks)
+        # We should have more than a single chunk.
+        assert len(chunks) >= 3
+
+    def test_indented_article_line_is_not_a_boundary(self):
+        content = (
+            "# Law\n\n"
+            "See the example below:\n\n"
+            "    第1条 (indented, inside a block quote)\n\n"
+            "continuing prose about article one.\n"
+        )
+        chunks = _md_chunks(content)
+        # Indented line must not create a new article section
+        # So only the H1 heading forms a boundary
+        assert len(chunks) == 1
+        assert chunks[0].section_header == "Law"
+
+
+# ---------------------------------------------------------------------------
+# 3. Code fence handling
+# ---------------------------------------------------------------------------
+
+
+class TestCodeFenceHandling:
+    def test_hash_inside_backtick_fence_is_not_heading(self):
+        content = (
+            "# Real\n\n"
+            "Before fence.\n\n"
+            "```\n"
+            "# not a heading\n"
+            "## also not\n"
+            "```\n\n"
+            "After fence.\n"
+        )
+        chunks = _md_chunks(content)
+        # Only one heading-driven section
+        assert len(chunks) == 1
+        assert chunks[0].section_header == "Real"
+        # Fence content survives in body
+        assert "# not a heading" in chunks[0].content
+
+    def test_longer_backtick_fence_not_closed_by_shorter_inner_line(self):
+        """CB-002: 4-backtick fence must not close on a 3-backtick inner line.
+
+        Markdown spec allows any run of 3+ backticks as an opener, but
+        the closing fence must be at least as long as the opener. If the
+        chunker toggles on ``^```` the 3-backtick inner line closes the
+        fence and the subsequent ``# inside`` registers as a heading.
+        """
+        content = (
+            "# Top\n\n"
+            "Before fence.\n\n"
+            "````\n"
+            "nested ```\n"
+            "# inside fenced block\n"
+            "````\n\n"
+            "After fence.\n"
+        )
+        chunks = _md_chunks(content)
+        # Only one heading boundary (``# Top``) — ``# inside`` is still
+        # inside the 4-backtick fence.
+        assert len(chunks) == 1
+        assert chunks[0].section_header == "Top"
+        assert "# inside fenced block" in chunks[0].content
+
+    def test_tilde_lines_are_body_not_fence(self):
+        """Tilde fences (``~~~``) are plain body text per design #6.
+
+        The chunker does NOT treat ``~~~`` as a code fence, so it does
+        not toggle fence state — meaning tilde lines themselves are
+        normal body lines and are NOT heading boundaries. Headings
+        adjacent to tilde lines still work as usual.
+        """
+        content = (
+            "# Top\n\n"
+            "Body before.\n\n"
+            "~~~\n"
+            "tilde line without leading hash\n"
+            "~~~\n\n"
+            "After.\n\n"
+            "## Sub\n\nsub-body\n"
+        )
+        chunks = _md_chunks(content)
+        headers = [c.section_header for c in chunks]
+        assert "Top" in headers
+        assert "Top > Sub" in headers
+
+
+# ---------------------------------------------------------------------------
+# 4. Empty section skipping
+# ---------------------------------------------------------------------------
+
+
+class TestEmptySections:
+    def test_empty_section_skipped(self):
+        content = "# Header1\n\n\n# Header2\n\nbody here\n"
+        chunks = _md_chunks(content)
+        # First H1 has empty body → skip
+        assert len(chunks) == 1
+        assert chunks[0].section_header == "Header2"
+
+
+# ---------------------------------------------------------------------------
+# 5. Size limit / paragraph split / single-paragraph overflow
+# ---------------------------------------------------------------------------
+
+
+class TestSizeLimit:
+    def test_paragraph_split_when_section_exceeds_max_chars(self):
+        para1 = "p1 " * 200  # ~600 chars
+        para2 = "p2 " * 200
+        para3 = "p3 " * 200
+        content = f"# Big\n\n{para1}\n\n{para2}\n\n{para3}\n"
+        chunks = _md_chunks(content, max_chars=500, overlap_chars=50)
+        assert len(chunks) >= 2
+        assert all(c.section_header == "Big" for c in chunks)
+
+    def test_single_paragraph_overflow_falls_back_to_slide_window(self):
+        long_para = "x" * 3000
+        content = f"# Over\n\n{long_para}\n"
+        chunks = _md_chunks(content, max_chars=500, overlap_chars=50)
+        assert len(chunks) >= 2
+        assert all(c.section_header == "Over" for c in chunks)
+
+    def test_paragraph_split_chunk_ids_are_unique(self):
+        """CB-001: paragraph-split oversize sections must have unique chunk_ids.
+
+        Previously every split piece reused ``sec.start_line``/
+        ``sec.end_line`` so ``repo::doc.md::2-5`` was emitted multiple
+        times, which collides in ``ChunkStore``. The fix differentiates
+        each slice (distinct line range or suffix).
+        """
+        para1 = "p1 " * 200
+        para2 = "p2 " * 200
+        para3 = "p3 " * 200
+        content = f"# Big\n\n{para1}\n\n{para2}\n\n{para3}\n"
+        chunks = _md_chunks(content, max_chars=500, overlap_chars=50)
+        assert len(chunks) >= 2
+        ids = [c.chunk_id for c in chunks]
+        assert len(ids) == len(set(ids)), f"duplicate chunk_ids: {ids}"
+
+    def test_single_paragraph_overflow_chunk_ids_are_unique(self):
+        """CB-001: slide-window fallback must also emit unique chunk_ids."""
+        long_para = "x" * 3000
+        content = f"# Over\n\n{long_para}\n"
+        chunks = _md_chunks(content, max_chars=500, overlap_chars=50)
+        assert len(chunks) >= 2
+        ids = [c.chunk_id for c in chunks]
+        assert len(ids) == len(set(ids)), f"duplicate chunk_ids: {ids}"
+
+    def test_slide_char_window_single_short_text(self):
+        out = _slide_char_window("hello", max_chars=10, overlap_chars=2)
+        assert out == [(0, 5, "hello")]
+
+    def test_slide_char_window_advances_by_step(self):
+        text = "a" * 25
+        out = _slide_char_window(text, max_chars=10, overlap_chars=2)
+        # step = 10 - 2 = 8; windows start at 0, 8, 16 (last extends to 25)
+        assert out[0][0] == 0
+        assert out[1][0] == 8
+        # every returned window's body matches the slice
+        for start, end, body in out:
+            assert body == text[start:end]
+        # last window ends at text length
+        assert out[-1][1] == len(text)
+
+
+# ---------------------------------------------------------------------------
+# 6. Chunk field contract
+# ---------------------------------------------------------------------------
+
+
+class TestChunkFields:
+    def test_markdown_chunks_populate_all_fields(self):
+        content = "# Heading\n\n## Sub\n\nbody content for the subsection\n"
+        chunks = _md_chunks(content)
+        c = chunks[-1]
+        assert c.language == "markdown"
+        assert c.symbols == []
+        assert c.section_header == "Heading > Sub"
+        # chunk_id contract: repo_id::rel_path::start-end
+        assert c.chunk_id.startswith("repo::doc.md::")
+        # file_header captures the head of content
+        assert c.file_header.startswith("# Heading")
+
+
+# ---------------------------------------------------------------------------
+# 7. chunk_file dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestChunkFileDispatch:
+    def test_markdown_language_dispatches_to_markdown_chunker(self):
+        content = "# Doc\n\nbody content\n"
+        chunks = chunk_file(
+            content=content,
+            rel_path="README.md",
+            language="markdown",
+            repo_id="repo",
+            repo_commit="head",
+        )
+        assert len(chunks) == 1
+        assert chunks[0].language == "markdown"
+        assert chunks[0].section_header == "Doc"
+
+    def test_non_markdown_falls_back_to_existing_behaviour(self):
+        content = "some plain text body\n"
+        chunks = chunk_file(
+            content=content,
+            rel_path="notes.txt",
+            language="plaintext",
+            repo_id="repo",
+            repo_commit="head",
+        )
+        assert chunks[0].language == "plaintext"
+        assert chunks[0].section_header == ""

--- a/baseline_reporag/tests/test_config.py
+++ b/baseline_reporag/tests/test_config.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from baseline_reporag.config import Config, deep_merge
+import pytest
+
+from baseline_reporag.config import Config, deep_merge, is_symbol_graph_enabled
 
 
 class TestDeepMerge:
@@ -90,3 +92,51 @@ class TestConfigToDict:
         cfg = Config({"items": [{"id": 1}, {"id": 2}]})
         d = cfg.to_dict()
         assert d == {"items": [{"id": 1}, {"id": 2}]}
+
+
+class TestIsSymbolGraphEnabled:
+    """Issue #109: ``indexing.symbol_graph.enabled`` flag honoring."""
+
+    def test_explicit_true(self):
+        cfg = Config({"indexing": {"symbol_graph": {"enabled": True}}})
+        assert is_symbol_graph_enabled(cfg) is True
+
+    def test_explicit_false(self):
+        cfg = Config({"indexing": {"symbol_graph": {"enabled": False}}})
+        assert is_symbol_graph_enabled(cfg) is False
+
+    def test_missing_symbol_graph_block_defaults_true(self):
+        cfg = Config({"indexing": {"other_key": 1}})
+        assert is_symbol_graph_enabled(cfg) is True
+
+    def test_missing_indexing_block_defaults_true(self):
+        cfg = Config({"repo": {"repo_id": "x"}})
+        assert is_symbol_graph_enabled(cfg) is True
+
+    def test_plain_dict_compatible(self):
+        cfg = {"indexing": {"symbol_graph": {"enabled": False}}}
+        assert is_symbol_graph_enabled(cfg) is False
+
+    def test_plain_dict_default_true(self):
+        assert is_symbol_graph_enabled({}) is True
+
+    # CB-003: non-bool values must raise rather than silently pass through.
+    def test_quoted_string_false_raises(self):
+        cfg = Config({"indexing": {"symbol_graph": {"enabled": "false"}}})
+        with pytest.raises((TypeError, ValueError)):
+            is_symbol_graph_enabled(cfg)
+
+    def test_quoted_string_true_raises(self):
+        cfg = Config({"indexing": {"symbol_graph": {"enabled": "true"}}})
+        with pytest.raises((TypeError, ValueError)):
+            is_symbol_graph_enabled(cfg)
+
+    def test_integer_value_raises(self):
+        cfg = Config({"indexing": {"symbol_graph": {"enabled": 1}}})
+        with pytest.raises((TypeError, ValueError)):
+            is_symbol_graph_enabled(cfg)
+
+    def test_list_value_raises(self):
+        cfg = {"indexing": {"symbol_graph": {"enabled": [True]}}}
+        with pytest.raises((TypeError, ValueError)):
+            is_symbol_graph_enabled(cfg)

--- a/baseline_reporag/tests/test_graph_expansion.py
+++ b/baseline_reporag/tests/test_graph_expansion.py
@@ -1,0 +1,97 @@
+"""Tests for ``expand_with_graph`` including ``graph=None`` support (Issue #109)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from baseline_reporag.ingestion.chunker import Chunk
+from baseline_reporag.retrieval.graph_expansion import expand_with_graph
+from baseline_reporag.retrieval.hybrid import RetrievalResult
+
+
+def _make_chunk(chunk_id: str, rel_path: str = "a.py") -> Chunk:
+    return Chunk(
+        chunk_id=chunk_id,
+        repo_id="test",
+        repo_commit="abc",
+        rel_path=rel_path,
+        language="python",
+        start_line=1,
+        end_line=10,
+        content="pass",
+        symbols=[],
+        section_header="",
+        file_header="",
+    )
+
+
+def _make_result(chunk_id: str) -> RetrievalResult:
+    return RetrievalResult(
+        chunk_id=chunk_id, score=1.0, lexical_score=0.5, embedding_score=0.5
+    )
+
+
+class TestExpandWithGraph:
+    def test_graph_provided_preserves_existing_behaviour(self):
+        """``graph != None`` keeps graph-neighbor expansion + file-neighbors."""
+        results = [_make_result("c0"), _make_result("c1")]
+
+        store = MagicMock()
+        store.get_many.return_value = [_make_chunk("c0"), _make_chunk("c1")]
+        store.get_neighbors.return_value = [_make_chunk("c2")]
+
+        graph = MagicMock()
+        graph.get_related_chunks.return_value = ["c3"]
+
+        out = expand_with_graph(
+            results=results,
+            store=store,
+            graph=graph,
+            repo_id="test",
+            repo_commit="abc",
+        )
+
+        assert out[0] == "c0"
+        assert out[1] == "c1"
+        assert "c3" in out  # graph-neighbor
+        assert "c2" in out  # file-neighbor
+        graph.get_related_chunks.assert_called()
+
+    def test_graph_none_skips_graph_neighbors_keeps_file_neighbors(self):
+        """``graph=None`` must skip graph-neighbors yet preserve file-neighbors."""
+        results = [_make_result("c0"), _make_result("c1")]
+
+        store = MagicMock()
+        store.get_many.return_value = [_make_chunk("c0"), _make_chunk("c1")]
+        store.get_neighbors.return_value = [_make_chunk("c2")]
+
+        out = expand_with_graph(
+            results=results,
+            store=store,
+            graph=None,
+            repo_id="test",
+            repo_commit="abc",
+        )
+
+        # original candidates preserved
+        assert out[0] == "c0"
+        assert out[1] == "c1"
+        # file-neighbors preserved
+        assert "c2" in out
+        # store continues to be consulted for file-neighbors
+        store.get_many.assert_called_once()
+        store.get_neighbors.assert_called()
+
+    def test_empty_candidates_returns_empty(self):
+        """No candidates → empty output, store should not error."""
+        store = MagicMock()
+        store.get_many.return_value = []
+
+        out = expand_with_graph(
+            results=[],
+            store=store,
+            graph=None,
+            repo_id="test",
+            repo_commit="abc",
+        )
+        assert out == []

--- a/baseline_reporag/tests/test_photon_pipeline.py
+++ b/baseline_reporag/tests/test_photon_pipeline.py
@@ -4206,3 +4206,70 @@ class TestWorkingMemoryConfigPastTurnPinningYamlPropagation:
         assert wm.enabled is True
         assert wm.max_turns == 5
         assert abs(wm.decay_factor - 0.25) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Issue #109: graph=None type compatibility at PHOTON pipeline layer
+# ---------------------------------------------------------------------------
+
+
+class TestPhotonPipelineGraphNoneCompatibility:
+    """``baseline_deps['graph']=None`` must build and query without error.
+
+    The real graph=None runtime branch is covered in
+    ``test_graph_expansion.py``; this test only asserts type compatibility
+    of PHOTON's internal ``RepoRAGPipeline`` construction when callers
+    pass ``graph=None`` (``expand_with_graph`` is still patched).
+    """
+
+    def test_photon_pipeline_builds_with_graph_none(self):
+        from baseline_reporag.ingestion.chunker import Chunk
+
+        cfg = _make_pruning_cfg_disabled()
+        pipeline, baseline_deps, photon_deps, mock_session, mock_results = (
+            _setup_pipeline_for_pruning(cfg, session_turns=0)
+        )
+
+        # Swap baseline.graph to None to simulate the enabled=false path.
+        pipeline.baseline.graph = None
+
+        chunks = [
+            Chunk(
+                chunk_id=f"chunk_{i}",
+                repo_id="test-repo",
+                repo_commit="abc123",
+                rel_path=f"file{i}.py",
+                language="python",
+                start_line=1,
+                end_line=10,
+                content=f"def func_{i}(): pass",
+                symbols=[f"func_{i}"],
+                section_header="",
+                file_header="",
+            )
+            for i in range(16)
+        ]
+
+        def mock_get_many(ids):
+            by_id = {c.chunk_id: c for c in chunks}
+            return [by_id[cid] for cid in ids if cid in by_id]
+
+        baseline_deps["store"].get_many.side_effect = mock_get_many
+        expanded_ids = [f"chunk_{i}" for i in range(16)]
+
+        with (
+            patch(
+                "baseline_reporag.photon_pipeline.hybrid_search",
+                return_value=mock_results,
+            ),
+            patch(
+                "baseline_reporag.photon_pipeline.expand_with_graph",
+                return_value=expanded_ids,
+            ),
+        ):
+            baseline_deps["generator"].generate.return_value = "Answer [C:1]"
+            result = pipeline.query(
+                "test question", session_id="s1", repo_id="test-repo"
+            )
+
+        assert result.answer == "Answer [C:1]"

--- a/baseline_reporag/tests/test_pipeline_integration.py
+++ b/baseline_reporag/tests/test_pipeline_integration.py
@@ -353,3 +353,71 @@ class TestCitationPostprocess:
         log_payload = pipeline.logger.log_turn.call_args[0][0]
         assert "citation_postprocessed" in log_payload
         assert log_payload["citation_postprocessed"] is True
+
+
+# ---------------------------------------------------------------------------
+# Issue #109: graph=None type compatibility at pipeline layer
+# ---------------------------------------------------------------------------
+
+
+@patch(
+    "baseline_reporag.pipeline.expand_with_graph",
+    side_effect=_mock_expand_with_graph,
+)
+@patch(
+    "baseline_reporag.pipeline.hybrid_search",
+    side_effect=_mock_hybrid_search,
+)
+class TestGraphNoneTypeCompatibility:
+    """Issue #109: ``graph=None`` must not cause assembly / type errors.
+
+    Actual ``graph is None`` branching is covered in
+    ``test_graph_expansion.py``. This test only verifies that the
+    pipeline can be built and a turn completes when ``graph=None`` is
+    plumbed through (``expand_with_graph`` is still patched).
+    """
+
+    def test_pipeline_accepts_graph_none(
+        self,
+        mock_search: MagicMock,
+        mock_expand: MagicMock,
+    ) -> None:
+        cfg_data = {
+            "repo": {"repo_id": "test_repo", "repo_commit": "abc123"},
+            "retrieval": {
+                "lexical_top_k": 10,
+                "embedding_top_k": 10,
+                "fused_top_k": 8,
+                "rerank_top_k": 8,
+                "weights": {"lexical": 0.5, "embedding": 0.5},
+                "graph_expansion": {"max_hops": 1, "max_nodes": 16},
+                "neighborhood_expansion": {"before": 1, "after": 1},
+                "query_expansion": {"enabled": False},
+                "reranker": {"enabled": False},
+                "file_type_boost": 0.0,
+            },
+            "evidence_pack": {"max_chunks": 16, "max_tokens": 16000},
+            "model": {"model_id": "test-model"},
+        }
+        config = Config(cfg_data)
+
+        mock_store = MagicMock()
+        mock_store.get_many.return_value = _make_test_chunks()
+
+        mock_gen = MagicMock()
+        mock_gen.generate.return_value = "Answer with [C:1]."
+
+        sessions = SessionManager()
+
+        pipeline = RepoRAGPipeline(
+            config=config,
+            store=mock_store,
+            lexical=MagicMock(),
+            embedding=MagicMock(),
+            graph=None,  # Issue #109: symbol-graph disabled path.
+            sessions=sessions,
+            generator=mock_gen,
+            logger=MagicMock(),
+        )
+        result = pipeline.query("test question", session_id="s1")
+        assert result.answer.endswith("[C:1].")

--- a/demo/run_demo.py
+++ b/demo/run_demo.py
@@ -35,7 +35,11 @@ def main() -> None:
         print(f"Available: {[s.id for s in SCENARIOS]}")
         return
 
-    from baseline_reporag.config import load_config
+    from baseline_reporag.config import (
+        is_symbol_graph_enabled,
+        load_config,
+        validate_repo_id,
+    )
     from baseline_reporag.generation.generator import Generator
     from baseline_reporag.indexing.embedding import EmbeddingIndex
     from baseline_reporag.indexing.lexical import LexicalIndex
@@ -46,16 +50,27 @@ def main() -> None:
     from baseline_reporag.pipeline import RepoRAGPipeline
 
     cfg = load_config(args.config)
-    repo_id = cfg.repo.repo_id
+    # CB-005: same allowlist as the CLI / pipeline factory. Fail-fast if
+    # the config carries ``../outside`` or an absolute path.
+    repo_id = validate_repo_id(cfg.repo.repo_id)
     idx_dir = Path(cfg.paths.data_root) / "indexes" / repo_id
     run_id = f"demo_{scenario.id}_{time.strftime('%Y%m%d')}"
+
+    # Issue #109: skip SymbolGraph.load when the feature is disabled
+    # (non-Python repositories).  graph=None is safe: expand_with_graph
+    # falls back to file-neighbors only.
+    graph: SymbolGraph | None = (
+        SymbolGraph.load(idx_dir / "symbol_graph.json")
+        if is_symbol_graph_enabled(cfg)
+        else None
+    )
 
     pipeline = RepoRAGPipeline(
         config=cfg,
         store=ChunkStore(idx_dir / "chunks.db"),
         lexical=LexicalIndex.load(idx_dir / "lexical.pkl"),
         embedding=EmbeddingIndex.load(idx_dir / "embedding"),
-        graph=SymbolGraph.load(idx_dir / "symbol_graph.json"),
+        graph=graph,
         sessions=SessionManager(log_dir=Path(cfg.paths.log_root) / "sessions"),
         generator=Generator(
             model_id=cfg.model.model_id,

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -53,6 +53,13 @@ python scripts/build_symbol_graph.py --config configs/baseline.yaml
 
 Constructs import/call/inheritance edges for graph-expanded retrieval.
 
+> **Note (Issue #109)**: Symbol graph is **Python-centric**. Non-Python
+> corpora (e.g. 制度文書 markdown) can set
+> `indexing.symbol_graph.enabled: false` in the YAML to skip both
+> `build_symbol_graph.py` and the runtime `SymbolGraph.load()`. In that
+> mode `expand_with_graph` still returns file-neighbors, only the
+> graph-neighbor branch is skipped.
+
 ### 6. Start the server
 
 ```bash
@@ -282,3 +289,42 @@ baseline プロジェクトは `N/A (baseline_rag)`、working_memory OFF は `N/
 - 同時実行数は 1（`MAX_CONCURRENT_EVAL=1`）、wall-clock timeout 3600s
 
 Eval ジョブの状態は `.cache/photon_app_state.json` の `eval_jobs` dict に永続化される。起動時の subprocess は `shell=False`、結果 JSON は `reports/eval_runs/<job_id>.json`、ログは `logs/eval/<job_id>.log`（両方 gitignore 済み）。進捗は `PROGRESS done=N total=M p50_ms=X nc=Y` 形式のログ行から自動抽出。正常終了時に `reports/eval_runs/<job_id>.done` マーカーファイルが作成される。
+
+---
+
+## Breaking changes / Migration (Issue #109)
+
+### Markdown chunker の導入
+
+Issue #109 で `.md` ファイルは見出し（H1-H3）・条文（`第N条`/`第N節`）・コードフェンス（バッククォートのみ）を尊重する専用 chunker (`_chunk_markdown`) で分割されるようになった。これにより:
+
+- `Chunk.section_header` が空文字列から `"H1 > H3"` 形式に変わる（評価値に影響する可能性あり、Gate 2 v4 Static NC ±1pp 以内を許容帯としてモニタ）
+- `chunk_id` は `{repo_id}::{rel_path}::{start_line}-{end_line}` のまま維持されるが、境界位置が変わるため旧 chunk_id との互換性はなし
+
+**移行手順（既存 index を使っている repo 向け）**:
+
+```bash
+rm -rf data/indexes/<repo_id>/
+python scripts/ingest_repo.py --repo <path> --repo-id <repo_id> --config configs/<profile>.yaml
+python scripts/build_indexes.py --repo-id <repo_id> --config configs/<profile>.yaml
+# Python repo のみ（非 Python は enabled=false で skip される）
+python scripts/build_symbol_graph.py --repo-id <repo_id> --config configs/<profile>.yaml
+```
+
+### `indexing.symbol_graph.enabled: false` の新運用パターン
+
+制度文書（法令・規程など）のように Python シンボルが存在しないリポジトリでは symbol graph が無価値なため、以下の設定で build/load を完全に skip できる:
+
+```yaml
+indexing:
+  symbol_graph:
+    enabled: false
+```
+
+Skip される箇所:
+
+- `scripts/build_symbol_graph.py` は `Skipped: indexing.symbol_graph.enabled=false` を stdout に出して早期 return（`symbol_graph.json` は生成されない）
+- `baseline_reporag/pipeline_factory.py` は `SymbolGraph.load` を呼ばず `graph=None` を pipeline に渡す
+- `expand_with_graph` は `graph=None` の場合 graph-neighbors の展開を skip し、file-neighbors（`store.get_neighbors`）のみを返す
+
+この経路で pipeline を組み立てても retrieval / generation のインターフェースに変化はなく、既存 CLI / server も設定を変えるだけで動く。

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -168,3 +168,43 @@ top -pid $(pgrep -f baseline_reporag)
 7. **Concurrent 起動**: `MAX_CONCURRENT_EVAL=1` のため、既に running の eval がある場合は Start ボタンが disabled になる（仕様）。
 
 参考: 設計方針書 `workspace/design/issue-82-app-photon-features-design-policy.md` §6.4 / §7.2
+
+---
+
+## Symbol Graph が生成されない / ロードされない (Issue #109)
+
+**Symptom**: `scripts/build_symbol_graph.py` を実行しても `data/indexes/<repo_id>/symbol_graph.json` が生成されない、あるいは `pipeline_factory` 経由で pipeline を組み立てても `graph` が `None` になる。
+
+**Cause**: Issue #109 で `indexing.symbol_graph.enabled` フラグが honor されるようになった。制度文書など非 Python リポジトリ向けに **`false` を明示した config** を使っている場合、`scripts/build_symbol_graph.py` は skip ログを出して早期 return し、`pipeline_factory` は `SymbolGraph.load` を呼ばず `graph=None` で pipeline を組み立てる。これは意図した挙動である。
+
+**Checklist**:
+
+1. **意図的な skip か?**: 使用中の YAML の `indexing.symbol_graph.enabled` を確認。`false` なら symbol graph は使われない（Python 以外の repo で推奨）。
+2. **Python repo でも disable になっていないか**: `true` に戻し、`python scripts/build_symbol_graph.py --repo-id <id>` を再実行。
+3. **`symbol_graph.json` 欠落 + enabled=true**: 現行設計では fail-fast（`FileNotFoundError`）。`python scripts/build_symbol_graph.py --repo-id <id>` で再生成すること。
+
+---
+
+## Breaking changes / Migration: Markdown chunker の index 再構築 (Issue #109)
+
+**Symptom**: Issue #109 の markdown chunker が有効になった後、既存 index から markdown chunk を query すると `section_header` が空のままだったり、BM25/embedding のスコアが以前と大きく異なる。
+
+**Cause**: Issue #109 以前は `.md` ファイルを単純な sliding-window で chunk していたため、`section_header=""` が DB に保存されている。新しい chunker は見出し（H1-H3）や条文（`第N条`）境界を尊重するため、chunk 境界・`section_header` の内容・chunk_id が **すべて変わる**。
+
+**Migration 手順**:
+
+```bash
+# 1. 既存の index を完全削除（SQLite + embedding + BM25 + symbol_graph）
+rm -rf data/indexes/<repo_id>/
+
+# 2. ingest からやり直し
+python scripts/ingest_repo.py --repo <path-to-repo> --repo-id <repo_id> --config configs/<your>.yaml
+
+# 3. BM25 + embedding index 再構築
+python scripts/build_indexes.py --repo-id <repo_id> --config configs/<your>.yaml
+
+# 4. symbol graph（Python repo のみ。非 Python repo は enabled=false で skip される）
+python scripts/build_symbol_graph.py --repo-id <repo_id> --config configs/<your>.yaml
+```
+
+**注意**: SQLite chunk ID は `{repo_id}::{rel_path}::{start_line}-{end_line}` で、markdown の境界が変わる以上、旧 chunk_id と新 chunk_id は一致しない。セッション履歴（`logs/sessions/`）に残る旧 chunk_id は次ターンの retrieval 対象にはならないが、index を削除する前に参照していた citation は意味を失う点に留意。

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -82,6 +82,25 @@ python scripts/build_symbol_graph.py \
   --config configs/my_project.yaml
 ```
 
+### 制度文書 (markdown 中心) リポジトリの場合 (Issue #109)
+
+Python シンボルが存在しない制度文書リポジトリ（法令・規程 markdown など）では symbol graph の構築は不要で、かつ runtime の `SymbolGraph.load` もコストなので skip するのが推奨:
+
+```yaml
+# configs/my_institutional_docs.yaml
+indexing:
+  symbol_graph:
+    enabled: false          # Issue #109: symbol graph を完全に skip
+```
+
+この設定で:
+
+- `scripts/build_symbol_graph.py` は `Skipped: indexing.symbol_graph.enabled=false` を出して早期 return（`symbol_graph.json` は作らない）
+- CLI / server / demo 経由の `pipeline_factory.build_pipeline` も `SymbolGraph.load` を呼ばず `graph=None` で pipeline を組み立て
+- retrieval の graph 拡張は skip されるが file-neighbors（同じファイル内の前後 chunk）は継続的に使われる
+
+Markdown chunker（Issue #109）は見出し（H1-H3）・条文（`第N条`/`第N節`）・コードフェンスを尊重するので、制度文書の retrieval 精度（`section_header` の明示など）が改善される。
+
 ---
 
 ## Step 5: baseline_rag で動作確認

--- a/scripts/build_symbol_graph.py
+++ b/scripts/build_symbol_graph.py
@@ -13,9 +13,21 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from baseline_reporag.config import load_config
+from baseline_reporag.config import (
+    is_symbol_graph_enabled,
+    load_config,
+    validate_repo_id,
+)
 from baseline_reporag.indexing.symbol_graph import SymbolGraph
 from baseline_reporag.ingestion.store import ChunkStore
+
+
+def _validate_repo_id(repo_id: str) -> None:
+    # CB-004: delegate to the shared helper so CLI / factory / demo all
+    # enforce the same allowlist. The wrapper exists so existing test
+    # patches on ``_validate_repo_id`` (and the ``main`` call site) keep
+    # the same import-level shape.
+    validate_repo_id(repo_id)
 
 
 def main() -> None:
@@ -27,18 +39,33 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    _validate_repo_id(args.repo_id)
+
     cfg = load_config(args.config)
+
+    # Issue #109: ``indexing.symbol_graph.enabled=false`` skips build/save
+    # entirely (intended for non-Python repositories). The wrapper
+    # (app/photon_app.py) owns the ``DONE`` contract — this script only
+    # prints the skip reason.
+    if not is_symbol_graph_enabled(cfg):
+        print("Skipped: indexing.symbol_graph.enabled=false")
+        return
+
     repo_commit = args.commit if args.commit else cfg.repo.repo_commit
     idx_dir = Path(cfg.paths.data_root) / "indexes" / args.repo_id
 
     store = ChunkStore(idx_dir / "chunks.db")
     print(f"Building symbol graph for {args.repo_id}@{repo_commit} ...")
 
-    graph = SymbolGraph()
-    graph.build(store, args.repo_id, repo_commit)
-    graph.save(idx_dir / "symbol_graph.json")
-
-    store.close()
+    # CB-006: ensure the sqlite handle is closed even if build/save raise.
+    # Previously a failure in the middle left the handle open; subsequent
+    # retries could hit WAL/lock contention or descriptor leaks.
+    try:
+        graph = SymbolGraph()
+        graph.build(store, args.repo_id, repo_commit)
+        graph.save(idx_dir / "symbol_graph.json")
+    finally:
+        store.close()
     print(f"Done -> {idx_dir}/symbol_graph.json")
 
 

--- a/tests/test_build_symbol_graph_cli.py
+++ b/tests/test_build_symbol_graph_cli.py
@@ -1,0 +1,155 @@
+"""Tests for the ``scripts/build_symbol_graph.py`` CLI (Issue #109).
+
+Exercises the ``indexing.symbol_graph.enabled`` conditional skip: when
+disabled, the script must not call ``SymbolGraph.build`` or
+``SymbolGraph.save`` and should emit a skip log line on stdout.
+
+CB-006: also verifies ``ChunkStore.close()`` is called even when
+``SymbolGraph.build`` / ``.save`` raises.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPT_PATH = _ROOT / "scripts" / "build_symbol_graph.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location(
+        "build_symbol_graph_cli_under_test", _SCRIPT_PATH
+    )
+    assert spec is not None
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _write_cfg(path: Path, *, enabled: bool) -> None:
+    path.write_text(
+        "repo:\n"
+        "  repo_id: demo\n"
+        "  repo_commit: head\n"
+        "paths:\n"
+        f"  data_root: {path.parent / 'data'}\n"
+        "  log_root: logs\n"
+        "indexing:\n"
+        "  symbol_graph:\n"
+        f"    enabled: {'true' if enabled else 'false'}\n"
+    )
+
+
+class TestBuildSymbolGraphConditionalSkip:
+    def test_enabled_false_skips_build_and_save(self, tmp_path, capsys):
+        cfg_path = tmp_path / "cfg.yaml"
+        _write_cfg(cfg_path, enabled=False)
+
+        mod = _load_script_module()
+
+        with (
+            patch.object(mod, "SymbolGraph") as mock_graph_cls,
+            patch.object(mod, "ChunkStore") as mock_store_cls,
+            patch.object(
+                sys,
+                "argv",
+                [str(_SCRIPT_PATH), "--repo-id", "demo", "--config", str(cfg_path)],
+            ),
+        ):
+            mock_graph_cls.return_value = MagicMock()
+            mock_store_cls.return_value = MagicMock()
+            mod.main()
+
+        # Neither build nor save was invoked.
+        mock_graph_cls.return_value.build.assert_not_called()
+        mock_graph_cls.return_value.save.assert_not_called()
+
+        captured = capsys.readouterr()
+        assert "Skipped" in captured.out
+        assert "indexing.symbol_graph.enabled" in captured.out
+
+    def test_enabled_true_builds_and_saves(self, tmp_path, capsys):
+        cfg_path = tmp_path / "cfg.yaml"
+        _write_cfg(cfg_path, enabled=True)
+
+        mod = _load_script_module()
+
+        with (
+            patch.object(mod, "SymbolGraph") as mock_graph_cls,
+            patch.object(mod, "ChunkStore") as mock_store_cls,
+            patch.object(
+                sys,
+                "argv",
+                [str(_SCRIPT_PATH), "--repo-id", "demo", "--config", str(cfg_path)],
+            ),
+        ):
+            mock_graph_cls.return_value = MagicMock()
+            mock_store_cls.return_value = MagicMock()
+            mod.main()
+
+        mock_graph_cls.return_value.build.assert_called_once()
+        mock_graph_cls.return_value.save.assert_called_once()
+
+
+class TestBuildSymbolGraphStoreCloseOnFailure:
+    """CB-006: ``ChunkStore`` must close even on ``build()``/``save()`` failure."""
+
+    def test_store_closed_when_build_raises(self, tmp_path):
+        cfg_path = tmp_path / "cfg.yaml"
+        _write_cfg(cfg_path, enabled=True)
+
+        mod = _load_script_module()
+
+        store = MagicMock()
+        graph = MagicMock()
+        graph.build.side_effect = RuntimeError("boom")
+
+        with (
+            patch.object(mod, "SymbolGraph") as mock_graph_cls,
+            patch.object(mod, "ChunkStore") as mock_store_cls,
+            patch.object(
+                sys,
+                "argv",
+                [str(_SCRIPT_PATH), "--repo-id", "demo", "--config", str(cfg_path)],
+            ),
+        ):
+            mock_store_cls.return_value = store
+            mock_graph_cls.return_value = graph
+            with pytest.raises(RuntimeError):
+                mod.main()
+
+        store.close.assert_called_once()
+        graph.save.assert_not_called()
+
+    def test_store_closed_when_save_raises(self, tmp_path):
+        cfg_path = tmp_path / "cfg.yaml"
+        _write_cfg(cfg_path, enabled=True)
+
+        mod = _load_script_module()
+
+        store = MagicMock()
+        graph = MagicMock()
+        graph.save.side_effect = OSError("disk full")
+
+        with (
+            patch.object(mod, "SymbolGraph") as mock_graph_cls,
+            patch.object(mod, "ChunkStore") as mock_store_cls,
+            patch.object(
+                sys,
+                "argv",
+                [str(_SCRIPT_PATH), "--repo-id", "demo", "--config", str(cfg_path)],
+            ),
+        ):
+            mock_store_cls.return_value = store
+            mock_graph_cls.return_value = graph
+            with pytest.raises(OSError):
+                mod.main()
+
+        store.close.assert_called_once()

--- a/tests/test_pipeline_factory_conditional_graph.py
+++ b/tests/test_pipeline_factory_conditional_graph.py
@@ -1,0 +1,112 @@
+"""Tests for Issue #109 ``indexing.symbol_graph.enabled=false`` path in
+``pipeline_factory._build_baseline_deps_no_mlx``.
+
+Ensures the factory honours the dead-flag:
+- enabled=false  → ``SymbolGraph.load`` is NOT called; ``graph`` is ``None``.
+- enabled=true   → existing behaviour (``SymbolGraph.load`` invoked).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+# Stub MLX if missing (pipeline_factory lazily imports generator.py → mlx_lm).
+if importlib.util.find_spec("mlx") is None:
+    for _mod in ("mlx", "mlx.core", "mlx_lm", "mlx_lm.sample_utils"):
+        if _mod not in sys.modules:
+            _stub = ModuleType(_mod)
+            _stub.make_sampler = lambda **kw: None  # type: ignore[attr-defined]
+            sys.modules[_mod] = _stub
+
+from baseline_reporag.config import Config  # noqa: E402
+from baseline_reporag.pipeline_factory import _build_baseline_deps_no_mlx  # noqa: E402
+
+
+def _cfg(*, enabled: bool | None, tmp_path) -> Config:
+    data = {
+        "repo": {"repo_id": "demo", "repo_commit": "head"},
+        "paths": {
+            "data_root": str(tmp_path / "data"),
+            "log_root": str(tmp_path / "logs"),
+        },
+        "model": {
+            "model_id": "test-model",
+        },
+        "generation": {
+            "max_new_tokens": 64,
+            "temperature": 0.0,
+            "top_p": 1.0,
+        },
+        "retrieval": {
+            "reranker": {"enabled": False},
+        },
+    }
+    if enabled is not None:
+        data["indexing"] = {"symbol_graph": {"enabled": enabled}}
+    return Config(data)
+
+
+class TestPipelineFactoryConditionalGraph:
+    def test_enabled_false_sets_graph_to_none(self, tmp_path):
+        cfg = _cfg(enabled=False, tmp_path=tmp_path)
+
+        with (
+            patch("baseline_reporag.ingestion.store.ChunkStore"),
+            patch("baseline_reporag.indexing.lexical.LexicalIndex"),
+            patch("baseline_reporag.indexing.embedding.EmbeddingIndex"),
+            patch(
+                "baseline_reporag.indexing.symbol_graph.SymbolGraph"
+            ) as mock_graph_cls,
+            patch("baseline_reporag.memory.session.SessionManager"),
+            patch("baseline_reporag.generation.generator.Generator"),
+            patch("baseline_reporag.logger.RunLogger"),
+        ):
+            deps = _build_baseline_deps_no_mlx(cfg)
+
+        assert deps["graph"] is None
+        mock_graph_cls.load.assert_not_called()
+
+    def test_enabled_true_loads_symbol_graph(self, tmp_path):
+        cfg = _cfg(enabled=True, tmp_path=tmp_path)
+        mock_graph = MagicMock()
+
+        with (
+            patch("baseline_reporag.ingestion.store.ChunkStore"),
+            patch("baseline_reporag.indexing.lexical.LexicalIndex"),
+            patch("baseline_reporag.indexing.embedding.EmbeddingIndex"),
+            patch(
+                "baseline_reporag.indexing.symbol_graph.SymbolGraph"
+            ) as mock_graph_cls,
+            patch("baseline_reporag.memory.session.SessionManager"),
+            patch("baseline_reporag.generation.generator.Generator"),
+            patch("baseline_reporag.logger.RunLogger"),
+        ):
+            mock_graph_cls.load.return_value = mock_graph
+            deps = _build_baseline_deps_no_mlx(cfg)
+
+        assert deps["graph"] is mock_graph
+        mock_graph_cls.load.assert_called_once()
+
+    def test_missing_indexing_block_defaults_to_loading(self, tmp_path):
+        cfg = _cfg(enabled=None, tmp_path=tmp_path)
+        mock_graph = MagicMock()
+
+        with (
+            patch("baseline_reporag.ingestion.store.ChunkStore"),
+            patch("baseline_reporag.indexing.lexical.LexicalIndex"),
+            patch("baseline_reporag.indexing.embedding.EmbeddingIndex"),
+            patch(
+                "baseline_reporag.indexing.symbol_graph.SymbolGraph"
+            ) as mock_graph_cls,
+            patch("baseline_reporag.memory.session.SessionManager"),
+            patch("baseline_reporag.generation.generator.Generator"),
+            patch("baseline_reporag.logger.RunLogger"),
+        ):
+            mock_graph_cls.load.return_value = mock_graph
+            deps = _build_baseline_deps_no_mlx(cfg)
+
+        assert deps["graph"] is mock_graph
+        mock_graph_cls.load.assert_called_once()

--- a/tests/test_repo_id_validation.py
+++ b/tests/test_repo_id_validation.py
@@ -1,0 +1,171 @@
+"""Tests for the shared ``validate_repo_id`` helper (CB-004 / CB-005).
+
+Codex review flagged that ``baseline_reporag/pipeline_factory.py`` and
+``demo/run_demo.py`` built filesystem paths from ``cfg.repo.repo_id``
+without the allowlist check that ``scripts/build_symbol_graph.py``
+already applied. These tests pin down the shared helper and ensure all
+three entry points use it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import patch
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+
+# Stub MLX for the pipeline_factory import.
+if importlib.util.find_spec("mlx") is None:
+    for _mod in ("mlx", "mlx.core", "mlx_lm", "mlx_lm.sample_utils"):
+        if _mod not in sys.modules:
+            _stub = ModuleType(_mod)
+            _stub.make_sampler = lambda **kw: None  # type: ignore[attr-defined]
+            sys.modules[_mod] = _stub
+
+from baseline_reporag.config import (  # noqa: E402
+    _REPO_ID_MAX_LENGTH,
+    Config,
+    validate_repo_id,
+)
+
+
+class TestValidateRepoIdHappyPath:
+    def test_alphanumeric_passes(self):
+        assert validate_repo_id("fastapi_fastapi") == "fastapi_fastapi"
+
+    def test_hyphen_passes(self):
+        assert validate_repo_id("my-repo-123") == "my-repo-123"
+
+    def test_underscore_passes(self):
+        assert validate_repo_id("Some_Repo_1") == "Some_Repo_1"
+
+
+class TestValidateRepoIdRejects:
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "../outside",
+            "..",
+            "/absolute/path",
+            "",
+            "a/b",
+            "a\\b",
+            "has space",
+            "dot.file",
+            "unicode_α",
+            "日本語",
+            "name;with;semicolons",
+            "null\x00byte",
+        ],
+    )
+    def test_rejects_path_traversal_and_special_chars(self, bad):
+        with pytest.raises(ValueError):
+            validate_repo_id(bad)
+
+    def test_rejects_non_string(self):
+        with pytest.raises((TypeError, ValueError)):
+            validate_repo_id(None)  # type: ignore[arg-type]
+
+
+class TestValidateRepoIdLengthLimit:
+    """CB-R2-001: reject repo_id that would overflow OS filename/path limits.
+
+    ``_REPO_ID_MAX_LENGTH`` is the authoritative ceiling; we pin the
+    boundary behaviour (max-length passes, max+1 raises) rather than a
+    hardcoded constant so future tuning is a one-line change in
+    ``baseline_reporag/config.py``.
+    """
+
+    def test_boundary_max_length_passes(self):
+        value = "a" * _REPO_ID_MAX_LENGTH
+        assert validate_repo_id(value) == value
+
+    def test_over_boundary_by_one_raises(self):
+        value = "a" * (_REPO_ID_MAX_LENGTH + 1)
+        with pytest.raises(ValueError):
+            validate_repo_id(value)
+
+    def test_far_over_boundary_raises(self):
+        value = "a" * 300
+        with pytest.raises(ValueError):
+            validate_repo_id(value)
+
+
+class TestPipelineFactoryUsesValidator:
+    """CB-004: pipeline factory must refuse unsafe ``repo_id`` values."""
+
+    def _cfg(self, repo_id: str, tmp_path) -> Config:
+        return Config(
+            {
+                "repo": {"repo_id": repo_id, "repo_commit": "head"},
+                "paths": {
+                    "data_root": str(tmp_path / "data"),
+                    "log_root": str(tmp_path / "logs"),
+                },
+                "model": {"model_id": "test-model"},
+                "generation": {
+                    "max_new_tokens": 64,
+                    "temperature": 0.0,
+                    "top_p": 1.0,
+                },
+                "retrieval": {"reranker": {"enabled": False}},
+                "indexing": {"symbol_graph": {"enabled": False}},
+            }
+        )
+
+    def test_factory_rejects_path_traversal(self, tmp_path):
+        from baseline_reporag.pipeline_factory import _build_baseline_deps_no_mlx
+
+        cfg = self._cfg("../outside", tmp_path=tmp_path)
+        with pytest.raises(ValueError):
+            _build_baseline_deps_no_mlx(cfg)
+
+    def test_factory_rejects_absolute_path(self, tmp_path):
+        from baseline_reporag.pipeline_factory import _build_baseline_deps_no_mlx
+
+        cfg = self._cfg("/tmp/x", tmp_path=tmp_path)
+        with pytest.raises(ValueError):
+            _build_baseline_deps_no_mlx(cfg)
+
+    def test_factory_accepts_valid_repo_id(self, tmp_path):
+        from baseline_reporag.pipeline_factory import _build_baseline_deps_no_mlx
+
+        cfg = self._cfg("demo", tmp_path=tmp_path)
+
+        with (
+            patch("baseline_reporag.ingestion.store.ChunkStore"),
+            patch("baseline_reporag.indexing.lexical.LexicalIndex"),
+            patch("baseline_reporag.indexing.embedding.EmbeddingIndex"),
+            patch("baseline_reporag.indexing.symbol_graph.SymbolGraph"),
+            patch("baseline_reporag.memory.session.SessionManager"),
+            patch("baseline_reporag.generation.generator.Generator"),
+            patch("baseline_reporag.logger.RunLogger"),
+        ):
+            deps = _build_baseline_deps_no_mlx(cfg)
+        assert deps is not None
+
+
+class TestBuildSymbolGraphReusesValidator:
+    """CB-004 follow-up: the CLI now delegates to the shared helper."""
+
+    def test_cli_validator_matches_shared_helper(self):
+        spec = importlib.util.spec_from_file_location(
+            "build_symbol_graph_cli_validator_under_test",
+            _ROOT / "scripts" / "build_symbol_graph.py",
+        )
+        assert spec is not None
+        mod = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        sys.modules[spec.name] = mod
+        spec.loader.exec_module(mod)
+
+        # Valid id passes.
+        mod._validate_repo_id("demo_repo")
+        # Invalid id raises.
+        with pytest.raises(ValueError):
+            mod._validate_repo_id("../x")


### PR DESCRIPTION
## 概要

Phase 2（制度文書ドメイン検証）の前提タスク。Markdown ファイルの見出し・条文境界に基づく chunker と、`indexing.symbol_graph.enabled` フラグを 4 経路で honor する条件分岐を追加。

## 変更内容

### Markdown chunker
- `baseline_reporag/ingestion/chunker.py` に `_chunk_markdown` 追加
  - `#`/`##`/`###` 見出しを分割境界、`第N条`/`第N節` の条文境界にも対応（漢数字・全角数字両対応）
  - コードフェンス内の `#` は境界として扱わない
  - `section_header` をネスト継承（`"H1 > H2 > H3"` 形式）
  - セクション超過時は段落分割 + sliding-window fallback

### Symbol graph conditional skip
- `baseline_reporag/config.py` に `is_symbol_graph_enabled(cfg) -> bool` ヘルパ追加
- 4 経路で honor: `scripts/build_symbol_graph.py` / `pipeline_factory.py` / `demo/run_demo.py` / `app/photon_app.py` (wrapper 経由)
- `retrieval/graph_expansion.py` の `expand_with_graph` を `graph: SymbolGraph | None` 対応に拡張

### Security hardening
- `validate_repo_id` を `baseline_reporag/config.py` に共通化
  - 長さ上限 64 文字、path traversal 防御、argv-list subprocess 呼び出し
- 影響スクリプト: `scripts/ingest_repo.py` / `scripts/build_indexes.py` / `scripts/build_symbol_graph.py`

## テスト

- [x] 新規単体テスト: `test_chunker_markdown.py` (20 ケース), `test_graph_expansion.py` (3 ケース), `test_repo_id_validation.py` (10 ケース)
- [x] CLI テスト: `test_build_symbol_graph_cli.py`, `test_pipeline_factory_conditional_graph.py`
- [x] `python -m pytest torch_ref/tests/ photon_mlx/tests/ baseline_reporag/tests/ tests/`: **897 pass** (2 fail は pre-existing `test_generate_training_corpus.py`)
- [x] `ruff check .`: 0 warnings
- [x] `ruff format --check .`: 0 diff

## Gate 2 v4 pre-merge 再計測

section_header が BM25/embedding tokenize に合流する副作用を測定するため、\`fastapi_fastapi\` index を再構築して eval を実行。

| 指標 | v4 基準 | 計測値 | Δ | 判定 |
|---|---|---|---|---|
| **Static NC** | 21.7% | **14.2%** | **-7.5pp** | **PASS (大幅良化)** |
| MT NC | 15.6% | **9.4%** | -6.2pp | PASS (良化) |
| Retrieval noise | 0% | **0.00%** | 0 | PASS |
| MT follow-up P50 latency | 22,207 ms | 22,293 ms | +0.4% | PASS |

- primary gate 21.7% ±1pp を大幅に下回って PASS
- 退行ゼロなので revert / Epic #117 tuning の発動不要
- 詳細レポート: \`reports/gate2_issue109_premerge.md\`

## ドキュメント

- `README.md` / `docs/deployment.md` / `docs/troubleshooting.md` / `docs/tutorial.md` に symbol_graph optional 化を明記

## 関連Issue

Closes #109

Epic: #117 (Phase 2 制度文書ドメイン検証)

🤖 Generated with [Claude Code](https://claude.com/claude-code)