### PR TITLE
feat(retrieval): query_expansion と noise_patterns の汎用化（ドメイン非依存化）(#111)

### DIFF
--- a/baseline_reporag/photon_pipeline.py
+++ b/baseline_reporag/photon_pipeline.py
@@ -711,7 +711,7 @@ class PhotonRAGPipeline:
         # --- Query expansion ---
         qe_cfg = cfg.retrieval.query_expansion
         if qe_cfg.get("enabled", False):
-            _queries = expand_query(question)
+            _queries = expand_query(question, mapping=qe_cfg.get("domain_map"))
             expansion_terms: str | None = _queries[1] if len(_queries) > 1 else None
         else:
             expansion_terms = None

--- a/baseline_reporag/pipeline.py
+++ b/baseline_reporag/pipeline.py
@@ -131,7 +131,7 @@ class RepoRAGPipeline:
         # --- Query expansion (computed once, shared by retrieval + reranker) ---
         qe_cfg = cfg.retrieval.query_expansion
         if qe_cfg.get("enabled", False):
-            _queries = expand_query(question)
+            _queries = expand_query(question, mapping=qe_cfg.get("domain_map"))
             expansion_terms: str | None = _queries[1] if len(_queries) > 1 else None
         else:
             expansion_terms = None

--- a/baseline_reporag/pipeline_factory.py
+++ b/baseline_reporag/pipeline_factory.py
@@ -126,7 +126,8 @@ def _build_baseline_deps_no_mlx(cfg: Config) -> dict:
         CrossEncoderReranker(
             model_id=reranker_cfg.get(
                 "model_id", "cross-encoder/ms-marco-MiniLM-L-6-v2"
-            )
+            ),
+            noise_patterns=reranker_cfg.get("noise_patterns"),
         )
         if reranker_cfg.get("enabled", False)
         else None

--- a/baseline_reporag/retrieval/query_expansion.py
+++ b/baseline_reporag/retrieval/query_expansion.py
@@ -10,9 +10,13 @@ No external model calls — zero latency overhead on top of retrieval.
 from __future__ import annotations
 
 import re
+from typing import TYPE_CHECKING
 
-# Mapping from Japanese technical terms to English/code equivalents commonly
-# found in Python/FastAPI codebases.  Keeps the list minimal and repo-relevant.
+if TYPE_CHECKING:
+    from baseline_reporag.config import Config
+
+# Mirror of configs/baseline.yaml retrieval.query_expansion.domain_map
+# (FastAPI default). Update both when modifying.
 _JP_TO_CODE: dict[str, list[str]] = {
     # --- Architecture / infrastructure terms ---
     "ミドルウェア": ["middleware", "Middleware", "BaseHTTPMiddleware"],
@@ -93,17 +97,50 @@ _IDENTIFIER_PATTERN = re.compile(
 )
 
 
-def expand_query(query: str) -> list[str]:
+def _normalize_mapping(
+    mapping: "Config | dict[str, list[str]] | None",
+) -> dict[str, list[str]]:
+    """Normalize mapping into a plain dict.
+
+    - None → built-in `_JP_TO_CODE` fallback (backward compat).
+    - Config wrapper → converted via `to_dict()`.
+    - dict → returned as-is (identity).
+    """
+    if mapping is None:
+        return _JP_TO_CODE
+    from baseline_reporag.config import Config
+
+    if isinstance(mapping, Config):
+        return mapping.to_dict()
+    return mapping
+
+
+def expand_query(
+    query: str,
+    mapping: "Config | dict[str, list[str]] | None" = None,
+) -> list[str]:
     """Return a list of expanded search queries derived from *query*.
 
-    The first element is always the original query unchanged.  Additional
-    elements are lightweight expansions — no LLM call is made.
+    Args:
+        query: Original user query.
+        mapping: Domain-specific Japanese→code-term mapping.
+            - None (default): use built-in `_JP_TO_CODE` (backward compat).
+            - dict: use as-is.
+            - Config wrapper: normalized to dict via `.to_dict()` internally.
+            - Empty dict/Config: explicit disable of Japanese expansion
+              (identifier extraction still runs).
+
+    Returns:
+        List where the first element is always the original query.
+        Additional element (if any) is a combined expansion query.
     """
+    effective_map = _normalize_mapping(mapping)
+
     queries: list[str] = [query]
     extra_terms: list[str] = []
 
     # 1. Japanese → code-term expansion
-    for jp, code_terms in _JP_TO_CODE.items():
+    for jp, code_terms in effective_map.items():
         if jp in query:
             extra_terms.extend(code_terms)
 

--- a/baseline_reporag/retrieval/reranker.py
+++ b/baseline_reporag/retrieval/reranker.py
@@ -12,13 +12,13 @@ Two-stage approach:
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from .hybrid import RetrievalResult
 from ..ingestion.store import ChunkStore
 
-# File path patterns that are never useful for code analysis questions.
-# Verified against FastAPI repo: these are meta-documents (LLM translation
-# prompts, sponsor lists, GitHub templates) that BM25 ranks high due to
-# ubiquitous FastAPI terminology.
+# Mirror of configs/baseline.yaml retrieval.reranker.noise_patterns
+# (FastAPI default). Update both when modifying.
 _NOISE_PATTERNS: tuple[str, ...] = (
     "llm-prompt",
     "sponsors.yml",
@@ -26,11 +26,6 @@ _NOISE_PATTERNS: tuple[str, ...] = (
     "DISCUSSION_TEMPLATE",
     "general-llm-prompt",
 )
-
-
-def _is_noise(chunk_id: str) -> bool:
-    path = chunk_id.split("::", 1)[1] if "::" in chunk_id else chunk_id
-    return any(p in path for p in _NOISE_PATTERNS)
 
 
 class CrossEncoderReranker:
@@ -43,16 +38,28 @@ class CrossEncoderReranker:
         model_id: HuggingFace model ID.  Defaults to the lightweight
             ms-marco-MiniLM-L-6-v2 (22 M params).
         max_length: Tokenizer truncation.  256 covers most code chunks.
+        noise_patterns: File path patterns to filter out pre-ranking.
+            - None (default): use built-in `_NOISE_PATTERNS` (backward compat).
+            - Sequence of str: use as-is (empty sequence → noise filter
+              explicit disable).
     """
 
     def __init__(
         self,
         model_id: str = "cross-encoder/ms-marco-MiniLM-L-6-v2",
         max_length: int = 256,
+        noise_patterns: Sequence[str] | None = None,
     ) -> None:
         from sentence_transformers import CrossEncoder  # lazy import
 
         self._model = CrossEncoder(model_id, max_length=max_length)
+        self._noise_patterns: tuple[str, ...] = (
+            _NOISE_PATTERNS if noise_patterns is None else tuple(noise_patterns)
+        )
+
+    def _is_noise(self, chunk_id: str) -> bool:
+        path = chunk_id.split("::", 1)[1] if "::" in chunk_id else chunk_id
+        return any(p in path for p in self._noise_patterns)
 
     def rerank(
         self,
@@ -77,7 +84,7 @@ class CrossEncoderReranker:
             return results
 
         # Stage 1: noise filter
-        clean = [r for r in results if not _is_noise(r.chunk_id)]
+        clean = [r for r in results if not self._is_noise(r.chunk_id)]
         if not clean:
             clean = results  # safety fallback
 

--- a/baseline_reporag/tests/test_query_expansion.py
+++ b/baseline_reporag/tests/test_query_expansion.py
@@ -1,0 +1,181 @@
+"""Unit tests for baseline_reporag.retrieval.query_expansion.
+
+Covers Issue #111: domain-agnostic generalization of `expand_query`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from baseline_reporag.config import Config, load_config
+from baseline_reporag.retrieval.query_expansion import (
+    _JP_TO_CODE,
+    _normalize_mapping,
+    expand_query,
+)
+
+
+# --------------------------------------------------------------------------- #
+# _normalize_mapping unit tests
+# --------------------------------------------------------------------------- #
+
+
+def test_normalize_mapping_none_returns_builtin():
+    result = _normalize_mapping(None)
+    assert result is _JP_TO_CODE
+
+
+def test_normalize_mapping_config_converts_to_dict():
+    cfg = Config({"ミドルウェア": ["middleware", "Middleware"]})
+    result = _normalize_mapping(cfg)
+    assert isinstance(result, dict)
+    assert result == {"ミドルウェア": ["middleware", "Middleware"]}
+
+
+def test_normalize_mapping_dict_identity():
+    mapping = {"ミドルウェア": ["middleware"]}
+    result = _normalize_mapping(mapping)
+    assert result is mapping
+
+
+def test_normalize_mapping_empty_dict_preserved():
+    result = _normalize_mapping({})
+    assert result == {}
+
+
+# --------------------------------------------------------------------------- #
+# expand_query behavior tests (Cases 1-7, 11)
+# --------------------------------------------------------------------------- #
+
+
+def test_case_1_mapping_none_matches_builtin():
+    """Case 1: mapping=None → backward compat with built-in _JP_TO_CODE."""
+    query = "ミドルウェアの使い方"
+    result_none = expand_query(query, mapping=None)
+    result_default = expand_query(query)
+    assert result_none == result_default
+    # Verify actual expansion happened from _JP_TO_CODE
+    assert len(result_none) == 2
+    assert "middleware" in result_none[1]
+
+
+def test_case_2_mapping_plain_dict():
+    """Case 2: mapping=<plain dict> → expansion from given dict."""
+    mapping = {"ミドルウェア": ["middleware", "MW"]}
+    result = expand_query("ミドルウェアの設定", mapping=mapping)
+    assert result[0] == "ミドルウェアの設定"
+    assert len(result) == 2
+    assert "middleware" in result[1]
+    assert "MW" in result[1]
+
+
+def test_case_3_mapping_config_wrapper():
+    """Case 3: mapping=<Config wrapper> → same result as plain dict."""
+    plain = {"ミドルウェア": ["middleware", "MW"]}
+    wrapped = Config(plain)
+    query = "ミドルウェアの設定"
+    result_plain = expand_query(query, mapping=plain)
+    result_wrapped = expand_query(query, mapping=wrapped)
+    assert result_plain == result_wrapped
+
+
+def test_case_4a_empty_mapping_no_identifier():
+    """Case 4a: mapping={} + query without identifier → [query] only."""
+    result = expand_query("テスト", mapping={})
+    assert result == ["テスト"]
+
+
+def test_case_4b_empty_mapping_with_identifier():
+    """Case 4b: mapping={} + query with identifier → identifier extraction runs."""
+    # Identifier is embedded in a no-space token so query.split() doesn't
+    # include it verbatim, triggering the identifier-extraction path.
+    result = expand_query("ApiRouterを使う方法", mapping={})
+    # Japanese expansion disabled, but identifier extraction still runs
+    assert result[0] == "ApiRouterを使う方法"
+    assert len(result) == 2
+    assert "ApiRouter" in result[1]
+
+
+def test_case_5_mapping_with_undefined_key():
+    """Case 5: mapping contains undefined key for this query → no expansion."""
+    mapping = {"存在しないキー": ["nothing"]}
+    result = expand_query("ミドルウェアの設定", mapping=mapping)
+    # No Japanese expansion, no identifiers → [query] only
+    assert result == ["ミドルウェアの設定"]
+
+
+def test_case_6_identifier_and_japanese_combined():
+    """Case 6: identifier extraction + Japanese expansion together."""
+    mapping = {"ミドルウェア": ["middleware"]}
+    # Identifier embedded without whitespace so identifier extraction fires.
+    query = "ApiRouterのミドルウェア設定"
+    result = expand_query(query, mapping=mapping)
+    assert result[0] == query
+    assert len(result) == 2
+    assert "middleware" in result[1]
+    assert "ApiRouter" in result[1]
+
+
+def test_case_7_snapshot_regression_full_builtin_pass_through():
+    """Case 7: passing full _JP_TO_CODE externally → equals mapping=None result."""
+    queries = [
+        "ミドルウェアの使い方",
+        "依存性注入の例",
+        "認証と認可の違い",
+        "非同期処理のデッドロック調査",
+        "APIRouter と include_router",
+        "OpenAPI スキーマ生成",
+    ]
+    for q in queries:
+        assert expand_query(q, mapping=_JP_TO_CODE) == expand_query(q, mapping=None)
+
+
+# --------------------------------------------------------------------------- #
+# Case 11: SoT equivalence (baseline.yaml ↔ module constant)
+# --------------------------------------------------------------------------- #
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+REPRESENTATIVE_QUERIES = [
+    "ミドルウェアの使い方",
+    "依存性注入の例",
+    "認証と認可の違い",
+    "非同期処理のデッドロック調査",
+    "APIRouter と include_router",
+    "OpenAPI スキーマ生成",
+    "エラーハンドリングのベストプラクティス",
+    "クエリパラメータのバリデータ",
+]
+
+
+def test_case_11_sot_equivalence_expand_query():
+    """Case 11: baseline.yaml domain_map == module constant for representative queries."""
+    cfg = load_config(REPO_ROOT / "configs" / "baseline.yaml")
+    domain_map = cfg.retrieval.query_expansion.get("domain_map")
+    assert domain_map is not None, (
+        "baseline.yaml must declare retrieval.query_expansion.domain_map"
+    )
+    for q in REPRESENTATIVE_QUERIES:
+        assert expand_query(q, mapping=domain_map) == expand_query(q, mapping=None), (
+            f"SoT divergence on query: {q}"
+        )
+
+
+def test_case_11_sot_equivalence_noise_patterns():
+    """Case 11 (paired): baseline.yaml noise_patterns == module _NOISE_PATTERNS."""
+    from baseline_reporag.retrieval.reranker import _NOISE_PATTERNS
+
+    cfg = load_config(REPO_ROOT / "configs" / "baseline.yaml")
+    yaml_patterns = cfg.retrieval.reranker.get("noise_patterns")
+    assert yaml_patterns is not None, (
+        "baseline.yaml must declare retrieval.reranker.noise_patterns"
+    )
+    assert tuple(yaml_patterns) == _NOISE_PATTERNS
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/baseline_reporag/tests/test_reranker.py
+++ b/baseline_reporag/tests/test_reranker.py
@@ -1,0 +1,97 @@
+"""Unit tests for baseline_reporag.retrieval.reranker noise filter.
+
+Covers Issue #111: domain-agnostic generalization of `noise_patterns`.
+
+We avoid loading the sentence-transformers CrossEncoder model by constructing
+the reranker via ``__new__`` and manually setting ``self._noise_patterns``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from baseline_reporag.retrieval.reranker import (
+    _NOISE_PATTERNS,
+    CrossEncoderReranker,
+)
+
+
+def _make_reranker(noise_patterns) -> CrossEncoderReranker:
+    """Instantiate CrossEncoderReranker without loading the ML model."""
+    obj = CrossEncoderReranker.__new__(CrossEncoderReranker)
+    effective = _NOISE_PATTERNS if noise_patterns is None else tuple(noise_patterns)
+    object.__setattr__(obj, "_noise_patterns", effective)
+    return obj
+
+
+def _chunk_id(path: str) -> str:
+    """Construct a chunk_id in the 'repo::path' format used by ChunkStore."""
+    return f"fastapi::{path}"
+
+
+# --------------------------------------------------------------------------- #
+# Case 8: noise_patterns=None → backward compat with _NOISE_PATTERNS
+# --------------------------------------------------------------------------- #
+
+
+def test_case_8_default_noise_patterns_filters_builtin():
+    reranker = _make_reranker(None)
+    assert reranker._is_noise(_chunk_id("docs/llm-prompt.md")) is True
+    assert reranker._is_noise(_chunk_id(".github/sponsors.yml")) is True
+    assert reranker._is_noise(_chunk_id("scripts/language_names.yml")) is True
+    assert (
+        reranker._is_noise(_chunk_id(".github/DISCUSSION_TEMPLATE/general.yml")) is True
+    )
+    assert reranker._is_noise(_chunk_id("docs/general-llm-prompt.md")) is True
+    # Non-noise paths pass through
+    assert reranker._is_noise(_chunk_id("fastapi/routing.py")) is False
+    assert reranker._is_noise(_chunk_id("fastapi/applications.py")) is False
+
+
+# --------------------------------------------------------------------------- #
+# Case 9: noise_patterns=[] → noise filter fully disabled (pass-through)
+# --------------------------------------------------------------------------- #
+
+
+def test_case_9_empty_noise_patterns_disables_filter():
+    reranker = _make_reranker([])
+    # Even previously-noise paths now pass through
+    assert reranker._is_noise(_chunk_id("docs/llm-prompt.md")) is False
+    assert reranker._is_noise(_chunk_id(".github/sponsors.yml")) is False
+    assert reranker._is_noise(_chunk_id("fastapi/routing.py")) is False
+
+
+# --------------------------------------------------------------------------- #
+# Case 10: noise_patterns=[...] → filter only by specified patterns
+# --------------------------------------------------------------------------- #
+
+
+def test_case_10_custom_noise_patterns_filter():
+    reranker = _make_reranker(["custom_pattern"])
+    assert reranker._is_noise(_chunk_id("foo/custom_pattern_impl.py")) is True
+    assert reranker._is_noise(_chunk_id("docs/llm-prompt.md")) is False
+    assert reranker._is_noise(_chunk_id("fastapi/routing.py")) is False
+
+
+def test_case_10_full_builtin_pass_through_snapshot():
+    """Passing _NOISE_PATTERNS explicitly → matches default (None) behavior."""
+    r_explicit = _make_reranker(list(_NOISE_PATTERNS))
+    r_default = _make_reranker(None)
+    test_ids = [
+        _chunk_id("docs/llm-prompt.md"),
+        _chunk_id(".github/sponsors.yml"),
+        _chunk_id("scripts/language_names.yml"),
+        _chunk_id(".github/DISCUSSION_TEMPLATE/general.yml"),
+        _chunk_id("docs/general-llm-prompt.md"),
+        _chunk_id("fastapi/routing.py"),
+        _chunk_id("fastapi/applications.py"),
+        _chunk_id("tests/test_routing.py"),
+    ]
+    for cid in test_ids:
+        assert r_explicit._is_noise(cid) == r_default._is_noise(cid), (
+            f"Snapshot mismatch on {cid}"
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/configs/baseline.yaml
+++ b/configs/baseline.yaml
@@ -127,11 +127,80 @@ retrieval:
   reranker:
     enabled: true
     model_id: "cross-encoder/ms-marco-MiniLM-L-6-v2"
+    noise_patterns:
+      - "llm-prompt"
+      - "sponsors.yml"
+      - "language_names"
+      - "DISCUSSION_TEMPLATE"
+      - "general-llm-prompt"
 
   query_expansion:
     enabled: true
     include_symbol_aliases: true
     include_filename_hints: true
+    domain_map:
+      "ミドルウェア": ["middleware", "Middleware", "BaseHTTPMiddleware"]
+      "依存性注入": ["dependency injection", "Depends", "dependencies"]
+      "依存性": ["dependency", "Depends", "dependencies"]
+      "ルーター": ["router", "APIRouter", "include_router"]
+      "エンドポイント": ["endpoint", "route", "path operation"]
+      "認証": ["authentication", "auth", "authenticate"]
+      "認可": ["authorization", "authorize", "permission"]
+      "セキュリティ": ["security", "SecurityScheme", "OAuth2"]
+      "バリデーション": ["validation", "validator", "pydantic"]
+      "スキーマ": ["schema", "BaseModel", "pydantic"]
+      "例外": ["exception", "HTTPException", "error handler"]
+      "エラーハンドラ": ["exception handler", "add_exception_handler"]
+      "リクエスト": ["request", "Request"]
+      "レスポンス": ["response", "Response", "JSONResponse"]
+      "セッション": ["session", "SessionMiddleware"]
+      "テスト": ["test", "TestClient", "pytest"]
+      "移行": ["migration", "migration plan"]
+      "リスク": ["risk", "impact"]
+      "影響": ["impact", "affected", "dependency"]
+      "キャッシュ": ["cache", "use_cache", "dependency_cache"]
+      "デコレータ": ["decorator", "@app.get", "@router"]
+      "ライフサイクル": ["lifecycle", "lifespan", "startup", "shutdown"]
+      "WebSocket": ["websocket", "WebSocket", "ws"]
+      "バックグラウンド": ["background", "BackgroundTasks"]
+      "静的ファイル": ["static", "StaticFiles", "mount"]
+      "設定": ["config", "Settings", "BaseSettings"]
+      "ログ": ["log", "logger", "logging"]
+      "ストリーミング": ["streaming", "StreamingResponse", "stream"]
+      "実行順序": ["execution order", "order", "stack"]
+      "移植": ["migration", "porting", "refactor"]
+      "エンコーディング": ["jsonable_encoder", "ENCODERS_BY_TYPE", "encoders"]
+      "デッドロック": ["run_in_threadpool", "asyncio", "anyio", "concurrency"]
+      "非同期": ["asyncio", "run_in_threadpool", "anyio", "concurrency"]
+      "ステータスコード": ["status_code", "routing"]
+      "マルチパート": ["UploadFile", "ImmutableMultiDict", "datastructures", "multipart"]
+      "フォームデータ": ["UploadFile", "Form", "datastructures"]
+      "ファイルアップロード": ["UploadFile", "File", "datastructures"]
+      "パスパラメータ": ["path_params", "solve_dependencies", "routing", "Path"]
+      "型変換": ["solve_dependencies", "request_path", "routing", "field"]
+      "クエリパラメータ": ["query_params", "Query", "Param", "ParamTypes"]
+      "デフォルト値": ["Param", "ParamTypes", "Query", "Body", "Form"]
+      "独自バリデータ": ["Param", "ParamTypes", "field_validator", "model_validator"]
+      "バリデータ": ["Param", "ParamTypes", "field_validator", "model_validator"]
+      "サブアプリ": ["mount", "sub_applications", "routing"]
+      "サブアプリケーション": ["mount", "sub_applications", "routing"]
+      "エラーハンドリング":
+        - "exception_handler"
+        - "add_exception_handler"
+        - "HTTPException"
+        - "exception_handlers"
+      "ハンドリング": ["exception_handler", "add_exception_handler", "handler"]
+      "ルーティング": ["routing", "APIRouter", "include_router", "route"]
+      "OpenAPI": ["openapi", "get_openapi", "generate_operation_id", "openapi_utils"]
+      "openapi": ["openapi", "get_openapi", "generate_operation_id", "openapi_utils"]
+      "スキーマ生成": ["get_openapi", "generate_operation_id", "openapi_utils"]
+      "セキュリティスキーム":
+        - "SecurityMiddleware"
+        - "add_middleware"
+        - "TrustedHostMiddleware"
+        - "security"
+      "HTTPSリダイレクト": ["HTTPSRedirectMiddleware", "add_middleware", "middleware"]
+      "信頼済みホスト": ["TrustedHostMiddleware", "add_middleware", "middleware"]
 
   neighborhood_expansion:
     enabled: true


### PR DESCRIPTION
## 概要

FastAPI 特有だった \`_JP_TO_CODE\` / \`_NOISE_PATTERNS\` を外部化し、config 経由でドメイン毎に差し替え可能にする。Phase 2 制度文書ドメイン向けの実値投入は Epic #117 配下の別 Issue で実施。

## 変更内容

### API 拡張（後方互換あり）
- \`retrieval/query_expansion.py\`: \`expand_query(query, mapping=None)\` に変更
  - \`mapping=None\` → 既定 \`_JP_TO_CODE\` fallback（現行挙動維持）
  - 明示指定 → 指定値を使用、空 dict で展開無効化
- \`retrieval/reranker.py\`: \`CrossEncoderReranker(..., noise_patterns=None)\` に変更
  - \`None\` → 既定 \`_NOISE_PATTERNS\` fallback
  - 明示指定 → 指定値、空 tuple/list で noise filter 無効化

### 呼び出し側更新
- \`pipeline.py\` / \`photon_pipeline.py\`: \`expand_query\` 呼び出しで \`domain_map\` を Config/dict どちらでも受けて正規化
- \`pipeline_factory.py\`: reranker instantiate 時に \`noise_patterns\` を propagate

### Config 明示化
- \`configs/baseline.yaml\`:
  - \`retrieval.query_expansion.domain_map\`: 現行 FastAPI マッピングを明示化
  - \`retrieval.reranker.noise_patterns\`: 現行 noise patterns を明示化
- \`photon_small.yaml\` / \`photon_long_context.yaml\` は後続 PR で追従予定

## テスト

- [x] 新規 \`test_query_expansion.py\`: fallback / override / empty の 3 パターン snapshot（現行と完全一致確認）
- [x] 新規 \`test_reranker.py\`: 同上（noise_patterns 差し替え）
- [x] \`python -m pytest torch_ref/tests/ photon_mlx/tests/ baseline_reporag/tests/ tests/\`: **850 pass** (2 fail は pre-existing)
- [x] \`ruff check .\`: 0 warnings
- [x] \`ruff format --check .\`: 0 diff

## 回帰確認

- 既定値で呼ぶ限り現行実装と戻り値が完全一致（snapshot テスト）
- 既存 integration test (\`test_pipeline_integration.py\` / \`test_photon_pipeline.py\`) は全て \`query_expansion.enabled=False\` / \`reranker.enabled=False\` なのでこの経路を通らず、影響なし

## 関連Issue

Closes #111

Epic: #117 (Phase 2 制度文書ドメイン検証)

依存: #109 (pipeline.py などが #109 と同じファイルを更新するため rebase の可能性あり)

🤖 Generated with [Claude Code](https://claude.com/claude-code)