### PR TITLE
fix(eval): QwenMLXAdapter を mlx-lm 新 API に追随 + 引用枝番サポート

### DIFF
--- a/baseline_reporag/eval/institutional/llm_client.py
+++ b/baseline_reporag/eval/institutional/llm_client.py
@@ -76,9 +76,11 @@ class QwenMLXAdapter:
     ) -> None:
         from mlx_lm import generate as mlx_generate  # lazy import
         from mlx_lm import load as mlx_load
+        from mlx_lm.sample_utils import make_sampler
 
         self.model = model
         self._generate_fn = mlx_generate
+        self._make_sampler = make_sampler
         self._model, self._tokenizer = mlx_load(model)
 
     def generate(
@@ -94,11 +96,25 @@ class QwenMLXAdapter:
             if response_format == "json_object"
             else ""
         )
+        user_prompt = prompt + suffix
+        chat_prompt = self._tokenizer.apply_chat_template(
+            [{"role": "user", "content": user_prompt}],
+            add_generation_prompt=True,
+            tokenize=False,
+        )
+        if seed is not None:
+            try:
+                import mlx.core as mx
+
+                mx.random.seed(seed)
+            except Exception:
+                pass
+        sampler = self._make_sampler(temp=temperature)
         return self._generate_fn(
             self._model,
             self._tokenizer,
-            prompt=prompt + suffix,
-            temp=temperature,
+            prompt=chat_prompt,
+            sampler=sampler,
             max_tokens=1024,
         )
 

--- a/baseline_reporag/eval/institutional/writer.py
+++ b/baseline_reporag/eval/institutional/writer.py
@@ -33,7 +33,7 @@ OPTIONAL_STATIC_KEYS: frozenset[str] = frozenset(
     }
 )
 
-_CITATION_PATTERN_RE = re.compile(r"^第\d+条(?:第\d+項)?(?:第\d+号)?$")
+_CITATION_PATTERN_RE = re.compile(r"^第\d+条(?:の\d+)?(?:第\d+項)?(?:第\d+号)?$")
 
 _NON_EMPTY_STRING_KEYS: frozenset[str] = frozenset({"question", "reference_answer"})
 

--- a/evals/institutional_static_eval_schema.md
+++ b/evals/institutional_static_eval_schema.md
@@ -22,7 +22,7 @@
 
 | key | 型 | 説明 |
 |---|---|---|
-| `expected_citation_patterns` | list[str] | `第N条` / `第N条第M項` / `第N条第M項第K号`。各要素は `^第\d+条(?:第\d+項)?(?:第\d+号)?$` に fullmatch する |
+| `expected_citation_patterns` | list[str] | `第N条` / `第N条の枝番` / `第N条第M項` / `第N条第M項第K号`。各要素は `^第\d+条(?:の\d+)?(?:第\d+項)?(?:第\d+号)?$` に fullmatch する（枝番 `の\d+` は任意で、`第24条の2` や `第5条の10第2項第3号` 等に対応） |
 | `source_document_id` | str | `document.md` の親ディレクトリ名 (例: `0123_rental_mgmt`) |
 | `generator_model` | str | 生成モデル名 (例: `gpt-4o-mini-2024-07-18`) |
 | `human_verified` | bool | 人手検証済みかどうか (default false) |

--- a/tests/test_institutional_writer.py
+++ b/tests/test_institutional_writer.py
@@ -65,7 +65,16 @@ def test_validate_record_rejects_empty_required_strings(
 
 @pytest.mark.parametrize(
     "pattern",
-    ["第3条", "第3条第1項", "第3条第1項第2号", "第10条", "第100条第2項第99号"],
+    [
+        "第3条",
+        "第3条第1項",
+        "第3条第1項第2号",
+        "第10条",
+        "第100条第2項第99号",
+        "第3条の2",
+        "第24条の2第1項",
+        "第5条の10第2項第3号",
+    ],
 )
 def test_citation_pattern_fullmatch_valid(pattern: str) -> None:
     rec = _valid_record()
@@ -75,7 +84,7 @@ def test_citation_pattern_fullmatch_valid(pattern: str) -> None:
 
 @pytest.mark.parametrize(
     "pattern",
-    ["第3条第1項第2号追加", "第3条の2", "Article 3", "", "第"],
+    ["第3条第1項第2号追加", "Article 3", "", "第", "第3条の"],
 )
 def test_citation_pattern_fullmatch_invalid(pattern: str) -> None:
     rec = _valid_record()


### PR DESCRIPTION
## Summary

Issue #110 で導入した制度文書 eval set 自動生成基盤を Qwen で実走行したところ 2 件の不具合が露呈したので修正する。

- **mlx-lm API 追随**: `mlx_lm.generate` の `temp=` 引数廃止 → `sampler=make_sampler(temp=...)` 経由に変更。併せて `tokenizer.apply_chat_template` で Qwen 想定の chat 形式に整形し、`seed` 指定時は `mx.random.seed` に委譲する (b093bb4)
- **引用パターン枝番許容**: `第24条の2` / `第5条の10第2項第3号` などの枝番条号を `_CITATION_PATTERN_RE` が reject していたので `(?:の\d+)?` を追加 (9c8f57c)

実走行ログ (`reports/institutional_generation_summary_20260424_201807.json`) で 6/6 成功を確認済み。

## Test plan

- [x] `pytest tests/test_institutional_writer.py tests/test_institutional_llm_client.py` 33 passed
- [x] `ruff check baseline_reporag/eval/institutional/ tests/test_institutional_writer.py` 警告ゼロ
- [x] `ruff format --check` 差分なし
- [x] Qwen で static 生成実走行 6/6 成功 (reports/institutional_generation_summary_20260424_201807.json)
- [ ] CI グリーン確認

Refs #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)