### PR TITLE
chore(ci): baseline_eval log glob を fastapi_fastapi pattern に絞る (#124)

### DIFF
--- a/.github/workflows/weekly_eval.yml
+++ b/.github/workflows/weekly_eval.yml
@@ -28,15 +28,18 @@ jobs:
             --config configs/baseline.yaml \
             --max-sessions 30
       - name: Check thresholds
+        # NOTE: glob の repo_id (fastapi_fastapi) は configs/baseline.yaml の
+        # repo.repo_id と同期して保つこと。別 corpus (例: institutional_documents)
+        # の log は別 job で扱う (Issue #124)。
         run: |
           python scripts/ci_eval_check.py \
-            --static-log logs/baseline_eval_*.jsonl \
-            --mt-log logs/mt_eval_*.jsonl
+            --static-log logs/baseline_eval_fastapi_fastapi_*.jsonl \
+            --mt-log logs/mt_eval_fastapi_fastapi_*.jsonl
       - name: Upload results
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: eval-results-${{ github.run_number }}
           path: |
-            logs/baseline_eval_*.jsonl
-            logs/mt_eval_*.jsonl
+            logs/baseline_eval_fastapi_fastapi_*.jsonl
+            logs/mt_eval_fastapi_fastapi_*.jsonl

--- a/scripts/ci_eval_check.py
+++ b/scripts/ci_eval_check.py
@@ -5,9 +5,14 @@ Exit code 0 = pass, 1 = threshold violated.
 
 Usage:
     python scripts/ci_eval_check.py \
-        --static-log logs/baseline_eval_*.jsonl \
-        --mt-log logs/mt_eval_*.jsonl \
+        --static-log logs/baseline_eval_fastapi_fastapi_*.jsonl \
+        --mt-log logs/mt_eval_fastapi_fastapi_*.jsonl \
         --eval-set data/eval_sets/static_eval.jsonl
+
+NOTE: glob patterns must include the corpus repo_id (e.g. ``fastapi_fastapi``)
+so logs from other corpora (e.g. ``institutional_documents``) are not picked
+up by ``_resolve_latest`` (Issue #124). See ``configs/baseline.yaml`` for the
+canonical repo_id used by the weekly workflow.
 """
 
 from __future__ import annotations
@@ -158,12 +163,22 @@ def main() -> None:
     parser.add_argument(
         "--static-log",
         required=True,
-        help="Glob pattern for static eval log (e.g. logs/baseline_eval_*.jsonl)",
+        help=(
+            "Glob pattern for static eval log "
+            "(e.g. logs/baseline_eval_fastapi_fastapi_*.jsonl). "
+            "Include the corpus repo_id to avoid picking up logs from other "
+            "corpora — see Issue #124."
+        ),
     )
     parser.add_argument(
         "--mt-log",
         required=True,
-        help="Glob pattern for multi-turn eval log (e.g. logs/mt_eval_*.jsonl)",
+        help=(
+            "Glob pattern for multi-turn eval log "
+            "(e.g. logs/mt_eval_fastapi_fastapi_*.jsonl). "
+            "Include the corpus repo_id to avoid picking up logs from other "
+            "corpora — see Issue #124."
+        ),
     )
     parser.add_argument(
         "--eval-set",

--- a/tests/test_ci_eval_check.py
+++ b/tests/test_ci_eval_check.py
@@ -1,0 +1,65 @@
+"""Regression tests for ci_eval_check (Issue #124).
+
+Ensures repo_id-scoped glob does not pick up logs from other corpora
+(e.g. institutional_documents) in the weekly fastapi_fastapi check path.
+
+NOTE: The literal "fastapi_fastapi" must stay in sync with
+.github/workflows/weekly_eval.yml glob and configs/baseline.yaml repo_id.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.ci_eval_check import _resolve_latest  # noqa: E402
+
+
+def test_resolve_latest_excludes_other_repo_id_logs(tmp_path: Path) -> None:
+    """fastapi_fastapi-scoped glob must NOT pick up institutional logs."""
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    # File content is irrelevant: _resolve_latest matches by name only.
+    # institutional log lands under logs/ directly (run log behavior of
+    # scripts/run_baseline_eval.py:111).
+    (logs / "baseline_eval_institutional_documents_20260425_010000.jsonl").write_text(
+        ""
+    )
+    # fastapi_fastapi log written 1s earlier — sorted latest would have
+    # picked the institutional one under the unscoped glob.
+    (logs / "baseline_eval_fastapi_fastapi_20260425_005959.jsonl").write_text("")
+
+    pattern = str(logs / "baseline_eval_fastapi_fastapi_*.jsonl")
+    resolved = _resolve_latest(pattern)
+
+    assert resolved is not None
+    assert "fastapi_fastapi" in resolved
+    assert "institutional_documents" not in resolved
+
+
+def test_resolve_latest_returns_lexicographic_max(tmp_path: Path) -> None:
+    """Multiple fastapi_fastapi logs -> lexicographically latest wins."""
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    # Empty files OK — _resolve_latest only inspects names.
+    (logs / "baseline_eval_fastapi_fastapi_20260101_000000.jsonl").write_text("")
+    (logs / "baseline_eval_fastapi_fastapi_20260425_120000.jsonl").write_text("")
+    (logs / "baseline_eval_fastapi_fastapi_20260301_060000.jsonl").write_text("")
+
+    pattern = str(logs / "baseline_eval_fastapi_fastapi_*.jsonl")
+    resolved = _resolve_latest(pattern)
+
+    assert resolved is not None
+    assert resolved.endswith("20260425_120000.jsonl")
+
+
+def test_resolve_latest_returns_none_when_no_match(tmp_path: Path) -> None:
+    """Empty glob result -> None (caller treats as failure)."""
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    pattern = str(logs / "baseline_eval_fastapi_fastapi_*.jsonl")
+    assert _resolve_latest(pattern) is None


### PR DESCRIPTION
Closes #124

## Summary

`scripts/ci_eval_check.py` と `.github/workflows/weekly_eval.yml` の baseline_eval log glob を fastapi_fastapi 限定に絞り、institutional 用 log（#112 で生成開始）が weekly check に巻き込まれないようにする。

## 変更ファイル

- `scripts/ci_eval_check.py`: argparse help / docstring を repo_id 込み example に
- `.github/workflows/weekly_eval.yml`: Check thresholds + Upload results step の glob を `logs/baseline_eval_fastapi_fastapi_*.jsonl` / `logs/mt_eval_fastapi_fastapi_*.jsonl` に限定（S1-001 Must Fix 対応）
- `tests/test_ci_eval_check.py`（新規）: regression 3 件

## 品質

- ruff check / format clean
- 新規テスト 3/3 pass

## Test plan

- [ ] reviewer による glob pattern の妥当性確認
- [ ] institutional 用 weekly check の追加は別 Issue で対応する方針合意

🤖 Generated with [Claude Code](https://claude.com/claude-code)