### PR TITLE
test(retrieval): #96 再発防止 guard - baseline.yaml reranker.model_id 不変宣言 (#114)

### DIFF
--- a/tests/test_pipeline_factory_yaml_invariants.py
+++ b/tests/test_pipeline_factory_yaml_invariants.py
@@ -1,0 +1,39 @@
+"""Issue #114 — YAML invariant tests for the global pipeline factory.
+
+Locks down the global-default ``reranker.model_id`` in
+``configs/baseline.yaml`` so a future Issue cannot silently swap it.
+#96 was reverted because an institutional-only evaluation result was
+promoted to the global default; this test forces an intentional update
+of both the YAML and the assertion in the same commit, surfacing intent
+and preventing #96-style regressions.
+
+The invariant is checked via ``baseline_reporag.config.load_config`` so
+the assertion goes through the same defaulting / merge path that
+``pipeline_factory`` consumes — a raw ``yaml.safe_load`` would skip
+``Config.merge_override`` and risk drifting from runtime behaviour.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from baseline_reporag.config import load_config
+
+CONFIGS_DIR = Path(__file__).resolve().parent.parent / "configs"
+
+GLOBAL_DEFAULT_RERANKER_MODEL_ID = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+
+
+def test_baseline_yaml_reranker_model_id_unchanged() -> None:
+    """``configs/baseline.yaml`` reranker.model_id must remain the global
+    English default.
+
+    Changing this requires updating both the YAML and this assertion in
+    the same commit. That intentional friction prevents another
+    institutional-domain evaluation result from leaking into the global
+    default — the failure mode that motivated the #96 revert. Issue
+    #114 evaluates a multilingual reranker for the institutional config
+    only; the global default stays unchanged.
+    """
+    cfg = load_config(CONFIGS_DIR / "baseline.yaml")
+    assert cfg.retrieval.reranker.model_id == GLOBAL_DEFAULT_RERANKER_MODEL_ID


### PR DESCRIPTION
## Summary

#114 の **scope を絞った partial close**。worker (pm-auto-issue2dev) が Phase 1-5 を経て、本 Issue の本体（institutional 用多言語 reranker A/B 実機評価、5+ 時間 compute）は worker スコープ外と判断。**#96 再発防止 guard test のみ本 PR で commit**、実機評価は別 follow-up Issue として後日対応。

## 変更内容

- `tests/test_pipeline_factory_yaml_invariants.py`（新規 39 行）
  - `configs/baseline.yaml` の `retrieval.reranker.model_id` を `cross-encoder/ms-marco-MiniLM-L-6-v2` で固定する不変テスト
  - 変更時は YAML と assertion を同じ commit で更新する意図的 friction
  - `baseline_reporag.config.load_config` 経由で defaulting/merge_override path を skip しない

## 背景: なぜ guard が必要か

- **#96**: institutional-only eval で得た `bge-reranker-v2-m3` を **global default** へ promote した結果、英語 corpus で retrieval 品質劣化を招き revert された。
- **#114**: institutional 用多言語 reranker A/B が本来の目的。global default は変更しない。
- 同じ regression を起こさないため、test レベルでの宣言的 lock を追加。

## 品質

- ruff check / format clean
- pytest: 1/1 pass
- 全テスト regression なし（#114 worker 実測 579/581 pass、既知 pre-existing 1 件除く）

## #114 残タスク（deferred）

worker progress-report 抜粋:
| 群 | 件数 | 充足 | deferred |
|----|-----|------|----------|
| 計測 | 2 | 0 | 2 |
| 品質目標 | 3 | 0 | 3 |
| 採用 / ドキュメント | 5 | 0 | 5 |
| テスト | 2 | 1 | 1 |
| **合計** | 12 | 1 | 11 |

deferred 11 件:
- 多言語 embedding (E5-base, BGE-m3, ruri-small-v2) × reranker (bge-reranker-v2-m3, japanese-reranker) の A/B 実機評価
- 最良 variant 選定と採用判定
- `configs/institutional_docs.yaml` への default 反映
- `reports/institutional_retrieval_ab.md` 作成

→ 本 PR merge 後、別 follow-up Issue で実機評価を実施する想定。

## 参考: worker が残した artifacts (worktree 内、未 commit)

- `workspace/design/issue-114-multilingual-rerank-design-policy.md`（28KB, 333行 — 4 variant 計画 + 実験プロトコル）
- `workspace/issues/114/work-plan.md`（14KB — 4 phase 14 task）
- `workspace/issues/114/issue-review/`（仮説検証 + 8 stage review）
- `workspace/issues/114/multi-stage-design-review/`（4 stage cross-review）
- `workspace/issues/114/pm-auto-dev/iteration-1/{tdd,acceptance,refactor,codex-review,progress}-report`

これらは follow-up Issue で再活用予定。

## Test plan

- [ ] reviewer による guard test ロジック確認
- [ ] follow-up Issue 起票で deferred 11 件の引き継ぎ

🤖 Generated with [Claude Code](https://claude.com/claude-code)