### PR TITLE
feat(indexing): EmbeddingIndex max_input_chars 設定可能化 + #133 Phase A (#133)

### DIFF
--- a/baseline_reporag/indexing/embedding.py
+++ b/baseline_reporag/indexing/embedding.py
@@ -73,12 +73,19 @@ class EmbeddingResult(NamedTuple):
     score: float
 
 
+_DEFAULT_MAX_INPUT_CHARS = 2048
+
+
 class EmbeddingIndex:
     def __init__(
         self,
         model_id: str = "sentence-transformers/all-MiniLM-L6-v2",
+        max_input_chars: int = _DEFAULT_MAX_INPUT_CHARS,
     ) -> None:
+        # max_input_chars: embedding 入力 truncate 上限。bge-m3 のような長文対応
+        # モデルでは 8192 等に上げる。chunker.max_chars (chunk size) とは別概念。
         self._model_id = model_id
+        self._max_input_chars = max_input_chars
         self._model: SentenceTransformer | None = None
         self._embeddings: np.ndarray | None = None  # shape (N, D), float32
         self._chunk_ids: list[str] = []
@@ -99,7 +106,7 @@ class EmbeddingIndex:
         self._chunk_ids = []
         for chunk in store.iter_repo(repo_id, repo_commit):
             text = f"{chunk.rel_path}\n{chunk.section_header}\n{chunk.content}"
-            texts.append(text[:2048])  # truncate to avoid OOM
+            texts.append(text[: self._max_input_chars])  # truncate to avoid OOM
             self._chunk_ids.append(chunk.chunk_id)
         texts = _e5_passage_prefix(self._model_id, texts)
         self._embeddings = self._model_().encode(
@@ -131,12 +138,23 @@ class EmbeddingIndex:
             json.dumps(self._chunk_ids), encoding="utf-8"
         )
         (dir_path / "model_id.txt").write_text(self._model_id, encoding="utf-8")
+        (dir_path / "max_input_chars.txt").write_text(
+            str(self._max_input_chars), encoding="utf-8"
+        )
 
     @classmethod
     def load(cls, dir_path: str | Path) -> EmbeddingIndex:
         dir_path = Path(dir_path)
         model_id = (dir_path / "model_id.txt").read_text(encoding="utf-8").strip()
-        idx = cls(model_id=model_id)
+        # 後方互換: legacy index (max_input_chars.txt なし) は default 2048。
+        max_input_chars_path = dir_path / "max_input_chars.txt"
+        if max_input_chars_path.exists():
+            max_input_chars = int(
+                max_input_chars_path.read_text(encoding="utf-8").strip()
+            )
+        else:
+            max_input_chars = _DEFAULT_MAX_INPUT_CHARS
+        idx = cls(model_id=model_id, max_input_chars=max_input_chars)
         idx._embeddings = np.load(dir_path / "embeddings.npy")
         idx._chunk_ids = json.loads(
             (dir_path / "chunk_ids.json").read_text(encoding="utf-8")

--- a/baseline_reporag/tests/test_embedding.py
+++ b/baseline_reporag/tests/test_embedding.py
@@ -114,6 +114,69 @@ class TestEmbeddingIndexBuildE5Prefix:
         assert len(encoded_text) == 9 + 2048
 
 
+class TestEmbeddingIndexMaxInputChars:
+    """#133: max_input_chars config 化 (bge-m3 等の 8192 max_length 活用)。
+
+    既存 baseline.yaml workload (default 2048) は不変。設計書 §3.1 / 判断 #3。
+    """
+
+    @patch("baseline_reporag.indexing.embedding.SentenceTransformer")
+    def test_default_max_input_chars_is_2048(self, mock_st) -> None:
+        mock_model = MagicMock()
+        mock_model.encode.return_value = np.zeros((1, 384), dtype=np.float32)
+        mock_st.return_value = mock_model
+        idx = EmbeddingIndex(model_id="sentence-transformers/all-MiniLM-L6-v2")
+        store = _make_fake_store([("c1", "", "", "a" * 3000)])
+        idx.build(store, repo_id="r", repo_commit="abc")
+        encoded_text = mock_model.encode.call_args[0][0][0]
+        assert len(encoded_text) == 2048
+
+    @patch("baseline_reporag.indexing.embedding.SentenceTransformer")
+    def test_custom_max_input_chars_extends_truncate(self, mock_st) -> None:
+        mock_model = MagicMock()
+        mock_model.encode.return_value = np.zeros((1, 1024), dtype=np.float32)
+        mock_st.return_value = mock_model
+        idx = EmbeddingIndex(model_id="BAAI/bge-m3", max_input_chars=8192)
+        store = _make_fake_store([("c1", "", "", "a" * 9000)])
+        idx.build(store, repo_id="r", repo_commit="abc")
+        encoded_text = mock_model.encode.call_args[0][0][0]
+        assert len(encoded_text) == 8192
+
+    @patch("baseline_reporag.indexing.embedding.SentenceTransformer")
+    def test_custom_max_input_chars_with_e5_prefix(self, mock_st) -> None:
+        mock_model = MagicMock()
+        mock_model.encode.return_value = np.zeros((1, 768), dtype=np.float32)
+        mock_st.return_value = mock_model
+        idx = EmbeddingIndex(
+            model_id="intfloat/multilingual-e5-base", max_input_chars=4096
+        )
+        store = _make_fake_store([("c1", "", "", "a" * 5000)])
+        idx.build(store, repo_id="r", repo_commit="abc")
+        encoded_text = mock_model.encode.call_args[0][0][0]
+        assert encoded_text.startswith("passage: ")
+        assert len(encoded_text) == 9 + 4096  # prefix + truncated body
+
+    def test_save_and_load_preserves_max_input_chars(self, tmp_path) -> None:
+        idx = EmbeddingIndex(
+            model_id="sentence-transformers/all-MiniLM-L6-v2", max_input_chars=4096
+        )
+        idx._embeddings = np.zeros((1, 384), dtype=np.float32)
+        idx._chunk_ids = ["c1"]
+        idx.save(tmp_path)
+        loaded = EmbeddingIndex.load(tmp_path)
+        assert loaded._max_input_chars == 4096
+
+    def test_load_legacy_index_defaults_max_input_chars_to_2048(self, tmp_path) -> None:
+        # Simulate legacy index without max_input_chars.txt
+        np.save(tmp_path / "embeddings.npy", np.zeros((1, 384), dtype=np.float32))
+        (tmp_path / "chunk_ids.json").write_text('["c1"]', encoding="utf-8")
+        (tmp_path / "model_id.txt").write_text(
+            "sentence-transformers/all-MiniLM-L6-v2", encoding="utf-8"
+        )
+        loaded = EmbeddingIndex.load(tmp_path)
+        assert loaded._max_input_chars == 2048
+
+
 class TestEmbeddingIndexSearchE5Prefix:
     @patch("baseline_reporag.indexing.embedding.SentenceTransformer")
     def test_search_passes_query_prefix_to_encode_for_e5(self, mock_st) -> None:

--- a/scripts/build_indexes.py
+++ b/scripts/build_indexes.py
@@ -49,8 +49,12 @@ def main() -> None:
     print(f"        saved -> {idx_dir}/lexical.pkl")
 
     print(f"  [2/2] Embedding index ({embedding_model}) ...")
+    # #133: max_input_chars を YAML から取得 (default 2048)。
+    # bge-m3 等の長文対応モデルでは config で 8192 等に上げる。
+    max_input_chars = cfg.indexing.embedding.get("max_input_chars", 2048)
     embedding = EmbeddingIndex(
         model_id=embedding_model,
+        max_input_chars=max_input_chars,
     )
     embedding.build(
         store,

--- a/tests/test_pipeline_factory_yaml_invariants.py
+++ b/tests/test_pipeline_factory_yaml_invariants.py
@@ -11,17 +11,30 @@ The invariant is checked via ``baseline_reporag.config.load_config`` so
 the assertion goes through the same defaulting / merge path that
 ``pipeline_factory`` consumes — a raw ``yaml.safe_load`` would skip
 ``Config.merge_override`` and risk drifting from runtime behaviour.
+
+Issue #133 — institutional 用 invariant の placeholder を追加 (skip)。
+A/B 実機評価で採用 variant が決定したら、skip を外して採用後の
+embedding/reranker model_id を assertion 化する。これにより
+institutional プロファイルから global default への cascade を防止する
+(設計書 §3.2 / 判断 #4)。
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from baseline_reporag.config import load_config
 
 CONFIGS_DIR = Path(__file__).resolve().parent.parent / "configs"
 
 GLOBAL_DEFAULT_RERANKER_MODEL_ID = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+
+# Issue #133 で採用 variant が決定したら以下を実値で埋め、@pytest.mark.skip を外す。
+# 採用判断は reports/institutional_retrieval_ab.md で行う。
+INSTITUTIONAL_RERANKER_MODEL_ID: str | None = None
+INSTITUTIONAL_EMBEDDING_MODEL_ID: str | None = None
 
 
 def test_baseline_yaml_reranker_model_id_unchanged() -> None:
@@ -37,3 +50,29 @@ def test_baseline_yaml_reranker_model_id_unchanged() -> None:
     """
     cfg = load_config(CONFIGS_DIR / "baseline.yaml")
     assert cfg.retrieval.reranker.model_id == GLOBAL_DEFAULT_RERANKER_MODEL_ID
+
+
+@pytest.mark.skipif(
+    INSTITUTIONAL_RERANKER_MODEL_ID is None,
+    reason="Issue #133: 採用 variant 決定後に有効化 (現在 A/B 評価中)",
+)
+def test_institutional_yaml_reranker_model_id_pinned() -> None:
+    """``configs/institutional_docs.yaml`` reranker.model_id を採用後値に pin する。
+
+    Issue #133 の A/B 評価で採用 variant が決まったら、
+    ``INSTITUTIONAL_RERANKER_MODEL_ID`` を埋めて skip を外すこと。
+    これにより institutional プロファイルから global default
+    (``configs/baseline.yaml``) への cascade を防ぐ。
+    """
+    cfg = load_config(CONFIGS_DIR / "institutional_docs.yaml")
+    assert cfg.retrieval.reranker.model_id == INSTITUTIONAL_RERANKER_MODEL_ID
+
+
+@pytest.mark.skipif(
+    INSTITUTIONAL_EMBEDDING_MODEL_ID is None,
+    reason="Issue #133: 採用 variant 決定後に有効化 (現在 A/B 評価中)",
+)
+def test_institutional_yaml_embedding_model_id_pinned() -> None:
+    """``configs/institutional_docs.yaml`` embedding.model_id を採用後値に pin する。"""
+    cfg = load_config(CONFIGS_DIR / "institutional_docs.yaml")
+    assert cfg.indexing.embedding.model_id == INSTITUTIONAL_EMBEDDING_MODEL_ID


### PR DESCRIPTION
Closes #133（Phase A、Phase B は後続 follow-up）

## Summary

#133 (多言語 embedding/reranker A/B) の **Phase A scope** を commit。worker (pm-auto-issue2dev) が Phase 1-5 (issue review / design / work-plan / TDD) を経て、本 Issue を以下に分割した:
- **Phase A (本 PR)**: コード変更 + variant config 雛形 + guard test
- **Phase B (deferred)**: 実機 GPU A/B eval、5 variant 比較、最良採用

Phase B は worker scope 外（GPU 占有 5+ 時間）として後続 follow-up に分離。

## 変更内容

### 1. `baseline_reporag/indexing/embedding.py`
`EmbeddingIndex` に `max_input_chars` パラメータ追加（default 2048）:
- `__init__(max_input_chars=2048)`: 長文対応モデル（bge-m3 8192 等）に config 化
- `build()`: `texts[:max_input_chars]` truncate（固定値 2048 を置換）
- `save()` / `load()`: `max_input_chars.txt` 永続化、後方互換（legacy index は default 2048）

### 2. `scripts/build_indexes.py`
`cfg.indexing.embedding.max_input_chars`（YAML）→ `EmbeddingIndex` に伝播。
これで variant config ごとに `max_input_chars` を切り替えられる。

### 3. `baseline_reporag/tests/test_embedding.py`
5 新規テスト:
- `max_input_chars` default value
- custom value override
- save/load round-trip
- legacy index (no `max_input_chars.txt`) backward compat
- truncate behavior

### 4. `tests/test_pipeline_factory_yaml_invariants.py`
institutional 用 V0 invariant test 2 件（placeholder skip、Phase B で活性化）。

## 背景: なぜ `max_input_chars` 設定可能化？

| Model | max input tokens | 現行 truncate (2048 chars) で覆える？ |
|-------|------------------|-----------------------------------|
| `intfloat/multilingual-e5-small` (default) | 512 | ✅ 余裕 |
| `intfloat/multilingual-e5-base` | 512 | ✅ 余裕 |
| `cl-nagoya/ruri-small-v2` | 512 | ✅ 余裕 |
| `BAAI/bge-m3` | **8192** | ❌ truncate 過大、long context 優位を相殺 |

bge-m3 を含む A/B のため、variant ごとに truncate 上限を切り替えられるよう改修。

## Phase B (deferred) — Issue #133 残スコープ

worker artifacts (worktree 削除前、`workspace/issues/133/` に保存):
- `workspace/issues/133/work-plan.md` (23KB) — A/B 実験計画
- `workspace/design/issue-133-multilingual-retrieval-ab-design-policy.md` (49.8KB)
- 5 variant configs (`configs/_experiments/institutional_V[0-4].yaml`、gitignore 済)

Phase B 実行内容:
1. V0 (現 default) — 比較基準
2. V1: E5-base + 現 reranker
3. V2: ruri-small-v2 + 現 reranker
4. V3: E5-small + bge-reranker-v2-m3
5. V4: bge-m3 (max_input_chars 8192) + bge-reranker-v2-m3

各 variant で institutional eval (116Q, ~30-60min) → 最良採用 → `configs/institutional_docs.yaml` 反映。

## 品質

- ruff check / format clean
- pytest 19 pass + 2 skip (institutional placeholder)
- baseline_reporag/tests/ 1042 pass (regression なし)
- 後方互換: legacy index は `max_input_chars.txt` 不要、default 2048 で動作

## Test plan

- [ ] reviewer による max_input_chars API レビュー
- [ ] Phase B 実行 (別 Issue or 主セッションで take over)

🤖 Generated with [Claude Code](https://claude.com/claude-code)