### PR TITLE
fix(photon): tokenizer mismatch — load real HF tokenizer in _build_photon_deps (#138)

### DIFF
--- a/baseline_reporag/photon_pipeline.py
+++ b/baseline_reporag/photon_pipeline.py
@@ -292,9 +292,27 @@ def _build_photon_deps(cfg: Config) -> dict[str, Any]:
         encoder_layers_per_level=cfg.hierarchy.encoder_layers_per_level,
         decoder_layers_per_level=cfg.hierarchy.decoder_layers_per_level,
     )
-    tok_cfg = TokenizerConfig(
-        vocab_size=cfg.model.get("vocab_size", 1000),
+    # Issue #138: ``tokenizer.vocab_size`` is the canonical source for
+    # production photon configs (institutional_docs_photon.yaml,
+    # photon_small.yaml, photon_long_context.yaml all set it under the
+    # ``tokenizer:`` block). The legacy ``model.vocab_size`` lookup is kept
+    # as a fallback so the ~17 unit tests that pre-date the
+    # ``tokenizer:`` section keep working without modification.
+    tokenizer_section = cfg.get("tokenizer")
+    tokenizer_id: str | None = (
+        getattr(tokenizer_section, "tokenizer_id", None)
+        if tokenizer_section is not None
+        else None
     )
+    cfg_vocab_size: int
+    if (
+        tokenizer_section is not None
+        and getattr(tokenizer_section, "vocab_size", None) is not None
+    ):
+        cfg_vocab_size = tokenizer_section.vocab_size
+    else:
+        cfg_vocab_size = cfg.model.get("vocab_size", 1000)
+    tok_cfg = TokenizerConfig(vocab_size=cfg_vocab_size)
     photon_cfg = PhotonConfig(
         model=model_cfg,
         hierarchy=hierarchy_cfg,
@@ -303,8 +321,26 @@ def _build_photon_deps(cfg: Config) -> dict[str, Any]:
 
     # Build the tokenizer before PhotonInference so both paths (question+evidence
     # prefill in PhotonRAGPipeline and chunk scoring in prune_evidence) share
-    # the same stub instance (Issue #58).
-    tokenizer = _get_stub_tokenizer(photon_cfg.tokenizer.vocab_size)
+    # the same instance (Issue #58).
+    #
+    # Issue #138 fix: when ``tokenizer.tokenizer_id`` is set we MUST load the
+    # matching HuggingFace tokenizer so training and inference encode text the
+    # same way. The previous unconditional ``_StubTokenizer`` (UTF-8
+    # byte-mod-vocab encoding) silently diverged from the real Qwen subword
+    # vocabulary used by ``scripts/generate_training_corpus.py``, which would
+    # have made any re-trained PHOTON checkpoint return garbage at inference
+    # time. ``_StubTokenizer`` is retained only as a fallback for legacy
+    # test fixtures that omit the ``tokenizer:`` block (and is not reachable
+    # from production photon configs).
+    if tokenizer_id:
+        tokenizer = _load_hf_tokenizer(tokenizer_id, photon_cfg.tokenizer.vocab_size)
+    else:
+        _logger.warning(
+            "config.tokenizer.tokenizer_id is unset; falling back to "
+            "_StubTokenizer (test/dev only — production photon configs "
+            "must set tokenizer_id, Issue #138)."
+        )
+        tokenizer = _get_stub_tokenizer(photon_cfg.tokenizer.vocab_size)
     model = PhotonModel(photon_cfg)
     # Issue #64 / Codex CB-001: extract working memory policy once, pass it
     # into PhotonInference alongside the Issue #63 drift_level_weights below.
@@ -428,6 +464,47 @@ class _StubTokenizer:
 
 def _get_stub_tokenizer(vocab_size: int) -> _StubTokenizer:
     return _StubTokenizer(vocab_size)
+
+
+def _load_hf_tokenizer(tokenizer_id: str, expected_vocab_size: int) -> Any:
+    """Load the HuggingFace ``AutoTokenizer`` matched to ``tokenizer_id``.
+
+    Issue #138: training (``scripts/generate_training_corpus.py``) loads a
+    real Qwen subword tokenizer, but inference previously used the
+    byte-mod ``_StubTokenizer``. A re-trained PHOTON checkpoint would then
+    receive garbage token streams at inference. This helper is the single
+    production code path that builds the inference-side tokenizer, and it
+    enforces:
+
+    - vocab_size parity between the loaded tokenizer and ``photon_cfg``,
+      so the embedding matrix and tokenizer agree on row count;
+    - a non-None ``pad_token_id`` so ``tokenize_evidence_pack`` can
+      chunk-align via padding without raising ``TypeError`` on tokenizers
+      that ship without a pad token (Qwen / GPT-style families).
+    """
+    try:
+        from transformers import AutoTokenizer
+    except ImportError as exc:  # pragma: no cover - dependency-time error
+        raise ImportError(
+            "transformers is required for PHOTON inference (Issue #138). "
+            "Install it via `pip install transformers`."
+        ) from exc
+
+    tokenizer = AutoTokenizer.from_pretrained(tokenizer_id, trust_remote_code=False)
+    actual_vocab_size = getattr(tokenizer, "vocab_size", None)
+    if actual_vocab_size is not None and actual_vocab_size != expected_vocab_size:
+        raise ValueError(
+            "tokenizer vocab_size mismatch (Issue #138): "
+            f"tokenizer={actual_vocab_size} cfg={expected_vocab_size}. "
+            "Update cfg.tokenizer.vocab_size to match the loaded tokenizer."
+        )
+    if getattr(tokenizer, "pad_token_id", None) is None:
+        eos_id = getattr(tokenizer, "eos_token_id", None)
+        if eos_id is not None:
+            tokenizer.pad_token_id = eos_id
+        else:
+            tokenizer.pad_token_id = 0
+    return tokenizer
 
 
 def _clear_photon_session_state(photon_inference: Any, session_id: str) -> None:

--- a/baseline_reporag/tests/test_photon_pipeline.py
+++ b/baseline_reporag/tests/test_photon_pipeline.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from baseline_reporag.generation.evidence_pack import build_evidence_pack
 
 # ---------------------------------------------------------------------------
@@ -499,6 +501,182 @@ class TestBuildPhotonDeps:
         cfg = load_config(str(cfg_file))
         deps = _build_photon_deps(cfg)
         assert deps["safe_recgen"] is None
+
+
+# ---------------------------------------------------------------------------
+# Issue #138: training/inference tokenizer must be unified
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPhotonDepsRealTokenizer:
+    """``_build_photon_deps`` must load the real HuggingFace tokenizer when
+    ``cfg.tokenizer.tokenizer_id`` is set, instead of the byte-mod
+    ``_StubTokenizer`` (which caused the training/inference mismatch
+    documented in Issue #138).
+    """
+
+    def test_loads_real_tokenizer_when_tokenizer_id_set(self, tmp_path):
+        from baseline_reporag.config import load_config
+        from baseline_reporag.photon_pipeline import (
+            _StubTokenizer,
+            _build_photon_deps,
+        )
+
+        cfg_file = tmp_path / "photon.yaml"
+        cfg_file.write_text(
+            "model:\n"
+            "  provider: photon\n"
+            "  architecture: photon_decoder\n"
+            "  base_embed_dim: 64\n"
+            "  hidden_size: 128\n"
+            "  intermediate_size: 256\n"
+            "  num_heads: 4\n"
+            "hierarchy:\n"
+            "  levels: 2\n"
+            "  chunk_sizes: [4, 4]\n"
+            "  encoder_layers_per_level: [2, 2]\n"
+            "  decoder_layers_per_level: [2, 2]\n"
+            "tokenizer:\n"
+            '  tokenizer_id: "fake-org/fake-tokenizer"\n'
+            "  vocab_size: 152064\n"
+            "inference:\n"
+            "  hierarchical_prefill: true\n"
+            "  safe_recgen_enabled: false\n"
+        )
+        cfg = load_config(str(cfg_file))
+
+        fake_tokenizer = MagicMock()
+        fake_tokenizer.vocab_size = 152064
+        fake_tokenizer.pad_token_id = 0
+        fake_tokenizer.encode.return_value = [1, 2, 3]
+
+        with patch(
+            "transformers.AutoTokenizer.from_pretrained",
+            return_value=fake_tokenizer,
+        ) as mock_from_pretrained:
+            deps = _build_photon_deps(cfg)
+
+        mock_from_pretrained.assert_called_once_with(
+            "fake-org/fake-tokenizer", trust_remote_code=False
+        )
+        assert deps["tokenizer"] is fake_tokenizer
+        assert not isinstance(deps["tokenizer"], _StubTokenizer)
+        assert deps["photon_cfg"].tokenizer.vocab_size == 152064
+
+    def test_vocab_size_mismatch_raises(self, tmp_path):
+        from baseline_reporag.config import load_config
+        from baseline_reporag.photon_pipeline import _build_photon_deps
+
+        cfg_file = tmp_path / "photon.yaml"
+        cfg_file.write_text(
+            "model:\n"
+            "  provider: photon\n"
+            "  architecture: photon_decoder\n"
+            "  base_embed_dim: 64\n"
+            "  hidden_size: 128\n"
+            "  intermediate_size: 256\n"
+            "  num_heads: 4\n"
+            "hierarchy:\n"
+            "  levels: 2\n"
+            "  chunk_sizes: [4, 4]\n"
+            "  encoder_layers_per_level: [2, 2]\n"
+            "  decoder_layers_per_level: [2, 2]\n"
+            "tokenizer:\n"
+            '  tokenizer_id: "fake-org/fake-tokenizer"\n'
+            "  vocab_size: 152064\n"
+            "inference:\n"
+            "  hierarchical_prefill: true\n"
+            "  safe_recgen_enabled: false\n"
+        )
+        cfg = load_config(str(cfg_file))
+
+        fake_tokenizer = MagicMock()
+        fake_tokenizer.vocab_size = 32000  # mismatch
+        fake_tokenizer.pad_token_id = 0
+
+        with patch(
+            "transformers.AutoTokenizer.from_pretrained",
+            return_value=fake_tokenizer,
+        ):
+            with pytest.raises(ValueError, match="vocab_size"):
+                _build_photon_deps(cfg)
+
+    def test_falls_back_to_stub_when_tokenizer_id_missing(self, tmp_path):
+        """Test/dev configs without ``tokenizer.tokenizer_id`` keep the stub
+        path so the existing 17 unit tests remain hermetic (no network).
+        Production configs always set ``tokenizer_id`` and therefore never
+        reach this branch (Issue #138)."""
+        from baseline_reporag.config import load_config
+        from baseline_reporag.photon_pipeline import (
+            _StubTokenizer,
+            _build_photon_deps,
+        )
+
+        cfg_file = tmp_path / "photon.yaml"
+        cfg_file.write_text(
+            "model:\n"
+            "  provider: photon\n"
+            "  architecture: photon_decoder\n"
+            "  base_embed_dim: 64\n"
+            "  hidden_size: 128\n"
+            "  intermediate_size: 256\n"
+            "  num_heads: 4\n"
+            "  vocab_size: 1000\n"
+            "hierarchy:\n"
+            "  levels: 2\n"
+            "  chunk_sizes: [4, 4]\n"
+            "  encoder_layers_per_level: [2, 2]\n"
+            "  decoder_layers_per_level: [2, 2]\n"
+            "inference:\n"
+            "  hierarchical_prefill: true\n"
+            "  safe_recgen_enabled: false\n"
+        )
+        cfg = load_config(str(cfg_file))
+        deps = _build_photon_deps(cfg)
+        assert isinstance(deps["tokenizer"], _StubTokenizer)
+
+    def test_institutional_docs_photon_uses_tokenizer_section_vocab(self, tmp_path):
+        """``cfg.tokenizer.vocab_size`` (152064) must drive PhotonModel sizing,
+        not ``cfg.model.vocab_size`` (which is unset in production photon
+        configs and would silently fall back to a 1000-vocab embedding —
+        the latent half of the Issue #138 mismatch)."""
+        from baseline_reporag.config import load_config
+        from baseline_reporag.photon_pipeline import _build_photon_deps
+
+        cfg_file = tmp_path / "photon.yaml"
+        cfg_file.write_text(
+            "model:\n"
+            "  provider: photon\n"
+            "  architecture: photon_decoder\n"
+            "  base_embed_dim: 64\n"
+            "  hidden_size: 128\n"
+            "  intermediate_size: 256\n"
+            "  num_heads: 4\n"
+            "hierarchy:\n"
+            "  levels: 2\n"
+            "  chunk_sizes: [4, 4]\n"
+            "  encoder_layers_per_level: [2, 2]\n"
+            "  decoder_layers_per_level: [2, 2]\n"
+            "tokenizer:\n"
+            '  tokenizer_id: "fake-org/qwen-like"\n'
+            "  vocab_size: 152064\n"
+            "inference:\n"
+            "  hierarchical_prefill: true\n"
+            "  safe_recgen_enabled: false\n"
+        )
+        cfg = load_config(str(cfg_file))
+
+        fake_tokenizer = MagicMock()
+        fake_tokenizer.vocab_size = 152064
+        fake_tokenizer.pad_token_id = 0
+
+        with patch(
+            "transformers.AutoTokenizer.from_pretrained",
+            return_value=fake_tokenizer,
+        ):
+            deps = _build_photon_deps(cfg)
+
+        assert deps["photon_cfg"].tokenizer.vocab_size == 152064
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 概要

S7-001 follow-up の **CRITICAL** fix。訓練 (`scripts/generate_training_corpus.py` が `mlx-community/Qwen2.5-Coder-14B-Instruct-4bit` を `AutoTokenizer` で load) と推論 (`baseline_reporag.photon_pipeline._build_photon_deps` が `_StubTokenizer(byte-mod-vocab)` を返却) で tokenizer が完全に乖離していた。再学習後の checkpoint を load しても、推論側は UTF-8 byte mod-vocab で encode された token 列しか受け取らず、Qwen subword で学習した embedding が一切活きない。本 PR がマージされるまで #135 Phase 6-8 (本格 GPU 再学習) に着手しても eval 結果は無意味になる。

## 変更内容 (commit b19e8db)

- **`baseline_reporag/photon_pipeline.py:429` 追加** — `_load_hf_tokenizer(tokenizer_id, expected_vocab_size)` を新設。`cfg.tokenizer.tokenizer_id` から `AutoTokenizer.from_pretrained(..., trust_remote_code=False)` を実体化する production 経路を単一化:
  - vocab_size mismatch は `ValueError` で fail-fast
  - `pad_token_id` 欠落 tokenizer (Qwen / GPT 系) は `eos_token_id` で fallback
  - `transformers` 未 install 時は明示的な `ImportError`
- **`baseline_reporag/photon_pipeline.py:295` 改修** — `_build_photon_deps` を `cfg.tokenizer.vocab_size` 優先 + `cfg.model.vocab_size` fallback に変更。これで `institutional_docs_photon.yaml` / `photon_small.yaml` / `photon_long_context.yaml` 等の production config はすべて `tokenizer.vocab_size: 152064` が正しく拾われ、152064 行 embedding が組まれる (従来は `model.vocab_size` 未設定で default 1000 行)。
- **`_StubTokenizer` の扱い** — 既存 17 件の hermetic unit test (tokenizer_id 未設定 YAML) との後方互換のためにのみ残し、`tokenizer_id` 未設定時のみ警告ログ付きで使用。Production photon config 経路では到達不能。
- **`baseline_reporag/tests/test_photon_pipeline.py` 追加** — 新規 test class `TestBuildPhotonDepsRealTokenizer` (4 件)。

## 受入条件 (Issue #138)

- [x] `_build_photon_deps` が config の `tokenizer.tokenizer_id` から実 HuggingFace tokenizer を load (`_load_hf_tokenizer` 経由)
- [x] `_StubTokenizer` が production code path に到達しないことを test で固定 (`test_loads_real_tokenizer_when_tokenizer_id_set` で `assert not isinstance(deps["tokenizer"], _StubTokenizer)`)
- [x] tokenizer vocab_size と config vocab_size の整合性 assert 追加 (`test_vocab_size_mismatch_raises`)
- [x] 既存の PhotonRAGPipeline 動作確認 (smoke test pass — 既存 112 test pass)
- [x] `ruff check` / `pytest` 全パス

## テスト結果

| 項目 | 結果 |
|---|---|
| 全テスト (`torch_ref/tests/ photon_mlx/tests/ baseline_reporag/tests/ tests/`) | **1046 passed** / 2 skipped / 2 failed (= CLAUDE.md 記載の pre-existing failure: `tests/test_generate_training_corpus.py` の `args.commit` AttributeError、本 PR と無関係) |
| `baseline_reporag/tests/test_photon_pipeline.py` | **112 passed** (新規 4 件含む) |
| `ruff check .` | All checks passed |
| `ruff format --check .` | 147 files already formatted |

新規テスト 4 件 (`TestBuildPhotonDepsRealTokenizer`):
- `test_loads_real_tokenizer_when_tokenizer_id_set` — `AutoTokenizer.from_pretrained` を mock し、tokenizer_id が正しく渡されること、返却 tokenizer が `_StubTokenizer` で**ない**ことを検証
- `test_vocab_size_mismatch_raises` — tokenizer.vocab_size != cfg.vocab_size で `ValueError`
- `test_falls_back_to_stub_when_tokenizer_id_missing` — `tokenizer_id` 未設定時の test/dev fallback path
- `test_institutional_docs_photon_uses_tokenizer_section_vocab` — `cfg.tokenizer.vocab_size` (152064) が `PhotonConfig` まで伝搬すること (latent half of #138)

## Related

- Closes #138
- **Blocks**: #135 Phase 6-8 (本格 GPU 再学習) はこの PR がマージされてから着手
- 元: commit `2dbf458` (S7-001 fix で random-init を解消したが tokenizer mismatch は残存)

🤖 Generated with [Claude Code](https://claude.com/claude-code)