### PR TITLE
feat(eval): Phase A reports — true PHOTON baseline (Qwen 2.5 + S7-001/138 fixed) (#148 Phase A pre-flight + measurements)

### DIFF
--- a/baseline_reporag/photon_pipeline.py
+++ b/baseline_reporag/photon_pipeline.py
@@ -766,12 +766,26 @@ def _load_hf_tokenizer(tokenizer_id: str, expected_vocab_size: int) -> Any:
         ) from None
 
     actual_vocab_size = getattr(tokenizer, "vocab_size", None)
-    if actual_vocab_size is not None and actual_vocab_size != expected_vocab_size:
-        raise ValueError(
-            "tokenizer vocab_size mismatch (Issue #138): "
-            f"tokenizer={actual_vocab_size} cfg={expected_vocab_size}. "
-            "Update cfg.tokenizer.vocab_size to match the loaded tokenizer."
-        )
+    if actual_vocab_size is not None:
+        # Issue #138 / #148 Phase A: allow vocab padding (e.g. Qwen2.5-Coder
+        # tokenizer has 151643 tokens, trained model embeddings are padded to
+        # 152064 = next multiple of 64 for tensor-core efficiency). Reject only
+        # when the cfg vocab is *smaller* than the tokenizer (would index OOB).
+        if actual_vocab_size > expected_vocab_size:
+            raise ValueError(
+                "tokenizer vocab_size mismatch (Issue #138): "
+                f"tokenizer={actual_vocab_size} cfg={expected_vocab_size}. "
+                "cfg.tokenizer.vocab_size must be >= tokenizer.vocab_size."
+            )
+        if actual_vocab_size < expected_vocab_size:
+            _logger.info(
+                "tokenizer vocab_size (%d) < cfg.tokenizer.vocab_size (%d) — "
+                "treating as padded vocab; rows %d..%d are unreachable",
+                actual_vocab_size,
+                expected_vocab_size,
+                actual_vocab_size,
+                expected_vocab_size - 1,
+            )
     if getattr(tokenizer, "pad_token_id", None) is None:
         eos_id = getattr(tokenizer, "eos_token_id", None)
         if eos_id is not None:

--- a/configs/institutional_docs_photon.yaml
+++ b/configs/institutional_docs_photon.yaml
@@ -188,9 +188,14 @@ model:
   #   checkpoint が手元にない場合は checkpoint の配置が完了するまで評価を開始しないこと。
   #   PHOTON_ALLOW_RANDOM_INIT=1 は unit/CI の negative-path テスト専用であり、
   #   Phase A 評価で使用することは S7-001 random-init eval の再発を招くため禁止します。
-  # checkpoint_path: ""  # TBD: Phase A 実行時に PHOTON_CHECKPOINT_ROOT 配下パスに置換
+  # Phase A.2 (#113 v2) execution: candidate-1 mulmoclaude 600-step ckpt at
+  #   PHOTON_CHECKPOINT_ROOT=/Users/maenokota/share/work/github_kewton/photon-mlx-develop/checkpoints
+  # state.json: step=600, best_val_loss=1.6238 (note: differs from roadmap.md's 0.4525).
+  checkpoint_path: "step_000600"
 
   # PHOTON-specific: 本 Issue baseline では参照されないが、#113 切替時のため継承値を保持。
+  # Issue #148 Phase A.2: num_heads matches mulmoclaude 600-step ckpt (10 × 64 = 640).
+  num_heads: 10
   base_embed_dim: 256
   hidden_size: 1024
   intermediate_size: 2816

--- a/configs/photon_small.yaml
+++ b/configs/photon_small.yaml
@@ -155,13 +155,24 @@ model:
   provider: "photon"
   model_id: "mlx-community/Qwen2.5-Coder-14B-Instruct-4bit"
 
+  # Issue #148 Phase A0/A.1 (Gate 2 v5): PHOTON checkpoint loading.
+  # Resolved against PHOTON_CHECKPOINT_ROOT (defaults to ./checkpoints/).
+  # state.json: step=600, best_val_loss=1.6238 (mulmoclaude 600-step ckpt).
+  # Required for fail-loud loading (Issue #148 Phase A0).
+  checkpoint_path: "step_000600"
+
   # PHOTON-specific:
   # - base_embed_dim = encoder bottom embed dim (paper Table 10: 416 for 600M)
   # - hidden_size    = main model width used by enc/dec blocks and LM head
+  # - num_heads      = q/kv head count (head_dim defaults to 64)
   # Small: paper-conformal downscale (~200M)
   base_embed_dim: 256
   hidden_size: 1024
   intermediate_size: 2816
+  # Issue #148 Phase A: matches the mulmoclaude 600-step ckpt architecture
+  # (10 heads × 64 head_dim = 640-dim q/kv projections). The pipeline_factory
+  # reads ``cfg.model.num_heads`` (not ``num_attention_heads``).
+  num_heads: 10
 
 generation:
   max_new_tokens: 768


### PR DESCRIPTION
## Summary

Issue #148 **Phase A** (PR #1.5 in the 3-PR plan) — combines the Phase A pre-flight latent-bug fixes with the actual Phase A measurements they enabled. After PR #150 (Phase A0 fail-loud checkpoint loading) merged, attempting the eval surfaced two more latent bugs that had been masked by the random-init era. Both are fixed here, and the eval was then run end-to-end.

## Phase A pre-flight fixes (commit `8e5579d`)

### Discovery 1: vocab_size validation too strict (#138 strict equality)
- `_load_hf_tokenizer` rejected the trained ckpt's standard ML vocab padding (Qwen2.5-Coder tokenizer 151,643 tokens, embedding matrix padded to 152,064 = next multiple of 64)
- Fix: relaxed to `actual <= expected`. Reject only when cfg vocab is *smaller* than tokenizer

### Discovery 2: yaml/loader schema drift
- `pipeline_factory` reads `cfg.model.get("num_heads", 4)`, but yaml puts `num_attention_heads: 16` under `generation:` block (key + section mismatch). Loader silently used default 4
- Trained ckpt requires `num_heads=10` (`q_proj=(640, 1024)`)
- Fix: added `model.num_heads: 10` to `configs/photon_small.yaml` and `configs/institutional_docs_photon.yaml`

## Phase A measurements (commit `4ed13a3`)

### Phase A.1 — Gate 2 v5 (FastAPI MT, 30 sessions × 6 turns)

| metric | baseline | **PHOTON** | delta |
|--------|---------|------------|-------|
| MT NC overall | 6.11% | **7.78%** | **+1.67pp** |
| MT NC Turn 5-6 | 1.67% | 1.67% | 0pp |
| Latency P50 | 20,440 ms | **12,604 ms** | **-38.3%** |
| Follow-up P50 (T2-T6) | 20,350 ms | **12,011 ms** | **-41.0%** |
| Follow-up P90 | 31,909 ms | 16,118 ms | -49.5% |

→ **真の PHOTON は baseline 同等** (NC +1.67pp 僅差)、**latency 大幅短縮 (-38% / -41%)** は維持。
→ v4 era の "PHOTON NC 6.7% (大幅改善)" は **random-init artifact** であり、真値は baseline と同等。

### Phase A.2 — #113 v2 (Institutional MT, 30 sessions × 6 turns)

| metric | baseline | **PHOTON** | delta |
|--------|---------|------------|-------|
| MT NC overall | 7.78% | **13.33%** | **+5.56pp** |
| MT NC Turn 5-6 | 5.00% | **11.67%** | +6.67pp |
| Latency P50 | 19,383 ms | **12,800 ms** | **-34.0%** |
| Follow-up P50 | 20,149 ms | **11,628 ms** | **-42.3%** |

→ **PHOTON は日本語制度文書ドメインで品質悪化** (+5.56pp)、特に Turn 5-6 で +6.67pp。
→ Issue #148 仮説 C「アーキ自体に課題、#135 再学習で改善が期待される」を支持。
→ mulmoclaude ckpt は英語コード訓練のため、日本語制度文書はドメイン外。

## Reports (新規)

- **`reports/gate2_judgment_v5_post_s7001.md`** — Gate 2 v5 判定 (Conditional Go)
  - 真の PHOTON 数値、v4 random-init era との delta、#135 unblock 判定
- **`reports/institutional_photon_mt_eval_v2.md`** — #113 v2 (制度文書 PHOTON 真の baseline)
  - 真の PHOTON 数値、v1 random-init era との delta、#135 再学習の justification

## Implications for #135 (本格再学習)

- **Phase A0 + Phase A.1 完了 = #135 GPU 着手 unblock** (Issue #148 の必須前提達成)
- **Phase A.2 結果 = #135 (日本語制度文書 corpus 再学習) の品質改善 justification 確定**
- 速度面 (latency -38〜42%) は ckpt 改善なしで既に benefit が出ているため、品質改善 + 速度維持が #135 の目標

## Pre-flight 設定 (実行手順)

```bash
# 1. data symlink (per-worktree, gitignored)
ln -sfn /Users/maenokota/share/work/github_kewton/photon-mlx-develop/data/{indexes,processed,raw} data/

# 2. checkpoint env var
export PHOTON_CHECKPOINT_ROOT=/Users/maenokota/share/work/github_kewton/photon-mlx-develop/checkpoints

# 3. eval execution (4 runs sequential, ~5 hours total)
python scripts/run_multi_turn_eval.py --config configs/baseline.yaml             --eval-set data/eval_sets/multi_turn_eval.jsonl             --output logs/phase_a1_baseline_run1.predictions.jsonl
python scripts/run_multi_turn_eval.py --config configs/photon_small.yaml         --eval-set data/eval_sets/multi_turn_eval.jsonl             --output logs/phase_a1_photon_run1.predictions.jsonl
python scripts/run_multi_turn_eval.py --config configs/institutional_docs.yaml   --eval-set data/eval_sets/institutional_multi_turn_eval.jsonl --output logs/phase_a2_baseline_run1.predictions.jsonl
python scripts/run_multi_turn_eval.py --config configs/institutional_docs_photon.yaml --eval-set data/eval_sets/institutional_multi_turn_eval.jsonl --output logs/phase_a2_photon_run1.predictions.jsonl
```

## Follow-ups (本 PR 範囲外、別 issue で起票予定)

`workspace/issues/148/pm-auto-dev/iteration-1/phase-a-followup-issues.md` に整理 (6 件):

1. **CB-005 (high)**: MLX import abort in fresh test env (Codex review iter2 の deferred)
2. **schema drift (medium)**: yaml `num_attention_heads` (under `generation:`) と loader `cfg.model.num_heads` の整合
3. **roadmap.md val_loss (info)**: 0.4525 vs ckpt 1.62 の不一致
4. **#143 2nd run (info)**: variance / nondeterminism 検証 (Option B → Full)
5. **deployment.md (medium)**: 具体的な ckpt 配置例の追加
6. **data/ 共有 (low)**: worktree 間の data 共有方針 (本 PR は ad-hoc symlink)

## Test plan

- [x] `ruff check .` (clean)
- [x] `ruff format --check .` (clean)
- [x] `python -m pytest baseline_reporag/tests/test_photon_pipeline_checkpoint_load.py tests/test_pipeline_factory_yaml_invariants.py -v` (28 pass)
- [x] Smoke test: PHOTON pipeline init + 1 query (success, 25s, valid answer + cite)
- [x] **Phase A.1 baseline run** (180 turns, 65 min)
- [x] **Phase A.1 PHOTON run** (180 turns, 41 min)
- [x] **Phase A.2 baseline run** (180 turns, 60 min)
- [x] **Phase A.2 PHOTON run** (180 turns, 40 min)

## Related

- **Origin**: #148 Phase A pre-flight + measurements
- **Builds on**: PR #150 (Phase A0 fail-loud checkpoint loading)
- **Unblocks**: **#135 Phase 6-8 (本格再学習)** ← Phase A0+A.1 完了で達成
- **Cross-references**: #137 (V4 retrieval), #138 (tokenizer mismatch), #143 (Qwen nondeterminism)

🤖 Generated with [Claude Code](https://claude.com/claude-code)