### PR TITLE
fix(eval): repo_id retrieval filter + refusal-aware citation grader (#154)

### DIFF
--- a/baseline_reporag/citation.py
+++ b/baseline_reporag/citation.py
@@ -6,6 +6,29 @@ from dataclasses import dataclass
 from .generation.evidence_pack import EvidencePack
 from .ingestion.store import Chunk
 
+# Issue #154 Bug 2: phrases that mark an answer as a legitimate refusal
+# ("we don't have evidence to answer"). When present, the answer must be
+# graded as no-citation regardless of any formal ``[C:N]`` markers — baseline
+# was producing refusals like ``根拠が不足しています ... [C:1]`` and the
+# regex-only check was treating them as cited, unfairly penalising PHOTON
+# which honestly omits the marker on refusals.
+REFUSAL_PATTERNS: tuple[str, ...] = (
+    "根拠が不足しています",
+    "根拠不足",
+    "情報がありません",
+    "情報はありません",
+    "わかりません",
+    "判断できません",
+    "特定できません",
+)
+
+
+def is_refusal_answer(answer: str) -> bool:
+    """True if *answer* contains any known refusal / abstain phrase."""
+    if not answer:
+        return False
+    return any(p in answer for p in REFUSAL_PATTERNS)
+
 
 @dataclass
 class CitationResult:
@@ -13,6 +36,7 @@ class CitationResult:
     cited_chunks: list[Chunk]
     wrong_citation_indices: list[int]  # [C:N] indices absent from the pack
     no_citation: bool
+    is_refusal: bool = False
 
 
 def resolve_citations(answer: str, pack: EvidencePack) -> CitationResult:
@@ -44,4 +68,5 @@ def resolve_citations(answer: str, pack: EvidencePack) -> CitationResult:
         cited_chunks=cited_chunks,
         wrong_citation_indices=wrong_indices,
         no_citation=len(indices) == 0,
+        is_refusal=is_refusal_answer(answer),
     )

--- a/baseline_reporag/eval/institutional/citation_eval.py
+++ b/baseline_reporag/eval/institutional/citation_eval.py
@@ -11,6 +11,8 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Iterable, Protocol
 
+from baseline_reporag.citation import is_refusal_answer
+
 
 class Grade(str, Enum):
     CORRECT_CHUNK = "correct_chunk"
@@ -88,6 +90,11 @@ def grade_prediction(
                 return Grade.ARTICLE_LEVEL_CORRECT
 
     if pred.get("no_citation") or not cited:
+        return Grade.NO_CITATION
+    # Issue #154 Bug 2: refusal answers ("根拠が不足しています ... [C:1]") fall
+    # through here with cited != [] because the LLM appended a formal marker.
+    # They are semantic no-citations, not wrong citations — grade accordingly.
+    if is_refusal_answer(str(pred.get("answer", ""))):
         return Grade.NO_CITATION
     return Grade.WRONG_CITATION
 

--- a/baseline_reporag/photon_pipeline.py
+++ b/baseline_reporag/photon_pipeline.py
@@ -1107,6 +1107,7 @@ class PhotonRAGPipeline:
                 lexical_weight=cfg.retrieval.weights.lexical,
                 embedding_weight=cfg.retrieval.weights.embedding,
                 expanded_queries=[expansion_terms] if expansion_terms else [],
+                repo_id=repo_id,
             )
 
         # --- Reranking ---

--- a/baseline_reporag/pipeline.py
+++ b/baseline_reporag/pipeline.py
@@ -148,6 +148,7 @@ class RepoRAGPipeline:
                 lexical_weight=cfg.retrieval.weights.lexical,
                 embedding_weight=cfg.retrieval.weights.embedding,
                 expanded_queries=[expansion_terms] if expansion_terms else [],
+                repo_id=repo_id,
             )
 
         # --- Reranking (noise filter + optional cross-encoder) ---

--- a/baseline_reporag/retrieval/hybrid.py
+++ b/baseline_reporag/retrieval/hybrid.py
@@ -21,6 +21,15 @@ def _normalize(pairs: list[tuple[str, float]]) -> dict[str, float]:
     return {cid: s / max_s for cid, s in pairs}
 
 
+def _belongs_to_repo(chunk_id: str, repo_id: str) -> bool:
+    """Return True iff ``chunk_id`` was indexed under ``repo_id``.
+
+    chunk_id format is ``{repo_id}::{rel_path}::{lines}``; we use the
+    ``::`` boundary so that ``repo_id="foo"`` does not match ``foobar::``.
+    """
+    return chunk_id.startswith(f"{repo_id}::")
+
+
 def _search_one(
     query: str,
     lexical_index: LexicalIndex,
@@ -29,10 +38,21 @@ def _search_one(
     embedding_top_k: int,
     lexical_weight: float,
     embedding_weight: float,
+    repo_id: str = "",
 ) -> dict[str, RetrievalResult]:
-    """Run hybrid search for a single query; returns a chunk_id → result map."""
+    """Run hybrid search for a single query; returns a chunk_id → result map.
+
+    When ``repo_id`` is non-empty, results whose ``chunk_id`` does not begin
+    with ``{repo_id}::`` are dropped before fusion (Issue #154 Bug 1: prevents
+    cross-repo chunk leakage when an in-memory index ever contains chunks
+    from more than one repo).
+    """
     lex_raw = lexical_index.search(query, top_k=lexical_top_k)
     emb_raw = embedding_index.search(query, top_k=embedding_top_k)
+
+    if repo_id:
+        lex_raw = [r for r in lex_raw if _belongs_to_repo(r.chunk_id, repo_id)]
+        emb_raw = [r for r in emb_raw if _belongs_to_repo(r.chunk_id, repo_id)]
 
     lex_norm = _normalize([(r.chunk_id, r.score) for r in lex_raw])
     emb_norm = _normalize([(r.chunk_id, r.score) for r in emb_raw])
@@ -60,6 +80,7 @@ def hybrid_search(
     lexical_weight: float = 0.45,
     embedding_weight: float = 0.45,
     expanded_queries: list[str] | None = None,
+    repo_id: str = "",
 ) -> list[RetrievalResult]:
     """Hybrid BM25 + embedding search with optional multi-query expansion.
 
@@ -67,6 +88,9 @@ def hybrid_search(
     strings), each query is searched independently and the results are merged
     by taking the **max score** across queries for each chunk.  This broadens
     recall without penalising chunks that only match one query variant.
+
+    When *repo_id* is provided, results whose ``chunk_id`` is not prefixed
+    with ``{repo_id}::`` are dropped — see ``_search_one`` (Issue #154).
     """
     # Primary query
     merged: dict[str, RetrievalResult] = _search_one(
@@ -77,6 +101,7 @@ def hybrid_search(
         embedding_top_k,
         lexical_weight,
         embedding_weight,
+        repo_id=repo_id,
     )
 
     # Expanded queries — merge by max score
@@ -91,6 +116,7 @@ def hybrid_search(
             embedding_top_k,
             lexical_weight,
             embedding_weight,
+            repo_id=repo_id,
         )
         for cid, res in extra.items():
             if cid not in merged or res.score > merged[cid].score:

--- a/baseline_reporag/tests/test_citation.py
+++ b/baseline_reporag/tests/test_citation.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from baseline_reporag.citation import resolve_citations
+from baseline_reporag.citation import is_refusal_answer, resolve_citations
 from baseline_reporag.generation.evidence_pack import EvidencePack
 from baseline_reporag.ingestion.chunker import Chunk
 
@@ -84,3 +84,62 @@ class TestEchoBackResistance:
         result = resolve_citations(answer, pack)
         assert set(result.cited_chunk_ids) == {"chunk_0", "chunk_1"}
         assert result.no_citation is False
+
+
+# Issue #154 Bug 2: refusal detection -------------------------------------
+
+
+class TestIsRefusalAnswer:
+    """is_refusal_answer は形式的な [C:N] と無関係に「根拠なし」回答を検出する。"""
+
+    def test_detects_abstain_marker(self) -> None:
+        assert is_refusal_answer("根拠が不足しています。詳細不明。") is True
+
+    def test_detects_marker_followed_by_citation(self) -> None:
+        # The bug: baseline writes refusal + [C:1] and used to be counted as cited
+        assert (
+            is_refusal_answer(
+                "根拠が不足しています。提供されたコードチャンクには情報がありません [C:1]"
+            )
+            is True
+        )
+
+    def test_detects_short_refusal(self) -> None:
+        assert is_refusal_answer("根拠不足。") is True
+
+    def test_detects_jouhou_ga_arimasen(self) -> None:
+        assert is_refusal_answer("該当する情報がありません。") is True
+
+    def test_normal_answer_is_not_refusal(self) -> None:
+        assert (
+            is_refusal_answer("The router is registered in fastapi/cli.py [C:1]")
+            is False
+        )
+
+    def test_empty_string_is_not_refusal(self) -> None:
+        assert is_refusal_answer("") is False
+
+
+class TestResolveCitationsRefusalFlag:
+    """resolve_citations は CitationResult.is_refusal を埋める。"""
+
+    def test_refusal_with_citation_marks_is_refusal(self) -> None:
+        pack = _make_pack(3)
+        answer = "根拠が不足しています。提供されたコードチャンクからは特定不能 [C:1]"
+        result = resolve_citations(answer, pack)
+        assert result.is_refusal is True
+        # 既存挙動の互換性: 形式的な [C:1] は no_citation=False のまま
+        assert result.no_citation is False
+
+    def test_refusal_without_citation(self) -> None:
+        pack = _make_pack(3)
+        answer = "根拠が不足しています。"
+        result = resolve_citations(answer, pack)
+        assert result.is_refusal is True
+        assert result.no_citation is True
+
+    def test_normal_answer_not_refusal(self) -> None:
+        pack = _make_pack(3)
+        answer = "The function is in [C:1]."
+        result = resolve_citations(answer, pack)
+        assert result.is_refusal is False

--- a/scripts/aggregate_institutional_baseline.py
+++ b/scripts/aggregate_institutional_baseline.py
@@ -29,6 +29,14 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Any, Callable, NamedTuple
 
+# Allow this script to import baseline_reporag when run via the
+# ``sys.path.insert(0, "scripts")`` pattern used by the test suite.
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from baseline_reporag.citation import is_refusal_answer  # noqa: E402
+
 REQUIRED_FIELDS: tuple[str, ...] = (
     "eval_id",
     "category",
@@ -50,7 +58,11 @@ FailurePick = tuple[PredictionRecord, bool]
 
 
 def is_no_citation(record: PredictionRecord) -> bool:
-    return bool(record["no_citation"]) or not record["cited_chunk_ids"]
+    # Issue #154 Bug 2: a refusal answer ("根拠が不足しています ... [C:1]") is
+    # semantically no-citation even when cited_chunk_ids is non-empty.
+    if bool(record["no_citation"]) or not record["cited_chunk_ids"]:
+        return True
+    return is_refusal_answer(str(record.get("answer", "")))
 
 
 def expand_prediction_paths(args_predictions: list[str]) -> list[Path]:

--- a/tests/test_aggregate_institutional.py
+++ b/tests/test_aggregate_institutional.py
@@ -160,6 +160,25 @@ def test_compute_overall_nc_counts_both_flags() -> None:
     assert stat["nc_rate"] == pytest.approx(2 / 3 * 100)
 
 
+def test_compute_overall_counts_refusal_with_citation_as_nc() -> None:
+    """Issue #154 Bug 2: refusal answers with formal [C:N] must count as NC."""
+    records = [
+        _make_record(
+            answer="根拠が不足しています。提供されたコードチャンクには情報がありません。 [C:1]",
+            no_citation=False,
+            cited_chunk_ids=["c1"],
+        ),
+        _make_record(
+            answer="The function is in cli.py [C:1]",
+            no_citation=False,
+            cited_chunk_ids=["c1"],
+        ),
+    ]
+    stat = agg.compute_overall(records)
+    assert stat["total"] == 2
+    assert stat["nc"] == 1, "refusal with formal [C:1] should be counted as NC"
+
+
 # ----------------------------------------------------------------------
 # T3: compute_category — alphabetical sort
 # ----------------------------------------------------------------------

--- a/tests/test_eval_institutional_citations.py
+++ b/tests/test_eval_institutional_citations.py
@@ -93,6 +93,40 @@ def test_no_citation_branch() -> None:
     assert grade is Grade.NO_CITATION
 
 
+def test_refusal_with_citation_is_no_citation() -> None:
+    """Issue #154 Bug 2: refusal answers with formal [C:N] must grade as NO_CITATION,
+    not WRONG_CITATION (which previously over-penalised baseline).
+    """
+    lookup = _lookup({"cx": ("body unrelated to ref", "doc_b")})
+    grade = grade_prediction(
+        {
+            "answer": "根拠が不足しています。提供されたコードチャンクには情報がありません。",
+            "cited_chunk_ids": ["cx"],
+            "no_citation": False,
+        },
+        {"reference_chunk_ids": ["c1"], "source_document_id": "doc_a"},
+        lookup,
+    )
+    assert grade is Grade.NO_CITATION
+
+
+def test_refusal_does_not_override_correct_chunk() -> None:
+    """A correct citation must still grade CORRECT_CHUNK even if the answer text
+    happens to mention 根拠が不足 — the grader prioritises true matches.
+    """
+    lookup = _lookup({"c1": ("第3条 内容", "doc_a")})
+    grade = grade_prediction(
+        {
+            "answer": "根拠が不足している部分は補足できません。 [C:1]",
+            "cited_chunk_ids": ["c1"],
+            "no_citation": False,
+        },
+        {"reference_chunk_ids": ["c1"], "source_document_id": "doc_a"},
+        lookup,
+    )
+    assert grade is Grade.CORRECT_CHUNK
+
+
 def test_dict_chunk_lookup_defaults() -> None:
     lookup = _lookup({})
     assert lookup.get_chunk_text("missing") == ""

--- a/tests/test_repo_isolation.py
+++ b/tests/test_repo_isolation.py
@@ -1,0 +1,115 @@
+"""Cross-repo retrieval isolation tests (Issue #154 Bug 1).
+
+If two repos' chunks ever share an index in memory, ``hybrid_search`` must drop
+chunks whose ``chunk_id`` does not begin with ``{repo_id}::``. The bug report
+showed a commandmate query returning ``fastapi_fastapi::...`` chunks; this
+suite pins the contract so the regression cannot reappear.
+"""
+
+from __future__ import annotations
+
+from baseline_reporag.indexing.embedding import EmbeddingResult
+from baseline_reporag.indexing.lexical import LexicalResult
+from baseline_reporag.retrieval.hybrid import hybrid_search
+
+
+class _FakeLexicalIndex:
+    def __init__(self, results: list[LexicalResult]) -> None:
+        self._results = results
+
+    def search(self, query: str, top_k: int = 20) -> list[LexicalResult]:
+        return list(self._results[:top_k])
+
+
+class _FakeEmbeddingIndex:
+    def __init__(self, results: list[EmbeddingResult]) -> None:
+        self._results = results
+
+    def search(self, query: str, top_k: int = 20) -> list[EmbeddingResult]:
+        return list(self._results[:top_k])
+
+
+def _mixed_lexical() -> _FakeLexicalIndex:
+    return _FakeLexicalIndex(
+        [
+            LexicalResult("fastapi_fastapi::fastapi/cli.py::1-7", 5.0),
+            LexicalResult("commandmate::src/cli/main.ts::1-30", 4.0),
+            LexicalResult("fastapi_fastapi::fastapi/openapi/docs.py::40-194", 3.0),
+            LexicalResult("commandmate::src/web/router.ts::1-50", 2.0),
+        ]
+    )
+
+
+def _mixed_embedding() -> _FakeEmbeddingIndex:
+    return _FakeEmbeddingIndex(
+        [
+            EmbeddingResult("fastapi_fastapi::fastapi/openapi/docs.py::197-298", 0.9),
+            EmbeddingResult("commandmate::src/lib/util.ts::10-40", 0.8),
+            EmbeddingResult("fastapi_fastapi::fastapi/cli.py::1-7", 0.7),
+            EmbeddingResult("commandmate::src/web/router.ts::1-50", 0.6),
+        ]
+    )
+
+
+def test_hybrid_search_drops_other_repo_chunks() -> None:
+    """When repo_id is set, results from other repos must be filtered out."""
+    results = hybrid_search(
+        query="cli web ui",
+        lexical_index=_mixed_lexical(),
+        embedding_index=_mixed_embedding(),
+        lexical_top_k=10,
+        embedding_top_k=10,
+        fused_top_k=10,
+        repo_id="commandmate",
+    )
+
+    assert results, "expected at least one commandmate chunk to survive the filter"
+    for r in results:
+        assert r.chunk_id.startswith("commandmate::"), (
+            f"cross-repo leakage: {r.chunk_id} returned for repo_id=commandmate"
+        )
+
+
+def test_hybrid_search_repo_filter_with_expanded_queries() -> None:
+    """Filter must also apply to expanded-query result merging."""
+    results = hybrid_search(
+        query="primary",
+        lexical_index=_mixed_lexical(),
+        embedding_index=_mixed_embedding(),
+        lexical_top_k=10,
+        embedding_top_k=10,
+        fused_top_k=10,
+        expanded_queries=["expansion-term"],
+        repo_id="commandmate",
+    )
+
+    for r in results:
+        assert r.chunk_id.startswith("commandmate::")
+
+
+def test_hybrid_search_no_repo_id_keeps_legacy_behaviour() -> None:
+    """Default (repo_id='') must not filter — preserves backward-compat."""
+    results = hybrid_search(
+        query="cli web ui",
+        lexical_index=_mixed_lexical(),
+        embedding_index=_mixed_embedding(),
+        lexical_top_k=10,
+        embedding_top_k=10,
+        fused_top_k=10,
+    )
+    repos_seen = {r.chunk_id.split("::", 1)[0] for r in results}
+    assert "fastapi_fastapi" in repos_seen and "commandmate" in repos_seen
+
+
+def test_hybrid_search_unknown_repo_returns_empty() -> None:
+    """Filtering for a repo with no matching chunks yields an empty result."""
+    results = hybrid_search(
+        query="anything",
+        lexical_index=_mixed_lexical(),
+        embedding_index=_mixed_embedding(),
+        lexical_top_k=10,
+        embedding_top_k=10,
+        fused_top_k=10,
+        repo_id="unknown_repo",
+    )
+    assert results == []


### PR DESCRIPTION
## Summary

Issue #148 Phase A.3 commandmate eval で発覚した 2 つの critical eval バグを修正します。両者ともに baseline vs PHOTON 比較を歪めており、本修正なしでは #135 の前後比較も信頼できません。

- **バグ 1（cross-repo chunk leakage）**: `hybrid_search` が `repo_id` を考慮せず、commandmate クエリで fastapi_fastapi の chunk が retrieval されていた。`_search_one` / `hybrid_search` にオプション `repo_id` を追加し、`chunk_id` が `{repo_id}::` で始まらない結果を破棄。`pipeline.py` / `photon_pipeline.py` の両呼出元から `repo_id` を伝搬。
- **バグ 2（refusal を「引用あり」と誤判定）**: 「根拠が不足しています ... [C:1]」のような形式的引用付き refusal が NC=False と判定され、honest refusal を出す PHOTON が不当に penalty を受けていた。`baseline_reporag/citation.py` に `is_refusal_answer()` / `REFUSAL_PATTERNS` を追加し、institutional grader と aggregate script で refusal を `NO_CITATION` に分類するよう更新。

## 受入条件への対応

| Issue 受入条件 | 対応 |
|---|---|
| retrieval pipeline が `repo_id` フィルタを厳密に適用することを test で固定 | `tests/test_repo_isolation.py`（4 件）で契約を pin |
| cross-repo leakage が起きないことを境界 test で検証 | 同上：unknown_repo / expanded_queries / mixed-repo シナリオを網羅 |
| citation grader に refusal phrase 検出を追加 | `is_refusal_answer()` + 7 つの REFUSAL_PATTERNS |
| refusal phrase + [C:N] が共存する回答は NC=True に分類 | `citation_eval.py` / `aggregate_institutional_baseline.py` に反映 |

## 設計判断

`apply_citation_postprocess` への refusal 検出拡張は試みたが、既存テスト `test_quoted_abstain_marker_is_not_skipped`（引用された marker は refusal 扱いしない契約）を破壊するため revert。eval バグの本質的な修正層は grader / aggregator なので、postprocess は既存の `startswith(ABSTAIN_MARKER)` のままで十分。

## 残タスク（本 PR 範囲外）

- commandmate eval の再実行（baseline NC が ~10% 以下に戻ることを確認）→ Issue 受入条件 ✅ には別途必要
- 過去の eval log の re-grade（修正後の grader で再集計）

## Test plan

- [x] `python -m pytest tests/test_repo_isolation.py` — 4 件全 PASS
- [x] `python -m pytest baseline_reporag/tests/test_citation.py tests/test_eval_institutional_citations.py tests/test_aggregate_institutional.py` — 全 PASS（追加 test 含む）
- [x] `python -m pytest torch_ref/tests/ photon_mlx/tests/ baseline_reporag/tests/ tests/` — 1178 passed / 3 failed（3 件は親コミットでも失敗する pre-existing：`test_generate_training_corpus.py` 2 件 + `test_vocab_size_mismatch_raises` 1 件）
- [x] `ruff check .` — All checks passed
- [x] `ruff format --check .` — 151 files already formatted
- [ ] commandmate eval 再実行で baseline NC が正常化することを確認（マージ後 / develop 上で）

🤖 Generated with [Claude Code](https://claude.com/claude-code)