### PR TITLE
feat(a1-phase2): compare script + --use-photon flag + demo smoke tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,9 @@ PYTEST ?= $(PYTHON) -m pytest
 # default ターゲットは help
 .DEFAULT_GOAL := help
 
-.PHONY: help setup ingest indexes graph prepare serve ask cli demo demo-list \
-        eval eval-baseline eval-photon check lint fmt fmt-check test test-fast clean
+.PHONY: help setup ingest indexes graph prepare serve ask ask-photon cli compare \
+        demo demo-list eval eval-baseline eval-photon \
+        check lint fmt fmt-check test test-fast clean
 
 help: ## 全 target を一覧表示
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -77,6 +78,14 @@ ask: ## CLI から 1 問 (Q="..." で質問を渡す)
 	$(PYTHON) -m baseline_reporag.cli --config $(CONFIG) --repo-id $(REPO_ID) --question "$(Q)"
 
 cli: ask ## ask の alias
+
+ask-photon: ## CLI from PHOTON pipeline (--use-photon shortcut)
+	@if [ -z "$(Q)" ]; then echo 'ERROR: Q="質問" を渡してください'; exit 1; fi
+	$(PYTHON) -m baseline_reporag.cli --use-photon --repo-id $(REPO_ID) --question "$(Q)"
+
+compare: ## baseline と PHOTON を 1 質問で並列比較 (Q="..." 必須)
+	@if [ -z "$(Q)" ]; then echo 'ERROR: Q="質問" を渡してください'; exit 1; fi
+	$(PYTHON) scripts/compare_baseline_photon.py --repo-id $(REPO_ID) --question "$(Q)"
 
 # ---------------------------------------------------------------------------
 # Demo scenarios

--- a/baseline_reporag/cli.py
+++ b/baseline_reporag/cli.py
@@ -8,6 +8,11 @@ Usage (single question):
 
 Usage (interactive):
     python -m baseline_reporag.cli --repo-id fastapi_fastapi
+
+Usage (PHOTON pipeline shortcut):
+    python -m baseline_reporag.cli --use-photon \
+        --repo-id fastapi_fastapi \
+        --question "..."
 """
 
 from __future__ import annotations
@@ -22,16 +27,43 @@ from .config import load_config
 # only when ``cfg.model.provider == "photon"``.
 from .pipeline_factory import build_pipeline
 
+# A-1 Phase 2: ``--use-photon`` のショートカットが指す PHOTON config。
+# baseline.yaml は PHOTON 専用フィールド (checkpoint_path, base_embed_dim 等)
+# を持たないため provider のみ override しても動かない。専用 config を使う。
+_PHOTON_DEFAULT_CONFIG = "configs/photon_small.yaml"
+_BASELINE_DEFAULT_CONFIG = "configs/baseline.yaml"
+
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Baseline RepoRAG CLI")
-    parser.add_argument("--config", default="configs/baseline.yaml")
+    parser.add_argument(
+        "--config",
+        default=None,
+        help=(
+            f"Config path (default: {_BASELINE_DEFAULT_CONFIG}; "
+            f"with --use-photon: {_PHOTON_DEFAULT_CONFIG})"
+        ),
+    )
+    parser.add_argument(
+        "--use-photon",
+        action="store_true",
+        help=(
+            "Shortcut to use the PHOTON pipeline. Equivalent to "
+            f"--config {_PHOTON_DEFAULT_CONFIG}. Cannot be combined with --config."
+        ),
+    )
     parser.add_argument("--repo-id", default="")
     parser.add_argument("--question", default="")
     parser.add_argument("--session-id", default="")
     args = parser.parse_args()
 
-    cfg = load_config(args.config)
+    if args.use_photon and args.config is not None:
+        parser.error("--use-photon cannot be combined with --config")
+    config_path = args.config or (
+        _PHOTON_DEFAULT_CONFIG if args.use_photon else _BASELINE_DEFAULT_CONFIG
+    )
+
+    cfg = load_config(config_path)
     repo_id = args.repo_id or cfg.repo.repo_id
 
     # Route via ``build_pipeline`` so ``model.provider`` (baseline vs

--- a/docs/playground.md
+++ b/docs/playground.md
@@ -64,15 +64,31 @@ make ask CONFIG=configs/local.small.yaml REPO_ID=<repo> Q="..."
 
 ## 2. baseline と PHOTON を比較したい
 
-### Cookbook 2-1: 同じ質問で 2 condition 比較 (CLI レベル)
+### Cookbook 2-1: 同じ質問で 2 condition 比較 (1 コマンド)
+
+`scripts/compare_baseline_photon.py` を使うと baseline と PHOTON を 1 質問で並べて比較できる:
 
 ```bash
-# baseline
-make ask CONFIG=configs/baseline.yaml REPO_ID=fastapi_fastapi Q="認証処理の入口は？"
-
-# PHOTON
 export PHOTON_CHECKPOINT_ROOT=/path/to/checkpoints
-make ask CONFIG=configs/photon_small.yaml REPO_ID=fastapi_fastapi Q="認証処理の入口は？"
+make compare REPO_ID=fastapi_fastapi Q="認証処理の入口は？"
+```
+
+出力: 各 variant の answer / latency / memory / citation を side-by-side で表示し、最後に
+delta (latency 差分 + パーセント) を要約。
+
+JSON 形式で取り出したい場合:
+```bash
+python scripts/compare_baseline_photon.py --repo-id fastapi_fastapi --question "..." --json
+```
+
+### Cookbook 2-1b: CLI から PHOTON だけ叩きたい
+
+`--use-photon` ショートカットで `configs/photon_small.yaml` を自動選択:
+
+```bash
+make ask-photon REPO_ID=fastapi_fastapi Q="..."
+# 等価:
+# python -m baseline_reporag.cli --use-photon --repo-id fastapi_fastapi --question "..."
 ```
 
 ### Cookbook 2-2: bench で N 件まとめて比較

--- a/scripts/compare_baseline_photon.py
+++ b/scripts/compare_baseline_photon.py
@@ -1,0 +1,198 @@
+"""compare_baseline_photon.py — 1 質問で baseline と PHOTON を並べて比較する。
+
+A-1 (self-use) Phase 2: 試行錯誤中に "この質問で PHOTON が baseline より速いか?
+citation を返すか?" を即座に確認するためのスクリプト。
+bench/run_all.py は重量級 (datasets 経由) なので、軽量な 1 question 比較を提供する。
+
+Usage:
+    python scripts/compare_baseline_photon.py \\
+        --repo-id fastapi_fastapi \\
+        --question "認証処理の入口は？"
+
+    # 別の config を指定:
+    python scripts/compare_baseline_photon.py \\
+        --baseline-config configs/baseline.yaml \\
+        --photon-config configs/photon_small.yaml \\
+        --repo-id fastapi_fastapi \\
+        --question "..."
+
+    # JSON 出力 (CI / 後続処理用):
+    python scripts/compare_baseline_photon.py --question "..." --repo-id ... --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from baseline_reporag.config import load_config
+from baseline_reporag.pipeline_factory import build_pipeline
+
+
+@dataclass
+class VariantResult:
+    """1 variant (baseline or photon) の実行結果。"""
+
+    variant_id: str
+    config_path: str
+    answer: str
+    cited_chunk_ids: list[str]
+    no_citation: bool
+    latency_total_ms: float
+    latency_retrieval_ms: float
+    latency_generation_ms: float
+    memory_peak_mb: float
+
+
+def run_variant(
+    variant_id: str,
+    config_path: str,
+    question: str,
+    repo_id: str,
+    session_id: str,
+) -> VariantResult:
+    """1 variant 分の pipeline を立てて 1 question を実行。"""
+    cfg = load_config(config_path)
+    resolved_repo_id = repo_id or cfg.repo.repo_id
+    pipeline = build_pipeline(cfg)
+    result = pipeline.query(
+        question=question,
+        session_id=session_id,
+        repo_id=resolved_repo_id,
+    )
+    return VariantResult(
+        variant_id=variant_id,
+        config_path=config_path,
+        answer=result.answer,
+        cited_chunk_ids=list(result.cited_chunk_ids),
+        no_citation=bool(result.no_citation),
+        latency_total_ms=float(result.latency.total_ms),
+        latency_retrieval_ms=float(result.latency.retrieval_ms),
+        latency_generation_ms=float(result.latency.generation_ms),
+        memory_peak_mb=float(result.memory.peak_mb),
+    )
+
+
+def print_text_report(question: str, results: list[VariantResult]) -> None:
+    """側並びの text レポートを出力。"""
+    print("=" * 78)
+    print(f"Question: {question}")
+    print("=" * 78)
+
+    for r in results:
+        print(f"\n[{r.variant_id}]  config={r.config_path}")
+        print(
+            f"  latency: {r.latency_total_ms:.0f} ms"
+            f"  (retrieval {r.latency_retrieval_ms:.0f}"
+            f" | gen {r.latency_generation_ms:.0f})"
+        )
+        print(f"  memory:  {r.memory_peak_mb:.1f} MB")
+        print(f"  cited:   {r.cited_chunk_ids}")
+        if r.no_citation:
+            print("  [WARNING] No citations")
+        print(f"\n  Answer:\n{_indent(r.answer, prefix='  ')}")
+
+    print("\n" + "=" * 78)
+    print("Summary (latency):")
+    for r in results:
+        print(f"  {r.variant_id:>10s}: {r.latency_total_ms:>8.0f} ms")
+    if len(results) >= 2:
+        delta = results[1].latency_total_ms - results[0].latency_total_ms
+        pct = (
+            (delta / results[0].latency_total_ms * 100)
+            if results[0].latency_total_ms
+            else 0.0
+        )
+        print(
+            f"  delta:      {delta:>+8.0f} ms"
+            f"  ({pct:>+5.1f}% vs {results[0].variant_id})"
+        )
+    print("=" * 78)
+
+
+def _indent(text: str, prefix: str = "  ") -> str:
+    return "\n".join(prefix + line for line in text.splitlines())
+
+
+def to_json_payload(question: str, results: list[VariantResult]) -> dict[str, Any]:
+    return {
+        "question": question,
+        "variants": [asdict(r) for r in results],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Compare baseline and PHOTON pipelines on a single question.",
+    )
+    parser.add_argument("--question", required=True, help="The question to ask.")
+    parser.add_argument(
+        "--repo-id",
+        default="",
+        help="Repo id to query against (falls back to cfg.repo.repo_id).",
+    )
+    parser.add_argument(
+        "--baseline-config",
+        default="configs/baseline.yaml",
+        help="Path to the baseline config (default: configs/baseline.yaml).",
+    )
+    parser.add_argument(
+        "--photon-config",
+        default="configs/photon_small.yaml",
+        help="Path to the PHOTON config (default: configs/photon_small.yaml).",
+    )
+    parser.add_argument(
+        "--session-id",
+        default="",
+        help=(
+            "Session id to use. Defaults to a fresh per-variant id so memory "
+            "state does not leak between baseline and PHOTON runs."
+        ),
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON instead of the text report.",
+    )
+    args = parser.parse_args()
+
+    baseline_session = args.session_id or "compare-baseline"
+    photon_session = args.session_id or "compare-photon"
+
+    baseline_result = run_variant(
+        variant_id="baseline",
+        config_path=args.baseline_config,
+        question=args.question,
+        repo_id=args.repo_id,
+        session_id=baseline_session,
+    )
+    photon_result = run_variant(
+        variant_id="photon",
+        config_path=args.photon_config,
+        question=args.question,
+        repo_id=args.repo_id,
+        session_id=photon_session,
+    )
+
+    results = [baseline_result, photon_result]
+
+    if args.json:
+        print(
+            json.dumps(
+                to_json_payload(args.question, results), ensure_ascii=False, indent=2
+            )
+        )
+    else:
+        print_text_report(args.question, results)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_cli_use_photon.py
+++ b/tests/test_cli_use_photon.py
@@ -1,0 +1,118 @@
+"""Tests for the ``--use-photon`` flag added in A-1 Phase 2.
+
+The flag is a shortcut: ``--use-photon`` is equivalent to
+``--config configs/photon_small.yaml`` (and is mutually exclusive with
+``--config``). The tests below verify:
+
+- ``--use-photon`` selects the PHOTON config path.
+- omitting both flags selects the baseline config path.
+- combining ``--use-photon`` with ``--config`` exits with an error.
+
+We mock ``load_config`` and ``build_pipeline`` so the tests run on
+baseline-only environments (no MLX, no real configs needed).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from baseline_reporag import cli as cli_module
+
+
+@pytest.fixture
+def mock_pipeline_and_config(monkeypatch):
+    """load_config + build_pipeline をモック化し、選ばれた config_path を捕捉する。"""
+    captured: dict[str, object] = {}
+
+    fake_cfg = MagicMock()
+    fake_cfg.repo.repo_id = "fake_repo"
+
+    def _fake_load_config(path: str):
+        captured["config_path"] = path
+        return fake_cfg
+
+    fake_pipeline = MagicMock()
+    fake_result = MagicMock()
+    fake_result.turn_id = 1
+    fake_result.latency.total_ms = 1.0
+    fake_result.latency.retrieval_ms = 0.5
+    fake_result.latency.generation_ms = 0.5
+    fake_result.memory.peak_mb = 1.0
+    fake_result.answer = "fake-answer"
+    fake_result.no_citation = False
+    fake_result.wrong_citation_indices = []
+    fake_result.cited_chunk_ids = []
+    fake_result.session_id = "test-session"
+    fake_pipeline.query.return_value = fake_result
+
+    monkeypatch.setattr(cli_module, "load_config", _fake_load_config)
+    monkeypatch.setattr(cli_module, "build_pipeline", lambda _cfg: fake_pipeline)
+
+    return captured
+
+
+def test_use_photon_picks_photon_config(mock_pipeline_and_config, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "sys.argv",
+        ["cli", "--use-photon", "--question", "Q?", "--repo-id", "fake_repo"],
+    )
+
+    cli_module.main()
+
+    assert mock_pipeline_and_config["config_path"] == "configs/photon_small.yaml"
+
+
+def test_default_picks_baseline_config(mock_pipeline_and_config, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "sys.argv",
+        ["cli", "--question", "Q?", "--repo-id", "fake_repo"],
+    )
+
+    cli_module.main()
+
+    assert mock_pipeline_and_config["config_path"] == "configs/baseline.yaml"
+
+
+def test_explicit_config_wins_over_default(
+    mock_pipeline_and_config, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "cli",
+            "--config",
+            "configs/institutional_docs.yaml",
+            "--question",
+            "Q?",
+            "--repo-id",
+            "fake_repo",
+        ],
+    )
+
+    cli_module.main()
+
+    assert mock_pipeline_and_config["config_path"] == "configs/institutional_docs.yaml"
+
+
+def test_use_photon_with_explicit_config_errors(monkeypatch, capsys) -> None:
+    """--use-photon と --config を同時指定すると argparse の error 経由で SystemExit。"""
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "cli",
+            "--use-photon",
+            "--config",
+            "configs/baseline.yaml",
+            "--question",
+            "Q?",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli_module.main()
+
+    assert excinfo.value.code == 2  # argparse error exit code
+    err = capsys.readouterr().err
+    assert "--use-photon cannot be combined with --config" in err

--- a/tests/test_compare_baseline_photon.py
+++ b/tests/test_compare_baseline_photon.py
@@ -1,0 +1,239 @@
+"""Tests for scripts/compare_baseline_photon.py.
+
+A-1 Phase 2 Step 1: 1 question で baseline と PHOTON を並べて比較するスクリプトの単体テスト。
+build_pipeline と pipeline.query を mock することで、MLX 不在環境でも動作する。
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _load_module():
+    """compare_baseline_photon を importlib で読み込む (scripts/ は package ではない)。"""
+    repo_root = Path(__file__).resolve().parent.parent
+    script_path = repo_root / "scripts" / "compare_baseline_photon.py"
+    spec = importlib.util.spec_from_file_location(
+        "compare_baseline_photon", script_path
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["compare_baseline_photon"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def fake_query_result():
+    """軽量な QueryResult スタブ。"""
+    from baseline_reporag.contracts import QueryResult
+    from baseline_reporag.profiler import LatencyBreakdown, MemorySnapshot
+
+    return QueryResult(
+        answer="The entry point is main.py:42.",
+        session_id="compare-baseline",
+        turn_id=1,
+        cited_chunk_ids=["c1", "c2"],
+        wrong_citation_indices=[],
+        no_citation=False,
+        latency=LatencyBreakdown(
+            retrieval_ms=100.0,
+            generation_ms=900.0,
+            citation_ms=0.0,
+            total_ms=1000.0,
+        ),
+        memory=MemorySnapshot(peak_mb=50.0, current_mb=25.0),
+        citation_postprocessed=False,
+        generator_used="qwen",
+        generator_fallback_reason=None,
+    )
+
+
+class TestRunVariant:
+    def test_returns_variant_result_with_pipeline_data(
+        self, monkeypatch, tmp_path: Path, fake_query_result
+    ) -> None:
+        """build_pipeline + pipeline.query の出力が VariantResult に正しく取り込まれる。"""
+        module = _load_module()
+
+        # 軽量 config を生成 (load_config が要求する最小フィールド)
+        cfg_path = tmp_path / "fake.yaml"
+        cfg_path.write_text(
+            "version: 1\n"
+            "paths:\n  data_root: ./data\n  log_root: ./logs\n"
+            'repo:\n  repo_id: "fake_repo"\n  repo_commit: "deadbeef"\n'
+            "model:\n"
+            '  provider: "baseline"\n'
+            '  model_id: "fake-model"\n',
+            encoding="utf-8",
+        )
+
+        fake_pipeline = MagicMock()
+        fake_pipeline.query.return_value = fake_query_result
+
+        # script は ``from baseline_reporag.pipeline_factory import build_pipeline``
+        # で module level にバインドしているため、script モジュール自体の
+        # 属性を patch する。
+        monkeypatch.setattr(module, "build_pipeline", lambda _cfg: fake_pipeline)
+
+        result = module.run_variant(
+            variant_id="baseline",
+            config_path=str(cfg_path),
+            question="Where is the entry point?",
+            repo_id="fake_repo",
+            session_id="test-1",
+        )
+
+        assert result.variant_id == "baseline"
+        assert result.config_path == str(cfg_path)
+        assert result.answer == "The entry point is main.py:42."
+        assert result.cited_chunk_ids == ["c1", "c2"]
+        assert result.no_citation is False
+        assert result.latency_total_ms == 1000.0
+        assert result.latency_retrieval_ms == 100.0
+        assert result.latency_generation_ms == 900.0
+        assert result.memory_peak_mb == 50.0
+
+        # pipeline.query が正しい引数で呼ばれた
+        fake_pipeline.query.assert_called_once()
+        call_kwargs = fake_pipeline.query.call_args.kwargs
+        assert call_kwargs["question"] == "Where is the entry point?"
+        assert call_kwargs["session_id"] == "test-1"
+        assert call_kwargs["repo_id"] == "fake_repo"
+
+    def test_falls_back_to_cfg_repo_id_when_repo_id_empty(
+        self, monkeypatch, tmp_path: Path, fake_query_result
+    ) -> None:
+        """空文字 repo_id の場合 cfg.repo.repo_id にフォールバックする。"""
+        module = _load_module()
+
+        cfg_path = tmp_path / "fake.yaml"
+        cfg_path.write_text(
+            "version: 1\n"
+            "paths:\n  data_root: ./data\n  log_root: ./logs\n"
+            'repo:\n  repo_id: "default_repo"\n  repo_commit: "deadbeef"\n'
+            "model:\n"
+            '  provider: "baseline"\n'
+            '  model_id: "fake-model"\n',
+            encoding="utf-8",
+        )
+
+        fake_pipeline = MagicMock()
+        fake_pipeline.query.return_value = fake_query_result
+
+        # script は ``from baseline_reporag.pipeline_factory import build_pipeline``
+        # で module level にバインドしているため、script モジュール自体の
+        # 属性を patch する。
+        monkeypatch.setattr(module, "build_pipeline", lambda _cfg: fake_pipeline)
+
+        module.run_variant(
+            variant_id="baseline",
+            config_path=str(cfg_path),
+            question="Q?",
+            repo_id="",  # empty → fallback
+            session_id="test-1",
+        )
+
+        call_kwargs = fake_pipeline.query.call_args.kwargs
+        assert call_kwargs["repo_id"] == "default_repo"
+
+
+class TestPrintTextReport:
+    def test_emits_question_variants_and_summary(
+        self, capsys, fake_query_result
+    ) -> None:
+        module = _load_module()
+
+        baseline_result = module.VariantResult(
+            variant_id="baseline",
+            config_path="configs/baseline.yaml",
+            answer="ans-baseline",
+            cited_chunk_ids=["c1"],
+            no_citation=False,
+            latency_total_ms=2000.0,
+            latency_retrieval_ms=200.0,
+            latency_generation_ms=1800.0,
+            memory_peak_mb=60.0,
+        )
+        photon_result = module.VariantResult(
+            variant_id="photon",
+            config_path="configs/photon_small.yaml",
+            answer="ans-photon",
+            cited_chunk_ids=["c2"],
+            no_citation=False,
+            latency_total_ms=1000.0,
+            latency_retrieval_ms=100.0,
+            latency_generation_ms=900.0,
+            memory_peak_mb=80.0,
+        )
+
+        module.print_text_report("Q?", [baseline_result, photon_result])
+        captured = capsys.readouterr().out
+
+        assert "Question: Q?" in captured
+        assert "[baseline]" in captured
+        assert "[photon]" in captured
+        assert "ans-baseline" in captured
+        assert "ans-photon" in captured
+        # delta は photon - baseline なので -1000 ms (-50.0%)
+        assert "-1000 ms" in captured
+        assert "-50.0%" in captured
+
+    def test_warns_on_no_citation(self, capsys) -> None:
+        module = _load_module()
+
+        result = module.VariantResult(
+            variant_id="baseline",
+            config_path="configs/baseline.yaml",
+            answer="no-cite",
+            cited_chunk_ids=[],
+            no_citation=True,
+            latency_total_ms=1000.0,
+            latency_retrieval_ms=100.0,
+            latency_generation_ms=900.0,
+            memory_peak_mb=10.0,
+        )
+        module.print_text_report("Q?", [result])
+        captured = capsys.readouterr().out
+        assert "[WARNING] No citations" in captured
+
+
+class TestToJsonPayload:
+    def test_includes_question_and_variant_dicts(self) -> None:
+        module = _load_module()
+
+        result = module.VariantResult(
+            variant_id="baseline",
+            config_path="configs/baseline.yaml",
+            answer="hello",
+            cited_chunk_ids=["c1"],
+            no_citation=False,
+            latency_total_ms=1.0,
+            latency_retrieval_ms=0.5,
+            latency_generation_ms=0.5,
+            memory_peak_mb=10.0,
+        )
+        payload = module.to_json_payload("Q?", [result])
+
+        assert payload["question"] == "Q?"
+        assert len(payload["variants"]) == 1
+        assert payload["variants"][0]["variant_id"] == "baseline"
+        assert payload["variants"][0]["answer"] == "hello"
+
+        # JSON serialisable
+        encoded = json.dumps(payload, ensure_ascii=False)
+        decoded = json.loads(encoded)
+        assert decoded["variants"][0]["cited_chunk_ids"] == ["c1"]
+
+
+class TestIndent:
+    def test_indents_each_line(self) -> None:
+        module = _load_module()
+        out = module._indent("a\nb\nc", prefix=">>")
+        assert out == ">>a\n>>b\n>>c"

--- a/tests/test_demo_scenarios.py
+++ b/tests/test_demo_scenarios.py
@@ -1,0 +1,106 @@
+"""Tests for the demo scenarios module.
+
+A-1 Phase 2 Step 3: smoke / structural tests for ``demo/scenarios.py`` and
+``demo/run_demo.py``. Full end-to-end demo runs (LLM-bound, several minutes
+per scenario) are deliberately out of scope — those should be exercised
+manually via ``make demo SCENARIO=demo-01`` against an ingested repo.
+
+What we verify here is:
+
+- ``SCENARIOS`` is a non-empty list of well-formed ``DemoScenario`` items.
+- ``demo-01`` through ``demo-05`` are present (catches accidental rename / drop).
+- Every scenario has at least one turn with a non-empty question.
+- The ``run_demo`` script's ``--list`` code path works and prints all ids.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _import_demo_scenarios():
+    """Import demo.scenarios via importlib (demo/ is not a package on its own)."""
+    sys.path.insert(0, str(REPO_ROOT))
+    try:
+        from demo.scenarios import SCENARIOS, DemoScenario, DemoTurn
+
+        return SCENARIOS, DemoScenario, DemoTurn
+    finally:
+        if str(REPO_ROOT) in sys.path:
+            sys.path.remove(str(REPO_ROOT))
+
+
+class TestScenariosCatalog:
+    def test_scenarios_is_non_empty_list(self) -> None:
+        SCENARIOS, _DemoScenario, _DemoTurn = _import_demo_scenarios()
+        assert isinstance(SCENARIOS, list)
+        assert len(SCENARIOS) >= 5, "expect at least 5 demo scenarios"
+
+    def test_required_scenario_ids_present(self) -> None:
+        SCENARIOS, _DemoScenario, _DemoTurn = _import_demo_scenarios()
+        ids = {s.id for s in SCENARIOS}
+        for required in ("demo-01", "demo-02", "demo-03", "demo-04", "demo-05"):
+            assert required in ids, f"missing scenario {required}"
+
+    def test_every_scenario_has_at_least_one_non_empty_turn(self) -> None:
+        SCENARIOS, _DemoScenario, _DemoTurn = _import_demo_scenarios()
+        for scenario in SCENARIOS:
+            assert scenario.turns, f"{scenario.id} has no turns"
+            for turn in scenario.turns:
+                assert turn.question.strip(), f"{scenario.id}: empty question detected"
+
+    def test_scenario_has_title_and_axis(self) -> None:
+        SCENARIOS, _DemoScenario, _DemoTurn = _import_demo_scenarios()
+        for scenario in SCENARIOS:
+            assert scenario.title.strip(), f"{scenario.id}: empty title"
+            assert scenario.axis.strip(), f"{scenario.id}: empty axis"
+
+
+class TestRunDemoListMode:
+    """Run ``demo/run_demo.py --list`` as a subprocess and verify the output."""
+
+    def test_list_mode_prints_all_scenario_ids(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(REPO_ROOT / "demo" / "run_demo.py"), "--list"],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+            timeout=60,
+        )
+        assert result.returncode == 0, f"--list exited non-zero. stderr={result.stderr}"
+        for scenario_id in ("demo-01", "demo-02", "demo-03", "demo-04", "demo-05"):
+            assert scenario_id in result.stdout, f"--list output missing {scenario_id}"
+
+    def test_no_args_prints_scenarios(self) -> None:
+        """`run_demo.py` without arguments falls through to print_scenarios()."""
+        result = subprocess.run(
+            [sys.executable, str(REPO_ROOT / "demo" / "run_demo.py")],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+            timeout=60,
+        )
+        assert result.returncode == 0
+        assert "demo-01" in result.stdout
+
+    def test_unknown_scenario_reports_available(self) -> None:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(REPO_ROOT / "demo" / "run_demo.py"),
+                "--scenario",
+                "demo-nonexistent",
+            ],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+            timeout=60,
+        )
+        # Script prints message and returns normally (no SystemExit).
+        assert result.returncode == 0
+        assert "Unknown scenario" in result.stdout


### PR DESCRIPTION
## Summary

A-1 (self-use) Phase 2: 試行錯誤の高速化のため 3 機能を追加する。

| 機能 | 用途 |
|------|------|
| `scripts/compare_baseline_photon.py` | 1 質問で baseline / PHOTON を side-by-side 比較 |
| CLI `--use-photon` フラグ | `configs/photon_small.yaml` への 1 行ショートカット |
| demo smoke tests | scenarios の構造的検証 + `--list` mode の subprocess 検証 |

## Changes

### `scripts/compare_baseline_photon.py` (new)

```bash
# 既定 (baseline.yaml vs photon_small.yaml)
make compare REPO_ID=fastapi_fastapi Q="認証処理の入口は？"

# 任意 config 指定
python scripts/compare_baseline_photon.py \
  --baseline-config configs/baseline.yaml \
  --photon-config configs/photon_small.yaml \
  --repo-id fastapi_fastapi --question "..."

# JSON 出力 (CI / 集計用)
python scripts/compare_baseline_photon.py --question "..." --repo-id ... --json
```

出力: 各 variant の answer / latency / memory / citation を並べて表示し、最後に latency delta + パーセントを要約。

### `baseline_reporag/cli.py`: `--use-photon` フラグ

```bash
# 既存 (baseline.yaml)
make ask REPO_ID=... Q="..."

# 新ショートカット (photon_small.yaml)
make ask-photon REPO_ID=... Q="..."
# 等価:
python -m baseline_reporag.cli --use-photon --repo-id ... --question "..."
```

`--use-photon` と `--config` は **相互排他** (両方指定すると argparse error)。
理由: `baseline.yaml` には PHOTON 専用フィールド (`checkpoint_path`, `base_embed_dim` 等) が無く、`provider` だけ override しても動かない。専用 config 必須。

### demo smoke tests

Full E2E demo は LLM-bound で数分かかるため out-of-scope (manual: `make demo SCENARIO=demo-01`)。
代わりに以下を自動化:

- `SCENARIOS` catalog の構造的検証 (5 件存在 / 各 turn が non-empty)
- `run_demo.py --list` subprocess 実行 (5 ID 表示確認)
- `run_demo.py --scenario <unknown>` の error 表示

## Test plan

- [x] `python -m pytest tests/test_compare_baseline_photon.py` — 6/6 PASS
- [x] `python -m pytest tests/test_cli_use_photon.py` — 4/4 PASS
- [x] `python -m pytest tests/test_demo_scenarios.py` — 7/7 PASS
- [x] `python -m pytest baseline_reporag/tests/ tests/ bench/tests/` — 828/831 PASS (3 件は既存 failure)
- [x] `ruff check .` — All checks passed
- [x] `make help` で `compare` / `ask-photon` target 表示確認

## Pre-existing failures (NOT introduced by this PR)

- `baseline_reporag/tests/test_photon_pipeline.py::TestBuildPhotonDepsRealTokenizer::test_vocab_size_mismatch_raises`
- `tests/test_generate_training_corpus.py::TestMain::test_main_cli_tokenizer_id`
- `tests/test_generate_training_corpus.py::TestMain::test_main_uses_tokenize_text`
- `ruff format --check` で `scripts/train_photon.py` 1 件 fmt drift

## Out of scope (A-1 Phase 3)

- architecture overview ドキュメント
- experiments_log テンプレート

🤖 Generated with [Claude Code](https://claude.com/claude-code)