### PR TITLE
feat(ingest): support non-git directories via synthesized commit id

### DIFF
--- a/docs/playground.md
+++ b/docs/playground.md
@@ -49,6 +49,28 @@ make prepare CONFIG=configs/institutional_docs.yaml REPO=/path/to/docs REPO_ID=d
 make ask CONFIG=configs/institutional_docs.yaml REPO_ID=docs Q="..."
 ```
 
+### Cookbook 1-2b: 非 git ディレクトリを ingest する (制度文書 PDF/Markdown 等)
+
+`scripts/ingest_repo.py` は **git 不在ディレクトリも自動対応** する (PR #169)。
+git 不在時は最大 mtime ベースの `manual-<mtime>` 形式の commit id が合成される
+(同一 snapshot に対して deterministic、ファイル更新時は新 id)。
+
+```bash
+# git init は不要 — そのまま ingest できる
+make prepare CONFIG=configs/institutional_docs.yaml \
+  REPO=/path/to/markdowndb/inst_test REPO_ID=inst_test
+```
+
+実行時に stderr に warning が出る (動作には影響なし):
+```
+[warn] /path/to/... is not a git repository;
+       using synthesized commit id 'manual-...' (based on max file mtime).
+```
+
+**bench の厳密な再現性**が必要な場合 (academic eval 等) は `git init` 推奨:
+- 非 git: ファイル更新で commit id が変わる (mtime に依存)
+- git: SHA で厳密に固定される
+
 ### Cookbook 1-3: 巨大 repo で chunk 数を絞りたい
 
 `configs/baseline.yaml` の `evidence_pack.max_chunks` / `max_tokens` を下げる。

--- a/scripts/ingest_repo.py
+++ b/scripts/ingest_repo.py
@@ -24,15 +24,64 @@ from baseline_reporag.ingestion.store import ChunkStore
 
 
 def resolve_commit(repo_path: str, ref: str) -> str:
+    """Resolve ``ref`` to a 40-char commit-id string used in chunks.db.
+
+    For git repositories, returns the actual commit SHA (legacy behaviour).
+    For non-git directories (PDF/markdown corpora 等の制度文書 use case)
+    falls back to a deterministic id derived from the maximum file mtime
+    under ``repo_path``: re-ingesting the same snapshot returns the same
+    id, while edits/additions produce a new id. The 40-char length matches
+    git SHA conventions so downstream tooling that assumes SHA-shape ids
+    keeps working.
+
+    Use a 40-char SHA explicitly (``--commit <SHA>``) to bypass both paths.
+    """
     if ref == "HEAD" or len(ref) < 40:
-        result = subprocess.run(
-            ["git", "-C", repo_path, "rev-parse", ref],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        return result.stdout.strip()
+        try:
+            result = subprocess.run(
+                ["git", "-C", repo_path, "rev-parse", ref],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            return result.stdout.strip()
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            return _synthesize_non_git_commit(repo_path)
     return ref
+
+
+def _synthesize_non_git_commit(repo_path: str) -> str:
+    """Make a stable 40-char ``manual-<mtime>`` id for non-git directories.
+
+    Falls back to top-level mtime when ``rglob`` finds no files (empty dir).
+    Per-file mtimes are walked so editing any file inside produces a fresh
+    id even when the parent directory's mtime would not change.
+    """
+    repo = Path(repo_path)
+    if not repo.exists():
+        raise FileNotFoundError(f"repo_path not found: {repo_path}")
+
+    max_mtime = repo.stat().st_mtime
+    for path in repo.rglob("*"):
+        try:
+            mtime = path.stat().st_mtime
+        except (OSError, FileNotFoundError):
+            # Broken symlinks etc — skip silently; they wouldn't affect
+            # the chunk content anyway.
+            continue
+        if mtime > max_mtime:
+            max_mtime = mtime
+
+    mtime_ms = int(max_mtime * 1000)
+    # ``manual-`` (7 chars) + 33 zero-padded digits = 40 chars total.
+    synthesized = f"manual-{mtime_ms:033d}"
+    print(
+        f"[warn] {repo_path} is not a git repository; "
+        f"using synthesized commit id {synthesized!r} "
+        f"(based on max file mtime).",
+        file=sys.stderr,
+    )
+    return synthesized
 
 
 def main() -> None:

--- a/tests/test_ingest_repo_resolve_commit.py
+++ b/tests/test_ingest_repo_resolve_commit.py
@@ -1,0 +1,123 @@
+"""Tests for ``scripts/ingest_repo.py::resolve_commit``.
+
+Issue: 制度文書 PDF/markdown など非 git ディレクトリも ingest できるよう
+``resolve_commit`` を拡張した。本テストは:
+
+- git repo: 既存の SHA 解決動作を保つこと
+- 非 git directory: ``manual-<mtime>`` 形式の 40 文字 id を返すこと
+- determinism: 同じ snapshot に対して同じ id を返すこと
+- file edit: ファイルを更新すると id が変わること
+- empty directory: 親 dir の mtime にフォールバックすること
+- non-existent path: FileNotFoundError を上げること
+- explicit 40-char SHA: 解決をスキップしてそのまま返すこと
+
+を検証する。
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_module():
+    """Load scripts/ingest_repo.py via importlib (scripts/ is not a package)."""
+    script_path = REPO_ROOT / "scripts" / "ingest_repo.py"
+    spec = importlib.util.spec_from_file_location("ingest_repo", script_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["ingest_repo"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestResolveCommitGitRepo:
+    """既存挙動: git repo では git rev-parse HEAD の出力を返す。"""
+
+    def test_returns_real_sha_for_git_repo(self, tmp_path: Path) -> None:
+        # tmp_path に新規 git repo を作成
+        subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+        subprocess.run(
+            ["git", "config", "user.email", "t@example.com"], cwd=tmp_path, check=True
+        )
+        subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, check=True)
+        (tmp_path / "f.txt").write_text("hello\n", encoding="utf-8")
+        subprocess.run(["git", "add", "f.txt"], cwd=tmp_path, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=tmp_path, check=True)
+
+        module = _load_module()
+        sha = module.resolve_commit(str(tmp_path), "HEAD")
+        # SHA-1 = 40 hex chars
+        assert len(sha) == 40
+        assert all(c in "0123456789abcdef" for c in sha)
+
+
+class TestResolveCommitNonGit:
+    """新規挙動: 非 git directory では manual-<mtime> を合成して返す。"""
+
+    def test_synthesizes_manual_id_for_non_git(self, tmp_path: Path, capsys) -> None:
+        # tmp_path は git init していない普通のディレクトリ
+        (tmp_path / "doc.md").write_text("hello\n", encoding="utf-8")
+        module = _load_module()
+
+        commit_id = module.resolve_commit(str(tmp_path), "HEAD")
+
+        assert commit_id.startswith("manual-")
+        assert len(commit_id) == 40
+        # warning は stderr に出る
+        err = capsys.readouterr().err
+        assert "is not a git repository" in err
+        assert commit_id in err
+
+    def test_deterministic_when_files_unchanged(self, tmp_path: Path) -> None:
+        (tmp_path / "doc.md").write_text("v1\n", encoding="utf-8")
+        module = _load_module()
+        first = module.resolve_commit(str(tmp_path), "HEAD")
+        second = module.resolve_commit(str(tmp_path), "HEAD")
+        assert first == second
+
+    def test_changes_when_a_file_is_modified(self, tmp_path: Path) -> None:
+        target = tmp_path / "doc.md"
+        target.write_text("v1\n", encoding="utf-8")
+        module = _load_module()
+        first = module.resolve_commit(str(tmp_path), "HEAD")
+
+        # mtime resolution に依存しないよう sleep + 明示 mtime セット
+        time.sleep(0.05)
+        new_mtime = target.stat().st_mtime + 10.0
+        os.utime(target, (new_mtime, new_mtime))
+
+        second = module.resolve_commit(str(tmp_path), "HEAD")
+        assert first != second
+
+    def test_empty_directory_uses_top_level_mtime(self, tmp_path: Path) -> None:
+        module = _load_module()
+        # 中身がない dir でも例外を出さず id を返す
+        commit_id = module.resolve_commit(str(tmp_path), "HEAD")
+        assert commit_id.startswith("manual-")
+        assert len(commit_id) == 40
+
+
+class TestResolveCommitErrors:
+    def test_non_existent_path_raises(self, tmp_path: Path) -> None:
+        module = _load_module()
+        with pytest.raises(FileNotFoundError):
+            module.resolve_commit(str(tmp_path / "does_not_exist"), "HEAD")
+
+
+class TestResolveCommitExplicitSha:
+    def test_40_char_sha_is_returned_unchanged(self, tmp_path: Path) -> None:
+        """明示的に 40 文字を渡すと git にも fs にも触れずそのまま返す。"""
+        module = _load_module()
+        sha = "a" * 40
+        result = module.resolve_commit("/path/that/does/not/exist", sha)
+        assert result == sha


### PR DESCRIPTION
## Summary

`scripts/ingest_repo.py::resolve_commit` を拡張し、**git 管理対象外のディレクトリも ingest できる**ようにする。制度文書 PDF/markdown などの非 git corpus 用途で発生していたエラーを解消。

## Background

Streamlit UI から制度文書ディレクトリ (`myWebData/markdowndb/inst_test/`) の ingest を実行したところ失敗:
```
subprocess.CalledProcessError: Command '['git', '-C', ..., 'rev-parse', 'HEAD']'
returned non-zero exit status 128.
fatal: ambiguous argument 'HEAD': unknown revision or path not in the working tree.
```

`resolve_commit` が `git rev-parse HEAD` を `check=True` で強制実行しており、git 不在で fail-fast していた。

## Changes

### `scripts/ingest_repo.py`

```python
def resolve_commit(repo_path: str, ref: str) -> str:
    if ref == "HEAD" or len(ref) < 40:
        try:
            result = subprocess.run([...], check=True)
            return result.stdout.strip()
        except (subprocess.CalledProcessError, FileNotFoundError):
            return _synthesize_non_git_commit(repo_path)
    return ref


def _synthesize_non_git_commit(repo_path: str) -> str:
    # rglob で全ファイルの最大 mtime を取得
    # → manual-<mtime_ms>(33 桁 0-pad) で 40 文字に整形
    # → stderr に warning を出力
```

| Input | Output |
|-------|--------|
| git repo | `<git SHA>` (40 hex chars) — **従来通り** |
| 非 git directory | `manual-<mtime_ms_33_digit>` (40 chars total) — **新規** |
| 不在 path | `FileNotFoundError` |
| 明示 40-char SHA | そのまま返す — 従来通り |

### Properties

- **deterministic**: 同一 snapshot に対し同じ id を返す
- **change-sensitive**: ファイル更新で id が変わる (`os.utime` で確認済)
- **fixed length**: 40 文字 (downstream の SHA-shape 仮定を維持)

### `docs/playground.md` Cookbook 1-2b 追記

非 git ディレクトリでの ingest 手順 + bench 厳密再現が必要な場合の `git init` 推奨を明記。

## Test plan

- [x] `python -m pytest tests/test_ingest_repo_resolve_commit.py` — 7/7 PASS
- [x] git repo の SHA 解決動作維持
- [x] 非 git で `manual-<mtime>` 形式の 40 文字 id
- [x] determinism (連続呼出で同一)
- [x] file edit で id 変化 (`os.utime` で 10 秒進めて検証)
- [x] empty directory 対応
- [x] 不在 path の FileNotFoundError
- [x] 明示 40-char SHA の pass-through
- [x] `ruff check .` — All checks passed
- [x] `ruff format --check` (PR 範囲) — 2 files already formatted
- [x] 実機 smoke test: `/tmp/test_non_git_repo` で `manual-...` を生成、再呼出で同一 id 確認

## Trade-off

- bench の **厳密な再現性** (academic eval) では git 必須 — `manual-<mtime>` は file system 操作で id が動く可能性あり
- 一般的な業務 corpus / 制度文書には十分

## Follow-up (別 PR)

- **Streamlit UI の zombie 検出バグ**: `_is_process_running` が `<defunct>` を `running` 扱いする問題。本 PR と独立しているため別 issue/PR で扱う。
- ユーザー側のリカバリー手順: `.cache/photon_app_state.json` の `idx_20260429_001014` zombie entry を手動削除 → 本 PR を pull → Streamlit UI 上で再実行

🤖 Generated with [Claude Code](https://claude.com/claude-code)