### PR TITLE
fix(streamlit): config selectbox + non-git ingest in ベクトルDB作成 UI

### DIFF
--- a/app/photon_app.py
+++ b/app/photon_app.py
@@ -97,23 +97,63 @@ def _atomic_write_text(path: Path, data: str) -> None:
     os.replace(tmp, path)
 
 
+# 除外パターン: backup / training-only / eval matrix
+# (UI から ingest 用に選んでも意味の無い config をフィルタする)
+_USER_CONFIG_EXCLUDE_SUFFIXES = (".wave6_backup",)
+_USER_CONFIG_EXCLUDE_PREFIXES = ("eval_",)
+_USER_CONFIG_EXCLUDE_STEMS = (
+    # training-only configs (ingest 用途では使わない)
+    "institutional_docs_photon_retrain",
+)
+
+
+def _discover_user_configs(configs_dir: Path | None = None) -> list[str]:
+    """Discover ``configs/*.yaml`` files suitable for ingest UI selection.
+
+    Returns project-relative paths (e.g. ``configs/baseline.yaml``) sorted
+    alphabetically. Excludes:
+
+    - ``*.wave6_backup`` (historical backups)
+    - ``eval_*.yaml`` (eval-matrix configs not meant for ingest)
+    - ``*_retrain.yaml`` (training-only configs)
+    """
+    base = configs_dir if configs_dir is not None else PROJECT_ROOT / "configs"
+    if not base.is_dir():
+        return []
+    out: list[str] = []
+    for path in sorted(base.glob("*.yaml")):
+        name = path.name
+        if any(name.endswith(suffix) for suffix in _USER_CONFIG_EXCLUDE_SUFFIXES):
+            continue
+        if any(name.startswith(prefix) for prefix in _USER_CONFIG_EXCLUDE_PREFIXES):
+            continue
+        if path.stem in _USER_CONFIG_EXCLUDE_STEMS:
+            continue
+        try:
+            rel = path.relative_to(PROJECT_ROOT)
+        except ValueError:
+            rel = path
+        out.append(str(rel))
+    return out
+
+
 # Driver executed in a child ``python -c`` to chain the 4 index-build
 # phases with argv-list subprocess.run calls (shell=False). No user input
 # is interpolated into this string — every user value arrives via sys.argv.
 _INDEX_PIPELINE_DRIVER = """
 import subprocess, sys
+
 repo_dir, repo_id, embed_model, config_path = sys.argv[1:5]
 
 def run(argv, phase):
     print(f'>>> {phase}: ' + ' '.join(argv), flush=True)
     subprocess.run(argv, check=True)
 
-# Phase 0: resolve commit SHA
-out = subprocess.run(
-    ['git', '-C', repo_dir, 'rev-parse', 'HEAD'],
-    check=True, capture_output=True, text=True,
-)
-commit = out.stdout.strip()
+# Phase 0: resolve commit (git SHA for git repos, synthesized
+# 'manual-<mtime>' id for non-git directories like 制度文書 corpora).
+# Shared with scripts/ingest_repo.py so all 3 phases agree on the same id.
+from scripts.ingest_repo import resolve_commit
+commit = resolve_commit(repo_dir, 'HEAD')
 print(f'Phase 1: Ingest (commit={commit})', flush=True)
 run(
     [
@@ -1054,6 +1094,25 @@ def page_index():
         help="インデックスの識別子。英数字とアンダースコアのみ",
     )
 
+    config_choices = _discover_user_configs()
+    if not config_choices:
+        st.error("configs/*.yaml が見つかりません")
+        return
+    default_config = "configs/baseline.yaml"
+    default_index = (
+        config_choices.index(default_config) if default_config in config_choices else 0
+    )
+    config_path = st.selectbox(
+        "Config",
+        options=config_choices,
+        index=default_index,
+        help=(
+            "ingestion / retrieval / generation の設定。制度文書 (markdown 中心) は "
+            "configs/institutional_docs.yaml、コードベース (Python など) は "
+            "configs/baseline.yaml が無難。Embedding モデルは下の選択で override されます。"
+        ),
+    )
+
     embedding_models = {
         "all-MiniLM-L6-v2 (軽量・英語向け)": "sentence-transformers/all-MiniLM-L6-v2",
         "multilingual-e5-small (多言語対応)": "intfloat/multilingual-e5-small",
@@ -1061,7 +1120,7 @@ def page_index():
         "all-MiniLM-L12-v2 (英語・高精度)": "sentence-transformers/all-MiniLM-L12-v2",
     }
     embedding_label = st.selectbox(
-        "Embedding モデル",
+        "Embedding モデル (config の値を override)",
         options=list(embedding_models.keys()),
         index=1,  # multilingual-e5-small をデフォルト
         help="ベクトル検索に使う embedding モデル。日本語を含む場合は multilingual 推奨",
@@ -1098,7 +1157,6 @@ def page_index():
             # config_path) arrive as argv and are never interpolated into a
             # shell string.
             driver = _INDEX_PIPELINE_DRIVER
-            config_path = "configs/baseline.yaml"
             cmd_argv = [
                 sys.executable,
                 "-u",

--- a/tests/test_photon_app_index_ui.py
+++ b/tests/test_photon_app_index_ui.py
@@ -1,0 +1,133 @@
+"""Tests for the ベクトルDB作成 UI helpers in ``app/photon_app.py``.
+
+Covers two follow-up changes after PR #169 (non-git ingest):
+
+1. ``_discover_user_configs`` enumerates ``configs/*.yaml`` while excluding
+   backup files, eval-matrix configs, and training-only configs.
+2. ``_INDEX_PIPELINE_DRIVER`` Phase 0 uses the shared
+   ``scripts.ingest_repo.resolve_commit`` (so non-git directories no longer
+   crash the Streamlit pipeline driver).
+
+We import ``app/photon_app.py`` via importlib to avoid pulling Streamlit's
+runtime path-config side effects.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent.parent
+PHOTON_APP_PATH = PROJECT_ROOT / "app" / "photon_app.py"
+
+
+def _load_photon_app_module():
+    module_name = "photon_app_under_test_index_ui"
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+    spec = importlib.util.spec_from_file_location(module_name, PHOTON_APP_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+photon_app = _load_photon_app_module()
+
+
+# ---------------------------------------------------------------
+# _discover_user_configs
+# ---------------------------------------------------------------
+
+
+class TestDiscoverUserConfigs:
+    def test_returns_baseline_and_institutional(self) -> None:
+        configs = photon_app._discover_user_configs()
+        assert "configs/baseline.yaml" in configs
+        assert "configs/institutional_docs.yaml" in configs
+        assert "configs/photon_small.yaml" in configs
+
+    def test_excludes_wave6_backup(self) -> None:
+        configs = photon_app._discover_user_configs()
+        assert not any(c.endswith(".wave6_backup") for c in configs)
+
+    def test_excludes_eval_matrix_configs(self) -> None:
+        configs = photon_app._discover_user_configs()
+        assert "configs/eval_qwen_model_matrix.yaml" not in configs
+        assert "configs/eval_qwen_model_matrix_400.yaml" not in configs
+
+    def test_excludes_retrain_config(self) -> None:
+        configs = photon_app._discover_user_configs()
+        assert "configs/institutional_docs_photon_retrain.yaml" not in configs
+
+    def test_alphabetical_order(self) -> None:
+        configs = photon_app._discover_user_configs()
+        assert configs == sorted(configs)
+
+    def test_synthetic_directory_with_excluded_patterns(self, tmp_path: Path) -> None:
+        # 合成ディレクトリで全除外パターンが効くことを確認
+        (tmp_path / "good.yaml").write_text("")
+        (tmp_path / "good2.yaml").write_text("")
+        (tmp_path / "old.yaml.wave6_backup").write_text("")
+        (tmp_path / "eval_matrix.yaml").write_text("")
+        (tmp_path / "something_retrain.yaml").write_text("")
+
+        # 既存除外 stem は "configs/" 以下のファイル名に依存するので、
+        # synthetic dir では default の動作だけ確認 (eval_/.wave6_backup の除外)
+        configs = photon_app._discover_user_configs(configs_dir=tmp_path)
+        # tmp_path 配下なので relative_to(PROJECT_ROOT) は失敗 → fallback で絶対パス
+        names = [Path(c).name for c in configs]
+        assert "good.yaml" in names
+        assert "good2.yaml" in names
+        assert "old.yaml.wave6_backup" not in names
+        assert "eval_matrix.yaml" not in names
+
+    def test_missing_configs_dir_returns_empty(self, tmp_path: Path) -> None:
+        configs = photon_app._discover_user_configs(configs_dir=tmp_path / "nope")
+        assert configs == []
+
+
+# ---------------------------------------------------------------
+# _INDEX_PIPELINE_DRIVER Phase 0: shared resolver
+# ---------------------------------------------------------------
+
+
+class TestDriverPhase0SharedResolver:
+    """Phase 0 が ``scripts.ingest_repo.resolve_commit`` を経由することを確認。"""
+
+    def test_driver_imports_resolve_commit(self) -> None:
+        driver = photon_app._INDEX_PIPELINE_DRIVER
+        assert "from scripts.ingest_repo import resolve_commit" in driver
+        assert "resolve_commit(repo_dir, 'HEAD')" in driver
+        # 旧コード (git rev-parse 直叩き) が残っていないこと
+        assert "rev-parse" not in driver, (
+            "Phase 0 が git rev-parse を直叩きしていると、非 git directory で "
+            "強制 fail してしまう。共有 resolver 経由に統一すること。"
+        )
+
+    def test_driver_resolves_non_git_via_synthesized_id(self, tmp_path: Path) -> None:
+        """Driver の Phase 0 を実機で動かし、non-git でも 40 文字 id を返すこと。"""
+        (tmp_path / "doc.md").write_text("hello\n", encoding="utf-8")
+
+        # Phase 0 だけを取り出して実行
+        phase0_script = (
+            "import sys\n"
+            "sys.path.insert(0, '.')\n"
+            "from scripts.ingest_repo import resolve_commit\n"
+            f"commit = resolve_commit({str(tmp_path)!r}, 'HEAD')\n"
+            "print(commit)\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", phase0_script],
+            capture_output=True,
+            text=True,
+            cwd=str(PROJECT_ROOT),
+            check=True,
+            timeout=30,
+        )
+        commit = result.stdout.strip()
+        assert commit.startswith("manual-")
+        assert len(commit) == 40


### PR DESCRIPTION
## Summary

「ベクトルDB作成」画面の 2 つの欠陥を修正:

1. **Config 選択 UI の欠落**: `page_index()` で `config_path = "configs/baseline.yaml"` がハードコードされており、`institutional_docs.yaml` など他の config を UI から選べなかった。
2. **Driver の git 強制**: `_INDEX_PIPELINE_DRIVER` Phase 0 が `git rev-parse HEAD` を `check=True` で直叩きしており、**PR #169 (`ingest_repo.py` の git 任意化) が入っても UI 経由では非 git directory が ingest 失敗していた**。

## Repro (PR #169 マージ後でも残っていた症状)

```
[Streamlit UI] 制度文書 (非 git directory) を投入
→ subprocess.CalledProcessError: ['git', '-C', ..., 'rev-parse', 'HEAD']
   exit 128: fatal: ambiguous argument 'HEAD'
```

`<string>` (= `_INDEX_PIPELINE_DRIVER`) の Phase 0 で fail していた。

## Changes

### `app/photon_app.py`

#### `_discover_user_configs()` 新規
`configs/*.yaml` を列挙、以下を除外:
- `*.wave6_backup` (履歴 backup)
- `eval_*.yaml` (eval matrix、ingest 用ではない)
- `*_retrain.yaml` (training-only)

`configs_dir` 引数で synthetic dir に対するテストも可能。

#### `page_index()`
- **Config selectbox を追加**: デフォルト `configs/baseline.yaml`、help text で「制度文書は institutional_docs.yaml、コードは baseline.yaml」を案内
- Embedding selectbox の label を `"Embedding モデル (config の値を override)"` に変更 (関係を明示)
- `config_path` ハードコード削除

#### `_INDEX_PIPELINE_DRIVER` Phase 0
`git rev-parse` 直叩きを削除、`from scripts.ingest_repo import resolve_commit` で共有関数経由に統一。これで PR #169 の非 git fallback (`manual-<mtime>`) が UI 経由でも効く。

### `tests/test_photon_app_index_ui.py` (新規, 9 件)

- **TestDiscoverUserConfigs (7 件)**:
  - baseline / institutional / photon_small が含まれる
  - `.wave6_backup` / `eval_*.yaml` / `*_retrain.yaml` の除外
  - alphabetical order
  - synthetic directory での除外パターン検証
  - 不在 `configs_dir` で空リスト
- **TestDriverPhase0SharedResolver (2 件)**:
  - Driver string が `resolve_commit` を import している
  - Driver string に `rev-parse` が残っていない (regression guard)
  - 非 git directory で実機 Phase 0 を動かし 40 文字 manual id を返す

## Test plan

- [x] `python -m pytest tests/test_photon_app_index_ui.py` — 9/9 PASS
- [x] `python -m pytest tests/test_photon_app_*` — 133/133 PASS (既存 4 ファイル + 新規)
- [x] `python -m pytest tests/` — 462/464 PASS (残 2 件は既存 pre-existing failure)
- [x] `ruff check .` — All passed
- [x] `ruff format --check` (PR 範囲) — 2 files already formatted
- [x] 実機 smoke: `_discover_user_configs()` で 11 個 config 列挙、除外パターンが効く
- [x] 実機 smoke: 非 git directory で `resolve_commit` が `manual-<mtime>` の 40 文字 id を返す

## Follow-up (別 PR)

- **Streamlit UI の zombie 検出バグ**: `_is_process_running` が `<defunct>` プロセスを `running` 扱いする問題。本 PR と独立 — `os.kill(pid, 0)` 後に `ps -o stat=` で `Z` 状態を判定する fix を別 PR (#170 候補) で対応予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)