### PR TITLE
fix(streamlit/cli): override cfg.repo from caller to load right corpus

### DIFF
--- a/app/photon_app.py
+++ b/app/photon_app.py
@@ -29,7 +29,10 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from baseline_reporag.config import load_config  # noqa: E402
-from baseline_reporag.pipeline_factory import build_pipeline  # noqa: E402
+from baseline_reporag.pipeline_factory import (  # noqa: E402
+    build_pipeline,
+    override_repo_for_pipeline,
+)
 
 
 # Issue #82 Wave 3: drift + turn-history panels (streamlit-free helpers).
@@ -1746,6 +1749,13 @@ def _run_query(proj: Project, question: str, session_key: str) -> tuple[str, dic
         return f"エラー: config load failed ({type(exc).__name__}: {exc})", dict(
             metadata_default
         )
+
+    # UI で選択された ``proj.repo_id`` を真実とし、config 側の hardcoded な
+    # ``repo.repo_id`` / ``repo.repo_commit`` を上書きする (build_pipeline は
+    # ``data/indexes/{cfg.repo.repo_id}`` から index を読むため、ここで揃え
+    # ないと別 repo の index がロードされる)。``repo_commit`` は chunks.db
+    # から実際の値を解決し、graph_expansion の SQL filter にも整合させる。
+    override_repo_for_pipeline(cfg, proj.repo_id)
 
     if pipeline_key not in st.session_state:
         try:

--- a/baseline_reporag/cli.py
+++ b/baseline_reporag/cli.py
@@ -25,7 +25,7 @@ from .config import load_config
 # environments without MLX do not fail at ``python -m baseline_reporag.cli``
 # load time.  The factory lazy-imports the PHOTON pipeline (and thus MLX)
 # only when ``cfg.model.provider == "photon"``.
-from .pipeline_factory import build_pipeline
+from .pipeline_factory import build_pipeline, override_repo_for_pipeline
 
 # A-1 Phase 2: ``--use-photon`` のショートカットが指す PHOTON config。
 # baseline.yaml は PHOTON 専用フィールド (checkpoint_path, base_embed_dim 等)
@@ -65,6 +65,12 @@ def main() -> None:
 
     cfg = load_config(config_path)
     repo_id = args.repo_id or cfg.repo.repo_id
+
+    # ``--repo-id`` が config の ``repo.repo_id`` と異なる場合、build_pipeline
+    # は ``data/indexes/{cfg.repo.repo_id}`` を読むため別 repo の index が
+    # ロードされてしまう。``override_repo_for_pipeline`` で cfg を整合させて
+    # から build_pipeline を呼び出す。
+    override_repo_for_pipeline(cfg, repo_id)
 
     # Route via ``build_pipeline`` so ``model.provider`` (baseline vs
     # photon) is honoured end-to-end — Issue #62 Phase 1 Stage 3 DR3-001:

--- a/baseline_reporag/pipeline_factory.py
+++ b/baseline_reporag/pipeline_factory.py
@@ -27,6 +27,8 @@ at module load.
 
 from __future__ import annotations
 
+import sqlite3
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from .config import Config, is_symbol_graph_enabled, validate_repo_id
@@ -38,7 +40,70 @@ if TYPE_CHECKING:
     from .pipeline import RepoRAGPipeline
 
 
-__all__ = ["QueryResult", "build_pipeline"]
+__all__ = ["QueryResult", "build_pipeline", "override_repo_for_pipeline"]
+
+
+def override_repo_for_pipeline(
+    cfg: Config,
+    repo_id: str | None,
+    *,
+    data_root: str | None = None,
+) -> None:
+    """Mutate ``cfg`` in-place so ``build_pipeline()`` loads the right corpus.
+
+    ``build_pipeline()`` resolves the index directory from
+    ``cfg.repo.repo_id`` (``data/indexes/{cfg.repo.repo_id}``) — when a
+    caller's ``repo_id`` differs from the config's hardcoded value (e.g.
+    Streamlit project selection, ``--repo-id`` CLI override), the indexes
+    loaded would be the wrong corpus.  Existing eval scripts
+    (``scripts/run_baseline_eval.py``, ``scripts/run_multi_turn_eval.py``)
+    document this and mutate ``cfg.repo.repo_id`` manually before
+    ``build_pipeline``; this helper centralises that pattern and additionally
+    resolves ``repo_commit`` from ``chunks.db`` so graph_expansion's
+    ``iter_repo(repo_id, repo_commit)`` SQL filter sees real data.
+
+    No-op when ``repo_id`` is falsy.
+
+    Note: the override is destructive — the caller's ``cfg`` instance has
+    its ``repo.repo_id`` and ``repo.repo_commit`` overwritten. Callers that
+    reuse a single ``cfg`` for multiple repos must reload via
+    ``load_config`` between switches.
+    """
+    if not repo_id:
+        return
+    cfg.repo.repo_id = repo_id
+    actual_commit = _lookup_repo_commit_from_db(
+        repo_id, data_root or cfg.paths.data_root
+    )
+    if actual_commit is not None:
+        cfg.repo.repo_commit = actual_commit
+
+
+def _lookup_repo_commit_from_db(repo_id: str, data_root: str) -> str | None:
+    """Read one ``repo_commit`` value stored in ``chunks.db`` for ``repo_id``.
+
+    Returns ``None`` when the index dir / DB does not exist or the table is
+    empty — the caller keeps the config's existing value in that case (so
+    fresh ingest is detectable as an error rather than silently replaced
+    with the empty string).
+    """
+    db_path = Path(data_root) / "indexes" / repo_id / "chunks.db"
+    if not db_path.is_file():
+        return None
+    try:
+        conn = sqlite3.connect(str(db_path))
+    except sqlite3.DatabaseError:
+        return None
+    try:
+        row = conn.execute(
+            "SELECT repo_commit FROM chunks WHERE repo_id = ? LIMIT 1",
+            (repo_id,),
+        ).fetchone()
+    except sqlite3.DatabaseError:
+        row = None
+    finally:
+        conn.close()
+    return row[0] if row else None
 
 
 def build_pipeline(cfg: Config) -> "RepoRAGPipeline | PhotonRAGPipeline":

--- a/scripts/compare_baseline_photon.py
+++ b/scripts/compare_baseline_photon.py
@@ -32,7 +32,7 @@ from typing import Any
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from baseline_reporag.config import load_config
-from baseline_reporag.pipeline_factory import build_pipeline
+from baseline_reporag.pipeline_factory import build_pipeline, override_repo_for_pipeline
 
 
 @dataclass
@@ -60,6 +60,9 @@ def run_variant(
     """1 variant 分の pipeline を立てて 1 question を実行。"""
     cfg = load_config(config_path)
     resolved_repo_id = repo_id or cfg.repo.repo_id
+    # build_pipeline は cfg.repo.repo_id から index dir を解決するため、
+    # caller の repo_id と異なる場合は事前に cfg を override する。
+    override_repo_for_pipeline(cfg, resolved_repo_id)
     pipeline = build_pipeline(cfg)
     result = pipeline.query(
         question=question,

--- a/tests/test_photon_app_helpers.py
+++ b/tests/test_photon_app_helpers.py
@@ -7,6 +7,7 @@ path and relying only on the helper functions that do not touch ``st``.
 from __future__ import annotations
 
 import importlib.util
+import sqlite3
 import subprocess
 import sys
 from pathlib import Path
@@ -223,7 +224,11 @@ class TestRunQueryUsesBuildPipeline:
         fake_pipeline = MagicMock()
         fake_pipeline.query.return_value = result
 
-        fake_cfg = SimpleNamespace(model=SimpleNamespace(provider="baseline"))
+        fake_cfg = SimpleNamespace(
+            model=SimpleNamespace(provider="baseline"),
+            repo=SimpleNamespace(repo_id="demo_repo", repo_commit="orig"),
+            paths=SimpleNamespace(data_root=str(tmp_path)),
+        )
 
         fake_session_state = _FakeSessionState()
 
@@ -247,7 +252,11 @@ class TestRunQueryUsesBuildPipeline:
 
     def test_run_query_handles_mlx_import_error(self, tmp_path: Path) -> None:
         proj = _make_proj(tmp_path, name="demo_photon")
-        fake_cfg = SimpleNamespace(model=SimpleNamespace(provider="photon"))
+        fake_cfg = SimpleNamespace(
+            model=SimpleNamespace(provider="photon"),
+            repo=SimpleNamespace(repo_id="demo_repo", repo_commit="orig"),
+            paths=SimpleNamespace(data_root=str(tmp_path)),
+        )
 
         fake_session_state = _FakeSessionState()
 
@@ -335,7 +344,11 @@ class TestRunQueryUsesPhotonConfigPath:
         )
         fake_pipeline = MagicMock()
         fake_pipeline.query.return_value = result
-        fake_cfg = SimpleNamespace(model=SimpleNamespace(provider="photon"))
+        fake_cfg = SimpleNamespace(
+            model=SimpleNamespace(provider="photon"),
+            repo=SimpleNamespace(repo_id="demo_repo", repo_commit="orig"),
+            paths=SimpleNamespace(data_root=str(tmp_path)),
+        )
         fake_session_state = _FakeSessionState()
 
         with (
@@ -377,7 +390,11 @@ class TestRunQueryUsesPhotonConfigPath:
         )
         fake_pipeline = MagicMock()
         fake_pipeline.query.return_value = result
-        fake_cfg = SimpleNamespace(model=SimpleNamespace(provider="baseline"))
+        fake_cfg = SimpleNamespace(
+            model=SimpleNamespace(provider="baseline"),
+            repo=SimpleNamespace(repo_id="demo_repo", repo_commit="orig"),
+            paths=SimpleNamespace(data_root=str(tmp_path)),
+        )
         fake_session_state = _FakeSessionState()
 
         with (
@@ -420,7 +437,11 @@ class TestRunQueryUsesPhotonConfigPath:
         )
         fake_pipeline = MagicMock()
         fake_pipeline.query.return_value = result
-        fake_cfg = SimpleNamespace(model=SimpleNamespace(provider="baseline"))
+        fake_cfg = SimpleNamespace(
+            model=SimpleNamespace(provider="baseline"),
+            repo=SimpleNamespace(repo_id="demo_repo", repo_commit="orig"),
+            paths=SimpleNamespace(data_root=str(tmp_path)),
+        )
         fake_session_state = _FakeSessionState()
 
         with (
@@ -456,3 +477,112 @@ class TestRunQueryUsesPhotonConfigPath:
             assert first_key not in fake_session_state, (
                 "stale pipeline cache for the previous config path was not evicted"
             )
+
+
+class TestRunQueryOverridesRepoFromProject:
+    """``_run_query`` MUST override ``cfg.repo.repo_id`` / ``cfg.repo.repo_commit``
+    from the UI-selected ``proj.repo_id`` so ``build_pipeline`` loads the right
+    corpus's indexes (``data/indexes/{cfg.repo.repo_id}``). This guards the
+    silent-retrieval-failure trap observed when a project's ``repo_id`` differs
+    from the config's hardcoded value (e.g. ``inst_test`` paired with
+    ``configs/institutional_docs_photon.yaml`` whose ``repo_id`` is
+    ``institutional_documents``).
+    """
+
+    def test_run_query_mutates_cfg_repo_to_match_proj_repo_id(
+        self, tmp_path: Path
+    ) -> None:
+        # Create a chunks.db so override_repo_for_pipeline can resolve the
+        # actual repo_commit from disk.
+        idx_dir = tmp_path / "indexes" / "alpha_repo"
+        idx_dir.mkdir(parents=True)
+        db_path = idx_dir / "chunks.db"
+        conn = sqlite3.connect(str(db_path))
+        try:
+            conn.execute(
+                """CREATE TABLE chunks (
+                    chunk_id TEXT PRIMARY KEY,
+                    repo_id TEXT NOT NULL,
+                    repo_commit TEXT NOT NULL,
+                    rel_path TEXT NOT NULL,
+                    language TEXT,
+                    start_line INTEGER,
+                    end_line INTEGER,
+                    section_header TEXT,
+                    content TEXT
+                )"""
+            )
+            conn.execute(
+                "INSERT INTO chunks VALUES (?,?,?,?,?,?,?,?,?)",
+                (
+                    "alpha_repo::doc.md::1-10",
+                    "alpha_repo",
+                    "real-commit-abc",
+                    "doc.md",
+                    "markdown",
+                    1,
+                    10,
+                    "",
+                    "x",
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        proj = _make_proj(tmp_path)
+        proj.repo_id = "alpha_repo"  # UI selection
+        proj.config_path = str(tmp_path / "cfg.yaml")
+        Path(proj.config_path).write_text("model:\n  provider: baseline\n")
+
+        # config has the WRONG repo (the trap reproduced)
+        fake_cfg = SimpleNamespace(
+            model=SimpleNamespace(provider="baseline"),
+            repo=SimpleNamespace(
+                repo_id="institutional_documents",
+                repo_commit="9e500539",
+            ),
+            paths=SimpleNamespace(data_root=str(tmp_path)),
+        )
+
+        # capture cfg state at build_pipeline call time
+        captured = {}
+
+        def fake_build(cfg):
+            captured["repo_id"] = cfg.repo.repo_id
+            captured["repo_commit"] = cfg.repo.repo_commit
+            return MagicMock(
+                query=MagicMock(
+                    return_value=SimpleNamespace(
+                        answer="ok",
+                        session_id="s",
+                        turn_id=1,
+                        cited_chunk_ids=[],
+                        wrong_citation_indices=[],
+                        no_citation=False,
+                        latency=SimpleNamespace(total_ms=0.0),
+                        memory=SimpleNamespace(),
+                        drift_metrics=None,
+                    )
+                )
+            )
+
+        fake_session_state = _FakeSessionState()
+        with (
+            patch.object(photon_app, "load_config", create=True, return_value=fake_cfg),
+            patch.object(
+                photon_app, "build_pipeline", create=True, side_effect=fake_build
+            ),
+            patch.object(photon_app.st, "session_state", fake_session_state),
+        ):
+            photon_app._run_query(proj, "q?", "sess")
+
+        # build_pipeline saw the OVERRIDDEN repo metadata, not the config's hardcoded value
+        assert captured["repo_id"] == "alpha_repo", (
+            "cfg.repo.repo_id must be overridden to the project's repo_id "
+            "before build_pipeline is invoked"
+        )
+        assert captured["repo_commit"] == "real-commit-abc", (
+            "cfg.repo.repo_commit must be resolved from chunks.db "
+            "(otherwise graph_expansion's iter_repo SQL filter sees no rows)"
+        )

--- a/tests/test_pipeline_factory_override_repo.py
+++ b/tests/test_pipeline_factory_override_repo.py
@@ -1,0 +1,208 @@
+"""Tests for ``pipeline_factory.override_repo_for_pipeline`` helper.
+
+Bug background: ``build_pipeline(cfg)`` resolves the index directory from
+``cfg.repo.repo_id`` (``data/indexes/{cfg.repo.repo_id}``). When a caller
+supplies their own ``repo_id`` (CLI ``--repo-id``, Streamlit project
+selection, ...) without mutating ``cfg`` first, the indexes loaded are
+the wrong corpus → silent retrieval failure with confusing errors.
+
+The helper centralises the documented "mutate-cfg-before-build_pipeline"
+pattern (already used by ``scripts/run_baseline_eval.py`` and
+``run_multi_turn_eval.py``) and additionally resolves the actual
+``repo_commit`` from ``chunks.db``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from baseline_reporag.config import Config
+from baseline_reporag.pipeline_factory import (
+    _lookup_repo_commit_from_db,
+    override_repo_for_pipeline,
+)
+
+
+def _make_chunks_db(db_path: Path, repo_id: str, repo_commit: str) -> None:
+    """Minimal chunks.db with one row matching the schema in store.py."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(
+            """CREATE TABLE chunks (
+                chunk_id TEXT PRIMARY KEY,
+                repo_id TEXT NOT NULL,
+                repo_commit TEXT NOT NULL,
+                rel_path TEXT NOT NULL,
+                language TEXT,
+                start_line INTEGER,
+                end_line INTEGER,
+                section_header TEXT,
+                content TEXT
+            )"""
+        )
+        conn.execute(
+            "INSERT INTO chunks VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                f"{repo_id}::doc.md::1-10",
+                repo_id,
+                repo_commit,
+                "doc.md",
+                "markdown",
+                1,
+                10,
+                "",
+                "test",
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _make_minimal_config(data_root: Path, repo_id: str, repo_commit: str) -> Config:
+    return Config(
+        {
+            "paths": {"data_root": str(data_root), "log_root": str(data_root / "logs")},
+            "repo": {"repo_id": repo_id, "repo_commit": repo_commit},
+            "model": {"provider": "baseline", "model_id": "fake"},
+        }
+    )
+
+
+# ---------------------------------------------------------------
+# _lookup_repo_commit_from_db
+# ---------------------------------------------------------------
+
+
+class TestLookupRepoCommitFromDb:
+    def test_returns_actual_commit(self, tmp_path: Path) -> None:
+        _make_chunks_db(
+            tmp_path / "indexes" / "myrepo" / "chunks.db",
+            repo_id="myrepo",
+            repo_commit="manual-12345",
+        )
+        commit = _lookup_repo_commit_from_db("myrepo", str(tmp_path))
+        assert commit == "manual-12345"
+
+    def test_returns_none_when_db_missing(self, tmp_path: Path) -> None:
+        commit = _lookup_repo_commit_from_db("ghost", str(tmp_path))
+        assert commit is None
+
+    def test_returns_none_when_repo_id_not_in_db(self, tmp_path: Path) -> None:
+        _make_chunks_db(
+            tmp_path / "indexes" / "other" / "chunks.db",
+            repo_id="other",
+            repo_commit="abc",
+        )
+        # Look up a repo_id that has its own dir but no matching row inside
+        # → fall through to None (cannot happen in practice but covers the
+        # edge case of an empty / hand-edited DB).
+        empty_db = tmp_path / "indexes" / "empty" / "chunks.db"
+        empty_db.parent.mkdir(parents=True)
+        conn = sqlite3.connect(str(empty_db))
+        try:
+            conn.execute(
+                """CREATE TABLE chunks (
+                    chunk_id TEXT PRIMARY KEY,
+                    repo_id TEXT NOT NULL,
+                    repo_commit TEXT NOT NULL,
+                    rel_path TEXT NOT NULL,
+                    language TEXT,
+                    start_line INTEGER,
+                    end_line INTEGER,
+                    section_header TEXT,
+                    content TEXT
+                )"""
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        assert _lookup_repo_commit_from_db("empty", str(tmp_path)) is None
+
+
+# ---------------------------------------------------------------
+# override_repo_for_pipeline
+# ---------------------------------------------------------------
+
+
+class TestOverrideRepoForPipeline:
+    def test_overrides_repo_id_and_commit_from_db(self, tmp_path: Path) -> None:
+        _make_chunks_db(
+            tmp_path / "indexes" / "inst_test" / "chunks.db",
+            repo_id="inst_test",
+            repo_commit="manual-99999",
+        )
+        cfg = _make_minimal_config(
+            tmp_path,
+            repo_id="institutional_documents",
+            repo_commit="9e500539",  # sentinel for old corpus
+        )
+
+        override_repo_for_pipeline(cfg, "inst_test")
+
+        assert cfg.repo.repo_id == "inst_test"
+        assert cfg.repo.repo_commit == "manual-99999"
+
+    def test_keeps_repo_commit_when_db_missing(self, tmp_path: Path) -> None:
+        """index dir/chunks.db が無い repo_id の場合、repo_id だけ更新し
+        repo_commit は元の値を保つ (silent な空文字置換を避ける)。"""
+        cfg = _make_minimal_config(tmp_path, repo_id="orig", repo_commit="orig-commit")
+
+        override_repo_for_pipeline(cfg, "fresh_unindexed")
+
+        assert cfg.repo.repo_id == "fresh_unindexed"
+        assert cfg.repo.repo_commit == "orig-commit"
+
+    def test_none_repo_id_is_noop(self, tmp_path: Path) -> None:
+        cfg = _make_minimal_config(tmp_path, "orig", "orig-commit")
+        override_repo_for_pipeline(cfg, None)
+        assert cfg.repo.repo_id == "orig"
+        assert cfg.repo.repo_commit == "orig-commit"
+
+    def test_empty_repo_id_is_noop(self, tmp_path: Path) -> None:
+        cfg = _make_minimal_config(tmp_path, "orig", "orig-commit")
+        override_repo_for_pipeline(cfg, "")
+        assert cfg.repo.repo_id == "orig"
+        assert cfg.repo.repo_commit == "orig-commit"
+
+    def test_explicit_data_root_kw_arg(self, tmp_path: Path) -> None:
+        """``data_root`` kwarg overrides ``cfg.paths.data_root`` for the lookup
+        — letting callers point at an alternate index location."""
+        alt_root = tmp_path / "alt"
+        _make_chunks_db(
+            alt_root / "indexes" / "myrepo" / "chunks.db",
+            repo_id="myrepo",
+            repo_commit="alt-commit",
+        )
+        cfg = _make_minimal_config(tmp_path, "orig", "orig-commit")
+
+        override_repo_for_pipeline(cfg, "myrepo", data_root=str(alt_root))
+
+        assert cfg.repo.repo_id == "myrepo"
+        assert cfg.repo.repo_commit == "alt-commit"
+
+
+# ---------------------------------------------------------------
+# Regression guard: existing callers must not regress
+# ---------------------------------------------------------------
+
+
+class TestExistingCallerCompat:
+    """Existing scripts (run_baseline_eval, run_multi_turn_eval) already
+    mutate ``cfg.repo.repo_id`` directly. The new helper must not introduce
+    any new globals or break the cfg shape they depend on.
+    """
+
+    def test_helper_does_not_change_attributes_other_than_repo(
+        self, tmp_path: Path
+    ) -> None:
+        cfg = _make_minimal_config(tmp_path, "orig", "orig-commit")
+        before_paths = (cfg.paths.data_root, cfg.paths.log_root)
+        before_model = (cfg.model.provider, cfg.model.model_id)
+
+        override_repo_for_pipeline(cfg, "newrepo")  # DB missing → no-op on commit
+
+        assert (cfg.paths.data_root, cfg.paths.log_root) == before_paths
+        assert (cfg.model.provider, cfg.model.model_id) == before_model


### PR DESCRIPTION
## Summary

UI / CLI で選択した `repo_id` が **config の hardcoded `repo.repo_id` に上書きされず**、`build_pipeline(cfg)` が誤った corpus の index をロードする構造的バグを修正。

## 観測した症状 (例)

Streamlit のチャットページで `inst_test` プロジェクト (制度文書 426 chunks ingest 済) に「葛飾区 産業観光部はどこにある？」と質問すると、LLM が以下のような hallucination 回答:

> 提供されたコードチャンクには Python/FastAPI などのソフトウェア開発に関するコード構造のみが含まれており、葛飾区の行政組織「産業観光部」の所在地に関する情報は一切存在しません。

実際は `inst_test` ではなく `institutional_documents` (342K 医薬品 chunks) が retrieval されており、Qwen3.5-Coder が無関係チャンクを「Python/FastAPI」と誤解したものでした。

## 根本原因

`pipeline_factory._build_baseline_deps` が **`cfg.repo.repo_id`** から index dir を解決:
```python
idx_dir = Path(cfg.paths.data_root) / "indexes" / cfg.repo.repo_id
```

caller が `pipeline.query(repo_id=...)` を渡しても、index 自体は config のハードコード値 (`institutional_documents`) を使う。

## ハードコーディング監査

`cfg.repo.repo_id` 利用箇所を全部調査。

| 場所 | 状態 |
|------|------|
| `scripts/run_baseline_eval.py:55` | ✓ 既に `cfg.repo.repo_id = repo_id` で手動 override (legacy pattern) |
| `scripts/run_multi_turn_eval.py:147` | ✓ 同上 |
| `baseline_reporag/cli.py:67` | 🔧 **本 PR で修正** (`--repo-id` 上書きが伝わらない) |
| `app/photon_app.py:_run_query` | 🔧 **本 PR で修正** (本件) |
| `scripts/compare_baseline_photon.py:62` | 🔧 **本 PR で修正** (PR #168 regression) |

## Changes

### `baseline_reporag/pipeline_factory.py`
新規 helper `override_repo_for_pipeline(cfg, repo_id)`:
- `cfg.repo.repo_id` を caller の値で上書き
- `chunks.db` から actual `repo_commit` を SELECT して `cfg.repo.repo_commit` も整合
- `chunks.db` 不在時は `repo_id` だけ更新し `repo_commit` は **元値を保持** (silent 空文字置換で graph_expansion の SQL filter を壊さないため)
- `repo_id=None` / `""` は no-op
- `data_root` kwarg で alt index location 対応

### 3 caller での適用
- `app/photon_app.py:_run_query`: `proj.repo_id` で override
- `baseline_reporag/cli.py`: `args.repo_id or cfg.repo.repo_id` を override
- `scripts/compare_baseline_photon.py`: `run_variant` 冒頭で override

## Test plan

| Test ファイル | 内容 | 件数 |
|--------------|------|------|
| `tests/test_pipeline_factory_override_repo.py` (new) | helper の単体テスト (`_lookup_repo_commit_from_db` 3 件 + `override_repo_for_pipeline` 5 件 + 互換性 1 件) | 9 PASS |
| `tests/test_photon_app_helpers.py` | 既存 5 件の `fake_cfg` を `SimpleNamespace(repo=..., paths=...)` に拡張、新規 `TestRunQueryOverridesRepoFromProject` 1 件追加 (chunks.db に書き込んで _run_query 経由で build_pipeline が override 後の cfg を受け取ることを E2E 検証) | 26 PASS |

- [x] `python -m pytest tests/test_pipeline_factory_override_repo.py` — 9/9 PASS
- [x] `python -m pytest tests/test_photon_app_helpers.py` — 26/26 PASS
- [x] `python -m pytest tests/ baseline_reporag/tests/ bench/tests/` — 867/870 PASS (3 件は CLAUDE.md 記載の既存 failure、無関係)
- [x] `ruff check .` / `ruff format --check` — All passed

## Effect on the live system

PR マージ後、Streamlit 再起動して再度 `inst_test` で質問すれば:
1. `_run_query` が `proj.repo_id="inst_test"` で `override_repo_for_pipeline` を呼ぶ
2. `cfg.repo.repo_id` が `"inst_test"` に、`cfg.repo.repo_commit` が `chunks.db` の `"manual-..."` 値に書き換えられる
3. `build_pipeline` が `data/indexes/inst_test/` から正しい indexes をロード
4. retrieval が制度文書 426 chunks に当たる

## Notes / Out of scope

- `cfg.repo.repo_path` (raw repo の絶対パス) は ingest 時のみ使用、retrieval/chat には影響しないため override 対象外
- 既存 `scripts/run_baseline_eval.py` / `run_multi_turn_eval.py` は legacy pattern を維持 (動作中なので置換せず)。次回触る機会があれば `override_repo_for_pipeline` 経由に統一してもよい

🤖 Generated with [Claude Code](https://claude.com/claude-code)