### PR TITLE
fix(ingestion): allow ChunkStore reuse across threads (Streamlit chat)

### DIFF
--- a/baseline_reporag/ingestion/store.py
+++ b/baseline_reporag/ingestion/store.py
@@ -56,12 +56,22 @@ def _row_to_chunk(row: tuple) -> Chunk:
 
 
 class ChunkStore:
-    """SQLite-backed persistent chunk store."""
+    """SQLite-backed persistent chunk store.
+
+    Streamlit's session_state caches the pipeline (and therefore this
+    ChunkStore) but reruns the script on a fresh thread on every UI
+    interaction. The default ``sqlite3.connect`` enforces same-thread
+    use and raises ``ProgrammingError`` on cross-thread reuse, breaking
+    multi-turn chat. We open with ``check_same_thread=False`` because
+    this app serialises queries per session — there is no concurrent
+    access to a single ``ChunkStore`` instance from multiple threads,
+    only sequential reuse from different threads across reruns.
+    """
 
     def __init__(self, db_path: str | Path) -> None:
         db_path = Path(db_path)
         db_path.parent.mkdir(parents=True, exist_ok=True)
-        self._conn = sqlite3.connect(str(db_path))
+        self._conn = sqlite3.connect(str(db_path), check_same_thread=False)
         self._conn.executescript(_SCHEMA)
         self._conn.commit()
 

--- a/tests/test_chunk_store_thread_safety.py
+++ b/tests/test_chunk_store_thread_safety.py
@@ -1,0 +1,89 @@
+"""Regression test: ``ChunkStore`` MUST be usable from a thread other than
+the one that created it.
+
+Bug: Streamlit caches the built pipeline in ``st.session_state`` and reruns
+the script on a fresh thread on every UI interaction.  The default
+``sqlite3.connect`` enforces same-thread use and raises
+``ProgrammingError`` on cross-thread reuse, breaking multi-turn chat
+mid-conversation. We open with ``check_same_thread=False``.
+
+Repro before the fix:
+    sqlite3.ProgrammingError: SQLite objects created in a thread can only
+    be used in that same thread. The object was created in thread id ...
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+from pathlib import Path
+
+from baseline_reporag.ingestion.chunker import Chunk
+from baseline_reporag.ingestion.store import ChunkStore
+
+
+def _make_chunk(chunk_id: str = "test::doc.md::1-10") -> Chunk:
+    return Chunk(
+        chunk_id=chunk_id,
+        repo_id="testrepo",
+        repo_commit="abc",
+        rel_path="doc.md",
+        language="markdown",
+        start_line=1,
+        end_line=10,
+        section_header="",
+        file_header="",
+        content="hello",
+        symbols=[],
+    )
+
+
+class TestChunkStoreCrossThread:
+    def test_can_query_from_different_thread(self, tmp_path: Path) -> None:
+        """ChunkStore created in main thread + queried from worker thread
+        must NOT raise sqlite3.ProgrammingError. Reproduces the Streamlit
+        rerun-on-different-thread case observed in chat UI."""
+        store = ChunkStore(tmp_path / "x.db")
+        store.upsert(_make_chunk())
+        store.commit()
+
+        results: list[tuple[str, object]] = []
+
+        def worker():
+            try:
+                count = store.count("testrepo", "abc")
+                results.append(("ok", count))
+            except sqlite3.ProgrammingError as exc:
+                results.append(("err", str(exc)))
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join(timeout=5)
+
+        assert results, "worker thread did not finish"
+        assert results[0][0] == "ok", (
+            f"cross-thread query raised: {results[0][1]} — "
+            "ChunkStore must be opened with check_same_thread=False so "
+            "Streamlit's cached pipeline survives reruns on new threads"
+        )
+        assert results[0][1] == 1
+
+    def test_can_insert_from_different_thread(self, tmp_path: Path) -> None:
+        store = ChunkStore(tmp_path / "y.db")
+        results: list[tuple[str, object]] = []
+
+        def worker():
+            try:
+                store.upsert(_make_chunk("from_other::a::1-1"))
+                store.commit()
+                results.append(("ok", store.count("testrepo", "abc")))
+            except sqlite3.ProgrammingError as exc:
+                results.append(("err", str(exc)))
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join(timeout=5)
+
+        assert results and results[0][0] == "ok"
+        # Read-back must also work from main thread (round-trip).
+        assert store.count("testrepo", "abc") == 1


### PR DESCRIPTION
## Summary

Streamlit のチャットページで Turn 2 以降に発生する `sqlite3.ProgrammingError` を修正。

## 観測した症状

UC1 (制度文書 多ターン深掘り) の Turn 2 で:
```
エラー: ProgrammingError: SQLite objects created in a thread can only be
used in that same thread. The object was created in thread id 6175453184
and this is thread id 17169903616.
```

## 根本原因

`baseline_reporag/ingestion/store.py:64` の `ChunkStore.__init__` が `sqlite3.connect(str(db_path))` を default の `check_same_thread=True` で開く。Streamlit は `_run_query` で組んだ pipeline を `st.session_state[pipeline_key]` に cache するが、UI 操作のたびに **新しい thread でスクリプトを再実行**する。

cache された pipeline 内の `ChunkStore._conn` は最初の thread で生成されたため、次の thread から `count()` や `get_many()` を呼ぶと SQLite が cross-thread access を弾く。

## Fix

```python
# baseline_reporag/ingestion/store.py
self._conn = sqlite3.connect(str(db_path), check_same_thread=False)
```

このアプリではセッション内のクエリは `_run_query` で逐次化されており、**1 つの ChunkStore に複数 thread が同時アクセスする経路は無い** (異なる thread からの**逐次再利用**のみ)。`check_same_thread=False` で安全に対応可能。

## Test plan

- [x] **新規 `tests/test_chunk_store_thread_safety.py` (2 件 PASS)**:
  - `test_can_query_from_different_thread`: 別 thread から `count()` 呼び出し成功
  - `test_can_insert_from_different_thread`: 別 thread から `upsert + commit + count` 成功 (round-trip)
- [x] 実機 smoke: `data/indexes/inst_test/chunks.db` を main + worker thread から `count('inst_test', 'manual-...')` 呼び出し、両方とも **426 chunks** を返却
- [x] `python -m pytest tests/ baseline_reporag/tests/`: **843/846 passed** (3 件は CLAUDE.md 記載の既存 failure、本 PR とは無関係)
- [x] `ruff check .` / `ruff format --check` (PR 範囲): All passed

## Why is `check_same_thread=False` safe here?

| 検討項目 | 評価 |
|---------|------|
| Streamlit のクエリ実行モデル | 1 セッションで逐次化 (multi-user でも別 ChunkStore instance を別 session_state が持つ) |
| 同時並列アクセスの可能性 | **無し** (rerun は前 rerun が完了してから走る) |
| 異 thread からの逐次再利用 | **頻発** (rerun ごとに thread が変わる) |
| trade-off | 並列での data race 検出 (default の thread guard) を失うが、本アプリでは過剰防御 |

## Effect on the live system

PR マージ後 Streamlit 再起動 → 既存の cached pipeline は invalidate されて再 build → 新 ChunkStore が `check_same_thread=False` で開かれる → Turn 2 以降も連続で動作する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)