### PR TITLE
Prepare v0.1.0 MVP release

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ MVP の配布物には、外部モデル重み、tokenizer、embedding / reranke
 - [v0.1.0 release plan](docs/release_plan_v0.1.0.md): MVP 公開範囲、artifact、PR、tag 方針
 - [v0.1.0 release notes](docs/release_notes_v0.1.0.md): MVP リリースノート草案
 - [Deployment guide](docs/deployment.md): checkpoint 配布とデプロイ運用
+- [Document collection](docs/document_collection.md): Web / PDF / text から ingest 用 Markdown corpus を作る汎用ツール
 - [Evaluation guide](docs/evaluation.md): multi-turn シナリオ評価とスコア化
 - [Playground guide](docs/playground.md): ローカル検証の補足
 - [Troubleshooting](docs/troubleshooting.md): エラー時の確認ポイント

--- a/docs/document_collection.md
+++ b/docs/document_collection.md
@@ -1,0 +1,129 @@
+# Document Collection
+
+This guide describes the generic document collection tool for preparing a small markdown corpus for PHOTON-RepoRAG.
+
+The tool is intentionally separate from the RAG pipeline. It helps collect HTML / PDF / text sources and writes an ingest-ready markdown layout, but it does not include downloaded documents, real URL lists, checkpoints, or personal local paths.
+
+## Scope
+
+Included:
+
+- Parse a small Markdown/plain-text URL list
+- Download HTML / PDF / text documents
+- Convert HTML to Markdown using a lightweight extractor
+- Extract PDF text when optional `pypdf` is installed
+- Normalize whitespace and control characters
+- Write an ingest-ready corpus layout
+- Write per-document metadata
+
+Not included:
+
+- Downloaded documents
+- Large real URL lists
+- `download/`, `markdowndb/`, `.venv/`, `.git/`, `workspace/`, `__pycache__/`
+- Private or license-unclear documents
+- Checkpoints or external model weights
+
+## URL List Format
+
+The URL list accepts these formats:
+
+```markdown
+https://example.com/docs/faq.md
+[Product guide](https://example.com/docs/product.html)
+Application form | https://example.com/docs/form.pdf
+```
+
+See `examples/document_urls.sample.md` for a syntax-only example. Do not commit large production URL lists.
+
+## Collect Documents
+
+```bash
+python scripts/collect_documents.py \
+  --urls examples/document_urls.sample.md \
+  --corpus-id my_corpus \
+  --output-root data/processed/document_corpora
+```
+
+The default output root is under `data/processed/`, which is gitignored.
+
+Output layout:
+
+```text
+data/processed/document_corpora/my_corpus/
+  manifest.json
+  product-guide/
+    document.md
+    metadata.json
+  application-form/
+    document.md
+    metadata.json
+```
+
+Each document directory contains:
+
+- `document.md`: normalized Markdown/text for RAG ingest
+- `metadata.json`: source URL, final URL, content type, status code, detected kind
+
+## PDF Extraction
+
+PDF extraction uses optional `pypdf`.
+
+```bash
+python -m pip install pypdf
+```
+
+`pypdf` is not a runtime dependency of PHOTON-RepoRAG. Install it only in the corpus-preparation environment when PDF extraction is needed.
+
+## Rate Limits And Source Terms
+
+The collector provides `--delay-seconds`, `--timeout-seconds`, and `--user-agent`. The operator is responsible for checking source terms, robots policy, and redistribution permissions before collecting or publishing derived corpora.
+
+Example:
+
+```bash
+python scripts/collect_documents.py \
+  --urls urls/my_sources.md \
+  --corpus-id my_corpus \
+  --delay-seconds 1.0 \
+  --user-agent "my-org-rag-corpus-builder/0.1"
+```
+
+## Ingest The Generated Corpus
+
+After collection, ingest the generated markdown corpus:
+
+```bash
+photon-rag ingest \
+  --repo data/processed/document_corpora/my_corpus \
+  --repo-id my_corpus \
+  --commit HEAD \
+  --config configs/institutional_docs.yaml
+
+photon-rag index \
+  --repo-id my_corpus \
+  --config configs/institutional_docs.yaml
+
+photon-rag heading-graph \
+  --repo-id my_corpus \
+  --config configs/institutional_docs.yaml
+```
+
+Then ask a baseline question:
+
+```bash
+photon-rag ask \
+  --config configs/institutional_docs.yaml \
+  --repo-id my_corpus \
+  --question "この文書群の主な対象は何ですか？"
+```
+
+## Repository Hygiene
+
+Do not commit generated corpora or downloaded source documents. Keep them under gitignored directories such as:
+
+- `data/raw/`
+- `data/processed/`
+- `workspace/`
+
+If a public example corpus is needed, add a tiny hand-written fixture under `examples/` instead of committing scraped real documents.

--- a/examples/document_urls.sample.md
+++ b/examples/document_urls.sample.md
@@ -1,0 +1,13 @@
+# Document Collection URL Sample
+
+# Supported formats:
+# - bare URL
+# - Markdown link
+# - title | URL
+#
+# Keep this file as a syntax example only. Do not commit large real URL lists,
+# downloaded documents, or generated corpora.
+
+[Example HTML document](https://example.com/docs/product.html)
+Example PDF document | https://example.com/docs/guide.pdf
+https://example.com/docs/faq.md

--- a/scripts/collect_documents.py
+++ b/scripts/collect_documents.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from functools import partial
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.document_collection import (  # noqa: E402
+    collect_documents,
+    default_fetcher,
+    parse_url_list,
+    write_collection_manifest,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Collect HTML/PDF/text documents into an ingest-ready markdown corpus"
+    )
+    parser.add_argument("--urls", required=True, help="Markdown/plain-text URL list")
+    parser.add_argument("--corpus-id", required=True)
+    parser.add_argument(
+        "--output-root",
+        default="data/processed/document_corpora",
+        help="Generated corpus root. The default is gitignored.",
+    )
+    parser.add_argument("--timeout-seconds", type=float, default=20.0)
+    parser.add_argument("--delay-seconds", type=float, default=0.5)
+    parser.add_argument(
+        "--user-agent",
+        default="photon-rag-document-collector/0.1",
+        help="HTTP User-Agent sent to source servers.",
+    )
+    parser.add_argument(
+        "--manifest",
+        default="",
+        help="Optional JSON manifest path. Defaults to <output>/<corpus>/manifest.json.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Parse the URL list and print sources without downloading.",
+    )
+    args = parser.parse_args(argv)
+
+    sources = parse_url_list(args.urls)
+    if args.dry_run:
+        print(json.dumps([source.__dict__ for source in sources], indent=2))
+        return 0
+
+    fetcher = partial(
+        default_fetcher,
+        timeout_seconds=args.timeout_seconds,
+        user_agent=args.user_agent,
+    )
+    collected = collect_documents(
+        sources,
+        output_root=args.output_root,
+        corpus_id=args.corpus_id,
+        fetcher=fetcher,
+        delay_seconds=args.delay_seconds,
+    )
+    manifest = (
+        Path(args.manifest)
+        if args.manifest
+        else Path(args.output_root) / args.corpus_id / "manifest.json"
+    )
+    write_collection_manifest(collected, manifest)
+    print(f"Collected {len(collected)} documents -> {Path(args.output_root) / args.corpus_id}")
+    print(f"Manifest: {manifest}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/document_collection.py
+++ b/scripts/document_collection.py
@@ -1,0 +1,341 @@
+from __future__ import annotations
+
+import json
+import re
+import time
+import unicodedata
+from dataclasses import asdict, dataclass
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Callable, Iterable
+from urllib.parse import urlparse
+
+
+_MARKDOWN_LINK_RE = re.compile(r"^\s*[-*]?\s*\[([^\]]+)\]\((https?://[^)]+)\)\s*$")
+_BARE_URL_RE = re.compile(r"^\s*[-*]?\s*(https?://\S+)\s*$")
+_TITLE_URL_RE = re.compile(r"^\s*[-*]?\s*([^|]+?)\s*\|\s*(https?://\S+)\s*$")
+_SAFE_SLUG_RE = re.compile(r"[^a-zA-Z0-9._-]+")
+
+
+@dataclass(frozen=True)
+class DocumentSource:
+    url: str
+    title: str | None = None
+    kind: str = "auto"
+
+
+@dataclass(frozen=True)
+class FetchedDocument:
+    url: str
+    content: bytes
+    content_type: str = ""
+    status_code: int = 200
+
+
+@dataclass(frozen=True)
+class CollectedDocument:
+    source: DocumentSource
+    output_dir: str
+    document_path: str
+    metadata_path: str
+    kind: str
+    title: str
+
+
+def parse_url_list(path: str | Path) -> list[DocumentSource]:
+    """Read a small Markdown/plain-text URL list.
+
+    Supported line formats:
+    - ``https://example.test/page.html``
+    - ``[Human title](https://example.test/page.html)``
+    - ``Human title | https://example.test/page.html``
+
+    Blank lines and Markdown comments beginning with ``#`` are ignored.
+    """
+    sources: list[DocumentSource] = []
+    for raw_line in Path(path).read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        markdown_match = _MARKDOWN_LINK_RE.match(line)
+        if markdown_match:
+            title, url = markdown_match.groups()
+            sources.append(DocumentSource(url=url, title=title.strip()))
+            continue
+        title_url_match = _TITLE_URL_RE.match(line)
+        if title_url_match:
+            title, url = title_url_match.groups()
+            sources.append(DocumentSource(url=url, title=title.strip()))
+            continue
+        bare_match = _BARE_URL_RE.match(line)
+        if bare_match:
+            sources.append(DocumentSource(url=bare_match.group(1)))
+            continue
+        raise ValueError(f"Unsupported URL list line: {raw_line!r}")
+    return sources
+
+
+def infer_kind(url: str, content_type: str = "", explicit_kind: str = "auto") -> str:
+    if explicit_kind != "auto":
+        if explicit_kind not in {"html", "pdf", "text", "markdown"}:
+            raise ValueError(f"Unsupported document kind: {explicit_kind!r}")
+        return explicit_kind
+    lowered_type = content_type.lower()
+    path = urlparse(url).path.lower()
+    if "pdf" in lowered_type or path.endswith(".pdf"):
+        return "pdf"
+    if "markdown" in lowered_type or path.endswith((".md", ".markdown")):
+        return "markdown"
+    if "html" in lowered_type or path.endswith((".html", ".htm")):
+        return "html"
+    return "text"
+
+
+def normalize_text(text: str) -> str:
+    text = unicodedata.normalize("NFKC", text)
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    text = "".join(
+        ch
+        for ch in text
+        if ch in {"\n", "\t"} or not unicodedata.category(ch).startswith("C")
+    )
+    lines = [re.sub(r"[ \t]+", " ", line).strip() for line in text.split("\n")]
+    compact: list[str] = []
+    blank_seen = False
+    for line in lines:
+        if not line:
+            if not blank_seen:
+                compact.append("")
+            blank_seen = True
+            continue
+        compact.append(line)
+        blank_seen = False
+    return "\n".join(compact).strip() + "\n"
+
+
+class _HtmlMarkdownParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.parts: list[str] = []
+        self.title_parts: list[str] = []
+        self._skip_depth = 0
+        self._heading_level: int | None = None
+        self._in_title = False
+        self._pending_list_item = False
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        tag = tag.lower()
+        if tag in {"script", "style", "noscript"}:
+            self._skip_depth += 1
+            return
+        if self._skip_depth:
+            return
+        if tag == "title":
+            self._in_title = True
+            return
+        if tag in {"p", "div", "section", "article", "main"}:
+            self.parts.append("\n\n")
+        elif tag in {"br", "hr"}:
+            self.parts.append("\n")
+        elif tag in {"h1", "h2", "h3", "h4", "h5", "h6"}:
+            self._heading_level = int(tag[1])
+            self.parts.append("\n\n" + ("#" * self._heading_level) + " ")
+        elif tag == "li":
+            self._pending_list_item = True
+            self.parts.append("\n- ")
+
+    def handle_endtag(self, tag: str) -> None:
+        tag = tag.lower()
+        if tag in {"script", "style", "noscript"} and self._skip_depth:
+            self._skip_depth -= 1
+            return
+        if self._skip_depth:
+            return
+        if tag == "title":
+            self._in_title = False
+        elif tag in {"p", "div", "section", "article", "main", "li"}:
+            self.parts.append("\n")
+        elif tag in {"h1", "h2", "h3", "h4", "h5", "h6"}:
+            self._heading_level = None
+            self.parts.append("\n\n")
+
+    def handle_data(self, data: str) -> None:
+        if self._skip_depth:
+            return
+        if self._in_title:
+            self.title_parts.append(data)
+            return
+        text = data.strip()
+        if not text:
+            return
+        if self._pending_list_item:
+            self._pending_list_item = False
+        self.parts.append(text + " ")
+
+
+def html_to_markdown(html: str, *, fallback_title: str = "Untitled") -> tuple[str, str]:
+    parser = _HtmlMarkdownParser()
+    parser.feed(html)
+    title = normalize_text(" ".join(parser.title_parts)).strip() or fallback_title
+    body = normalize_text("".join(parser.parts))
+    if not body.strip():
+        body = title + "\n"
+    return title, body
+
+
+def pdf_to_text(content: bytes) -> str:
+    """Extract text from a PDF using optional ``pypdf``.
+
+    ``pypdf`` is intentionally optional so the base RAG package does not gain
+    another heavy dependency just for corpus preparation. Install it in the
+    caller environment when PDF extraction is required.
+    """
+    try:
+        from pypdf import PdfReader  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "PDF extraction requires optional dependency 'pypdf'. "
+            "Install it in your corpus-preparation environment."
+        ) from exc
+
+    import io
+
+    reader = PdfReader(io.BytesIO(content))
+    pages = [page.extract_text() or "" for page in reader.pages]
+    return normalize_text("\n\n".join(pages))
+
+
+def slugify(value: str, fallback: str = "document") -> str:
+    value = unicodedata.normalize("NFKC", value).strip().lower()
+    value = _SAFE_SLUG_RE.sub("-", value).strip("-._")
+    return value[:80] or fallback
+
+
+def source_to_slug(source: DocumentSource, index: int) -> str:
+    if source.title:
+        return slugify(source.title, fallback=f"document-{index:03d}")
+    parsed = urlparse(source.url)
+    candidate = Path(parsed.path).stem or parsed.netloc or f"document-{index:03d}"
+    return slugify(candidate, fallback=f"document-{index:03d}")
+
+
+def default_fetcher(
+    source: DocumentSource,
+    *,
+    timeout_seconds: float = 20.0,
+    user_agent: str = "photon-rag-document-collector/0.1",
+) -> FetchedDocument:
+    import httpx
+
+    response = httpx.get(
+        source.url,
+        follow_redirects=True,
+        timeout=timeout_seconds,
+        headers={"User-Agent": user_agent},
+    )
+    response.raise_for_status()
+    return FetchedDocument(
+        url=str(response.url),
+        content=response.content,
+        content_type=response.headers.get("content-type", ""),
+        status_code=response.status_code,
+    )
+
+
+def convert_to_markdown(
+    source: DocumentSource,
+    fetched: FetchedDocument,
+) -> tuple[str, str, str]:
+    kind = infer_kind(
+        fetched.url or source.url,
+        content_type=fetched.content_type,
+        explicit_kind=source.kind,
+    )
+    fallback_title = source.title or source.url
+    if kind == "html":
+        title, markdown = html_to_markdown(
+            fetched.content.decode("utf-8", errors="replace"),
+            fallback_title=fallback_title,
+        )
+        return title, markdown, kind
+    if kind == "pdf":
+        title = source.title or Path(urlparse(source.url).path).stem or source.url
+        return title, pdf_to_text(fetched.content), kind
+    text = fetched.content.decode("utf-8", errors="replace")
+    title = source.title or Path(urlparse(source.url).path).stem or source.url
+    return title, normalize_text(text), kind
+
+
+def collect_documents(
+    sources: Iterable[DocumentSource],
+    *,
+    output_root: str | Path,
+    corpus_id: str,
+    fetcher: Callable[[DocumentSource], FetchedDocument],
+    delay_seconds: float = 0.0,
+) -> list[CollectedDocument]:
+    """Fetch sources and write an ingest-ready markdown corpus.
+
+    Output layout:
+    ``<output_root>/<corpus_id>/<slug>/document.md`` plus ``metadata.json``.
+    This mirrors the institutional corpus layout already used by evaluation
+    helpers while keeping generated data outside the repository by default.
+    """
+    root = Path(output_root) / corpus_id
+    root.mkdir(parents=True, exist_ok=True)
+    collected: list[CollectedDocument] = []
+    slug_counts: dict[str, int] = {}
+
+    for index, source in enumerate(sources, start=1):
+        if index > 1 and delay_seconds > 0:
+            time.sleep(delay_seconds)
+        fetched = fetcher(source)
+        title, markdown, kind = convert_to_markdown(source, fetched)
+        base_slug = source_to_slug(DocumentSource(url=source.url, title=title), index)
+        slug_counts[base_slug] = slug_counts.get(base_slug, 0) + 1
+        slug = (
+            base_slug
+            if slug_counts[base_slug] == 1
+            else f"{base_slug}-{slug_counts[base_slug]:02d}"
+        )
+        doc_dir = root / slug
+        doc_dir.mkdir(parents=True, exist_ok=True)
+        document_path = doc_dir / "document.md"
+        metadata_path = doc_dir / "metadata.json"
+        document_path.write_text(markdown, encoding="utf-8")
+        metadata = {
+            "source_url": source.url,
+            "final_url": fetched.url,
+            "title": title,
+            "kind": kind,
+            "content_type": fetched.content_type,
+            "status_code": fetched.status_code,
+        }
+        metadata_path.write_text(
+            json.dumps(metadata, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        collected.append(
+            CollectedDocument(
+                source=source,
+                output_dir=str(doc_dir),
+                document_path=str(document_path),
+                metadata_path=str(metadata_path),
+                kind=kind,
+                title=title,
+            )
+        )
+    return collected
+
+
+def write_collection_manifest(
+    collected: list[CollectedDocument],
+    path: str | Path,
+) -> None:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps([asdict(item) for item in collected], ensure_ascii=False, indent=2)
+        + "\n",
+        encoding="utf-8",
+    )

--- a/tests/test_document_collection.py
+++ b/tests/test_document_collection.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from scripts.document_collection import (  # noqa: E402
+    DocumentSource,
+    FetchedDocument,
+    collect_documents,
+    convert_to_markdown,
+    html_to_markdown,
+    infer_kind,
+    normalize_text,
+    parse_url_list,
+    pdf_to_text,
+)
+
+
+def test_parse_url_list_accepts_supported_formats(tmp_path: Path) -> None:
+    urls = tmp_path / "urls.md"
+    urls.write_text(
+        "\n".join(
+            [
+                "# comment",
+                "https://example.test/plain.md",
+                "[HTML title](https://example.test/page.html)",
+                "PDF title | https://example.test/form.pdf",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    sources = parse_url_list(urls)
+
+    assert sources == [
+        DocumentSource(url="https://example.test/plain.md"),
+        DocumentSource(url="https://example.test/page.html", title="HTML title"),
+        DocumentSource(url="https://example.test/form.pdf", title="PDF title"),
+    ]
+
+
+def test_parse_url_list_rejects_unknown_line(tmp_path: Path) -> None:
+    urls = tmp_path / "urls.md"
+    urls.write_text("not a url\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Unsupported URL list line"):
+        parse_url_list(urls)
+
+
+def test_html_to_markdown_extracts_content_and_ignores_scripts() -> None:
+    title, markdown = html_to_markdown(
+        """
+        <html>
+          <head><title> Example Product </title><script>alert(1)</script></head>
+          <body>
+            <h1>Overview</h1>
+            <p>Solves multi-turn RAG questions.</p>
+            <ul><li>Ingest</li><li>Ask</li></ul>
+          </body>
+        </html>
+        """
+    )
+
+    assert title == "Example Product"
+    assert "# Overview" in markdown
+    assert "Solves multi-turn RAG questions." in markdown
+    assert "- Ingest" in markdown
+    assert "alert" not in markdown
+
+
+def test_normalize_text_removes_control_chars_and_compacts_blank_lines() -> None:
+    text = "ＡＢＣ\x00\r\n\r\n\r\nfoo\t\tbar\n"
+
+    assert normalize_text(text) == "ABC\n\nfoo bar\n"
+
+
+def test_infer_kind_uses_content_type_and_url_suffix() -> None:
+    assert infer_kind("https://example.test/a", "application/pdf") == "pdf"
+    assert infer_kind("https://example.test/a.pdf", "") == "pdf"
+    assert infer_kind("https://example.test/a.md", "") == "markdown"
+    assert infer_kind("https://example.test/a.html", "") == "html"
+    assert infer_kind("https://example.test/a.bin", "") == "text"
+
+
+def test_collect_documents_writes_ingest_ready_layout(tmp_path: Path) -> None:
+    sources = [
+        DocumentSource(url="https://example.test/product.html", title="Product"),
+        DocumentSource(url="https://example.test/faq.md"),
+    ]
+
+    def fake_fetcher(source: DocumentSource) -> FetchedDocument:
+        if source.url.endswith(".html"):
+            return FetchedDocument(
+                url=source.url,
+                content=b"<html><title>Product</title><h1>Product</h1><p>Body</p></html>",
+                content_type="text/html",
+            )
+        return FetchedDocument(
+            url=source.url,
+            content="## FAQ\n回答です。".encode(),
+            content_type="text/markdown",
+        )
+
+    collected = collect_documents(
+        sources,
+        output_root=tmp_path,
+        corpus_id="sample_corpus",
+        fetcher=fake_fetcher,
+    )
+
+    assert len(collected) == 2
+    product_dir = tmp_path / "sample_corpus" / "product"
+    faq_dir = tmp_path / "sample_corpus" / "faq"
+    assert (product_dir / "document.md").read_text(encoding="utf-8").startswith(
+        "# Product"
+    )
+    assert "回答です。" in (faq_dir / "document.md").read_text(encoding="utf-8")
+
+    metadata = json.loads((product_dir / "metadata.json").read_text(encoding="utf-8"))
+    assert metadata["source_url"] == "https://example.test/product.html"
+    assert metadata["kind"] == "html"
+    assert "maenokota" not in json.dumps(metadata)
+
+
+def test_collect_documents_keeps_duplicate_titles_separate(tmp_path: Path) -> None:
+    sources = [
+        DocumentSource(url="https://example.test/a.html", title="Same"),
+        DocumentSource(url="https://example.test/b.html", title="Same"),
+    ]
+
+    def fake_fetcher(source: DocumentSource) -> FetchedDocument:
+        return FetchedDocument(
+            url=source.url,
+            content=b"<html><title>Same</title><p>Body</p></html>",
+            content_type="text/html",
+        )
+
+    collected = collect_documents(
+        sources,
+        output_root=tmp_path,
+        corpus_id="sample_corpus",
+        fetcher=fake_fetcher,
+    )
+
+    assert [Path(item.output_dir).name for item in collected] == ["same", "same-02"]
+
+
+def test_convert_pdf_requires_optional_dependency_when_missing(monkeypatch) -> None:
+    real_import = __import__
+
+    def fake_import(name: str, *args, **kwargs):
+        if name == "pypdf":
+            raise ImportError("blocked for test")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", fake_import)
+
+    with pytest.raises(RuntimeError, match="requires optional dependency 'pypdf'"):
+        pdf_to_text(b"%PDF-1.4")
+
+
+def test_convert_to_markdown_for_text() -> None:
+    title, markdown, kind = convert_to_markdown(
+        DocumentSource(url="https://example.test/readme.txt", title="Readme"),
+        FetchedDocument(
+            url="https://example.test/readme.txt",
+            content=b"Line 1\r\n\r\nLine 2",
+            content_type="text/plain",
+        ),
+    )
+
+    assert title == "Readme"
+    assert markdown == "Line 1\n\nLine 2\n"
+    assert kind == "text"


### PR DESCRIPTION
## Summary

- Prepare the v0.1.0 MVP release path around GitHub Release + source checkout.
- Add release plan and release notes drafts.
- Align README quickstart with the Streamlit-first MVP flow.
- Add the generic document collection tool for preparing markdown corpora without committing real collected data.
- Keep checkpoints, external model weights, local workspace/projects/cache/logs, and generated reports out of release artifacts.

## Release scope

- Primary distribution: GitHub Release + source checkout.
- Optional artifacts: sdist / wheel built with python -m build.
- Excluded from release artifacts: checkpoints, external model weights, tokenizer / embedding / reranker weights, local workspace/projects/cache/logs/reports.
- Hugging Face checkpoint publication: deferred.
- PyPI publish: deferred until Streamlit app packaging / entrypoint policy is finalized.

## Validation

- python -m build -> pass
- release/package smoke checks from prior PRs -> pass
- PR #209 package-smoke -> pass
- document collection unit tests -> pass

Related issues: #205, #207, #208